### PR TITLE
feat: implement tool approval gate for supervised autonomy mode

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -82,6 +82,8 @@ import { type SessionDescriptor, SessionEventBroker, type SessionRuntime } from 
 import {
   type ApprovalCallback,
   type ApprovalDecision,
+  type ToolRequestedCallback,
+  type ToolStartedCallback,
   createBuiltInTools,
 } from './tools.js';
 
@@ -286,9 +288,28 @@ export class AgentRunner implements SessionRuntime {
     const approvalCallback = spec.source.interactive
       ? this.makeApprovalCallback(spec.sessionId, approvalGate)
       : undefined;
-    const agent = await this.createAgent(spec, config, approvalCallback);
+    let session: RunnerSession | undefined;
+    const agent = await this.createAgent(
+      spec,
+      config,
+      approvalCallback,
+      (...args) => {
+        if (!session) {
+          throw new Error('Session was not initialized before tool execution was requested.');
+        }
+
+        return this.makeToolRequestedCallback(session)(...args);
+      },
+      (...args) => {
+        if (!session) {
+          throw new Error('Session was not initialized before tool execution started.');
+        }
+
+        return this.makeToolStartedCallback(session)(...args);
+      },
+    );
     const paths = createSessionLogPaths(spec.sessionId, now);
-    const session: RunnerSession = {
+    session = {
       spec,
       createdAt: now,
       updatedAt: now,
@@ -449,6 +470,78 @@ export class AgentRunner implements SessionRuntime {
     };
   }
 
+  private makeToolStartedCallback(session: RunnerSession): ToolStartedCallback {
+    return async (toolName, toolCallId, args) => {
+      const ts = new Date().toISOString();
+
+      await this.events.publish({
+        type: 'tool_started',
+        sessionId: session.spec.sessionId,
+        tool: toolName,
+        ...(args !== undefined ? { args } : {}),
+      });
+
+      await this.queueSideEffect(session, async () => {
+        await Promise.all([
+          this.logWriter.appendSession(session.sessionLogRelativePath, {
+            ts,
+            role: 'tool_call',
+            type: 'tool_started',
+            name: toolName,
+            args,
+            toolCallId,
+          }),
+          this.logWriter.appendEpisodic(session.episodicRelativePath, {
+            ts,
+            session: session.spec.sessionId,
+            type: 'tool_started',
+            data: {
+              tool: toolName,
+              args,
+              toolCallId,
+            },
+          }),
+        ]);
+      });
+    };
+  }
+
+  private makeToolRequestedCallback(session: RunnerSession): ToolRequestedCallback {
+    return async (toolName, toolCallId, args) => {
+      const ts = new Date().toISOString();
+
+      await this.events.publish({
+        type: 'tool_requested',
+        sessionId: session.spec.sessionId,
+        tool: toolName,
+        ...(args !== undefined ? { args } : {}),
+      });
+
+      await this.queueSideEffect(session, async () => {
+        await Promise.all([
+          this.logWriter.appendSession(session.sessionLogRelativePath, {
+            ts,
+            role: 'tool_call',
+            type: 'tool_requested',
+            name: toolName,
+            args,
+            toolCallId,
+          }),
+          this.logWriter.appendEpisodic(session.episodicRelativePath, {
+            ts,
+            session: session.spec.sessionId,
+            type: 'tool_requested',
+            data: {
+              tool: toolName,
+              args,
+              toolCallId,
+            },
+          }),
+        ]);
+      });
+    };
+  }
+
   private async recordApprovalRequested(
     session: RunnerSession,
     toolName: string,
@@ -517,12 +610,16 @@ export class AgentRunner implements SessionRuntime {
     spec: SessionSpec,
     config: AgentConfig,
     approvalCallback?: ApprovalCallback,
+    onToolRequested?: ToolRequestedCallback,
+    onToolStarted?: ToolStartedCallback,
   ): Promise<Agent> {
     const tools = createBuiltInTools({
       workspace: this.options.workspace,
       security: this.options.security,
       containerManager: this.containerManager,
       ...(approvalCallback ? { approvalCallback } : {}),
+      ...(onToolRequested ? { onToolRequested } : {}),
+      ...(onToolStarted ? { onToolStarted } : {}),
     });
     const systemPrompt = await this.buildSystemPrompt(config);
 
@@ -559,6 +656,8 @@ export class AgentRunner implements SessionRuntime {
         security: this.options.security,
         containerManager: this.containerManager,
         ...(approvalCallback ? { approvalCallback } : {}),
+        onToolRequested: this.makeToolRequestedCallback(session),
+        onToolStarted: this.makeToolStartedCallback(session),
       }),
     );
     session.agent.sessionId = session.spec.sessionId;
@@ -729,35 +828,6 @@ export class AgentRunner implements SessionRuntime {
       }
 
       case 'tool_execution_start': {
-        const ts = new Date().toISOString();
-
-        void this.events.publish({
-          type: 'tool_start',
-          sessionId: session.spec.sessionId,
-          tool: event.toolName,
-          args: event.args,
-        });
-        void this.queueSideEffect(session, async () => {
-          await Promise.all([
-            this.logWriter.appendSession(session.sessionLogRelativePath, {
-              ts,
-              role: 'tool_call',
-              name: event.toolName,
-              args: event.args,
-              toolCallId: event.toolCallId,
-            }),
-            this.logWriter.appendEpisodic(session.episodicRelativePath, {
-              ts,
-              session: session.spec.sessionId,
-              type: 'tool_called',
-              data: {
-                tool: event.toolName,
-                args: event.args,
-                toolCallId: event.toolCallId,
-              },
-            }),
-          ]);
-        });
         break;
       }
 

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -13,6 +13,61 @@ import {
 import type { SessionMessage, SessionSpec } from '@cloudmind/protocol';
 import { NotFoundError, ValidationError, getErrorMessage } from '@cloudmind/shared';
 
+// ---------------------------------------------------------------------------
+// ApprovalGate — per-session registry of pending tool approval Promises.
+// The tool's execute() calls gate.request(), which suspends until the HTTP
+// /approve endpoint resolves it via gate.respond().
+// ---------------------------------------------------------------------------
+
+const APPROVAL_TIMEOUT_MS = 120_000; // 2 minutes before auto-deny
+
+class ApprovalGate {
+  private readonly pending = new Map<
+    string,
+    { resolve: (approved: boolean) => void; timeout: ReturnType<typeof setTimeout> }
+  >();
+
+  /** Suspend until the user approves or denies this toolCallId. */
+  request(toolCallId: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(toolCallId);
+        resolve(false); // auto-deny on timeout
+      }, APPROVAL_TIMEOUT_MS);
+
+      this.pending.set(toolCallId, { resolve, timeout });
+    });
+  }
+
+  /**
+   * Resolve a pending approval.
+   * Returns true if a pending entry was found, false if it was already resolved
+   * or never registered (e.g. the gate timed out).
+   */
+  respond(toolCallId: string, approved: boolean): boolean {
+    const pending = this.pending.get(toolCallId);
+
+    if (!pending) {
+      return false;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(toolCallId);
+    pending.resolve(approved);
+    return true;
+  }
+
+  /** Cancel all pending approvals (e.g. on session teardown). */
+  cancelAll(): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timeout);
+      entry.resolve(false);
+    }
+
+    this.pending.clear();
+  }
+}
+
 import {
   AgentSecurity,
   AgentWorkspace,
@@ -21,7 +76,7 @@ import {
 } from './core/index.js';
 import { SessionLogWriter, createSessionLogPaths } from './session-logs.js';
 import { type SessionDescriptor, SessionEventBroker, type SessionRuntime } from './runtime.js';
-import { createBuiltInTools } from './tools.js';
+import { type ApprovalCallback, createBuiltInTools } from './tools.js';
 
 const SECRET_NAME_CANDIDATES: Record<string, string[]> = {
   anthropic: ['ANTHROPIC_API_KEY'],
@@ -40,6 +95,7 @@ interface RunnerSession extends SessionDescriptor {
   sessionLogRelativePath: string;
   episodicRelativePath: string;
   latestAssistantText: string | undefined;
+  approvalGate: ApprovalGate;
 }
 
 export interface AgentRunnerOptions {
@@ -219,7 +275,11 @@ export class AgentRunner implements SessionRuntime {
     }
 
     const config = await this.options.workspace.readConfig();
-    const agent = await this.createAgent(spec, config);
+    const approvalGate = new ApprovalGate();
+    const approvalCallback = spec.source.interactive
+      ? this.makeApprovalCallback(spec.sessionId, approvalGate)
+      : undefined;
+    const agent = await this.createAgent(spec, config, approvalCallback);
     const paths = createSessionLogPaths(spec.sessionId, now);
     const session: RunnerSession = {
       spec,
@@ -231,6 +291,7 @@ export class AgentRunner implements SessionRuntime {
       sessionLogRelativePath: paths.sessionLogRelativePath,
       episodicRelativePath: paths.episodicRelativePath,
       latestAssistantText: undefined,
+      approvalGate,
     };
 
     agent.subscribe((event) => {
@@ -272,6 +333,25 @@ export class AgentRunner implements SessionRuntime {
   getEpisodicLogRelativePath(sessionId: string): string {
     const session = this.getRequiredSession(sessionId);
     return session.episodicRelativePath;
+  }
+
+  /**
+   * Resolve a pending tool approval for the given session.
+   * Called by the HTTP `POST /sessions/:id/approve` endpoint.
+   * Returns true if a pending approval was found and resolved, false otherwise.
+   */
+  respondToApproval(
+    sessionId: string,
+    toolCallId: string,
+    approved: boolean,
+  ): boolean {
+    const session = this.sessions.get(sessionId);
+
+    if (!session) {
+      return false;
+    }
+
+    return session.approvalGate.respond(toolCallId, approved);
   }
 
   async waitForSessionIdle(sessionId: string): Promise<void> {
@@ -333,14 +413,33 @@ export class AgentRunner implements SessionRuntime {
     return { sessionId };
   }
 
+  private makeApprovalCallback(
+    sessionId: string,
+    gate: ApprovalGate,
+  ): ApprovalCallback {
+    return async (toolName, toolCallId, args) => {
+      await this.events.publish({
+        type: 'tool_approval_required',
+        sessionId,
+        toolName,
+        toolCallId,
+        ...(args !== undefined ? { args } : {}),
+      });
+
+      return gate.request(toolCallId);
+    };
+  }
+
   private async createAgent(
     spec: SessionSpec,
     config: AgentConfig,
+    approvalCallback?: ApprovalCallback,
   ): Promise<Agent> {
     const tools = createBuiltInTools({
       workspace: this.options.workspace,
       security: this.options.security,
       containerManager: this.containerManager,
+      ...(approvalCallback ? { approvalCallback } : {}),
     });
     const systemPrompt = await this.buildSystemPrompt(config);
 
@@ -366,11 +465,17 @@ export class AgentRunner implements SessionRuntime {
     this.ensureProviderApiKey(config.model.provider);
     session.agent.setModel(resolveModel(config));
     session.agent.setSystemPrompt(await this.buildSystemPrompt(config));
+
+    const approvalCallback = session.spec.source.interactive
+      ? this.makeApprovalCallback(session.spec.sessionId, session.approvalGate)
+      : undefined;
+
     session.agent.setTools(
       createBuiltInTools({
         workspace: this.options.workspace,
         security: this.options.security,
         containerManager: this.containerManager,
+        ...(approvalCallback ? { approvalCallback } : {}),
       }),
     );
     session.agent.sessionId = session.spec.sessionId;

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -24,15 +24,18 @@ const APPROVAL_TIMEOUT_MS = 120_000; // 2 minutes before auto-deny
 class ApprovalGate {
   private readonly pending = new Map<
     string,
-    { resolve: (approved: boolean) => void; timeout: ReturnType<typeof setTimeout> }
+    {
+      resolve: (decision: ApprovalDecision) => void;
+      timeout: ReturnType<typeof setTimeout>;
+    }
   >();
 
   /** Suspend until the user approves or denies this toolCallId. */
-  request(toolCallId: string): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
+  request(toolCallId: string): Promise<ApprovalDecision> {
+    return new Promise<ApprovalDecision>((resolve) => {
       const timeout = setTimeout(() => {
         this.pending.delete(toolCallId);
-        resolve(false); // auto-deny on timeout
+        resolve('timed_out');
       }, APPROVAL_TIMEOUT_MS);
 
       this.pending.set(toolCallId, { resolve, timeout });
@@ -53,7 +56,7 @@ class ApprovalGate {
 
     clearTimeout(pending.timeout);
     this.pending.delete(toolCallId);
-    pending.resolve(approved);
+    pending.resolve(approved ? 'approved' : 'rejected');
     return true;
   }
 
@@ -61,7 +64,7 @@ class ApprovalGate {
   cancelAll(): void {
     for (const [, entry] of this.pending) {
       clearTimeout(entry.timeout);
-      entry.resolve(false);
+      entry.resolve('cancelled');
     }
 
     this.pending.clear();
@@ -76,7 +79,11 @@ import {
 } from './core/index.js';
 import { SessionLogWriter, createSessionLogPaths } from './session-logs.js';
 import { type SessionDescriptor, SessionEventBroker, type SessionRuntime } from './runtime.js';
-import { type ApprovalCallback, createBuiltInTools } from './tools.js';
+import {
+  type ApprovalCallback,
+  type ApprovalDecision,
+  createBuiltInTools,
+} from './tools.js';
 
 const SECRET_NAME_CANDIDATES: Record<string, string[]> = {
   anthropic: ['ANTHROPIC_API_KEY'],

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -425,6 +425,12 @@ export class AgentRunner implements SessionRuntime {
     gate: ApprovalGate,
   ): ApprovalCallback {
     return async (toolName, toolCallId, args) => {
+      const session = this.sessions.get(sessionId);
+
+      if (session) {
+        await this.recordApprovalRequested(session, toolName, toolCallId, args);
+      }
+
       await this.events.publish({
         type: 'tool_approval_required',
         sessionId,
@@ -433,8 +439,78 @@ export class AgentRunner implements SessionRuntime {
         ...(args !== undefined ? { args } : {}),
       });
 
-      return gate.request(toolCallId);
+      const decision = await gate.request(toolCallId);
+
+      if (session) {
+        await this.recordApprovalResolved(session, toolName, toolCallId, decision);
+      }
+
+      return decision;
     };
+  }
+
+  private async recordApprovalRequested(
+    session: RunnerSession,
+    toolName: string,
+    toolCallId: string,
+    args: unknown,
+  ): Promise<void> {
+    const ts = new Date().toISOString();
+
+    await this.queueSideEffect(session, async () => {
+      await Promise.all([
+        this.logWriter.appendSession(session.sessionLogRelativePath, {
+          ts,
+          role: 'system',
+          type: 'tool_approval_requested',
+          toolName,
+          toolCallId,
+          ...(args !== undefined ? { args } : {}),
+        }),
+        this.logWriter.appendEpisodic(session.episodicRelativePath, {
+          ts,
+          session: session.spec.sessionId,
+          type: 'tool_approval_requested',
+          data: {
+            toolName,
+            toolCallId,
+            ...(args !== undefined ? { args } : {}),
+          },
+        }),
+      ]);
+    });
+  }
+
+  private async recordApprovalResolved(
+    session: RunnerSession,
+    toolName: string,
+    toolCallId: string,
+    decision: ApprovalDecision,
+  ): Promise<void> {
+    const ts = new Date().toISOString();
+
+    await this.queueSideEffect(session, async () => {
+      await Promise.all([
+        this.logWriter.appendSession(session.sessionLogRelativePath, {
+          ts,
+          role: 'system',
+          type: 'tool_approval_resolved',
+          toolName,
+          toolCallId,
+          decision,
+        }),
+        this.logWriter.appendEpisodic(session.episodicRelativePath, {
+          ts,
+          session: session.spec.sessionId,
+          type: 'tool_approval_resolved',
+          data: {
+            toolName,
+            toolCallId,
+            decision,
+          },
+        }),
+      ]);
+    });
   }
 
   private async createAgent(

--- a/apps/agent/src/app.ts
+++ b/apps/agent/src/app.ts
@@ -5,6 +5,7 @@ import {
   agentLocalRoutes,
   isSessionMessage,
   isSessionSpec,
+  isToolApprovalRequest,
 } from '@cloudmind/protocol';
 import {
   CloudMindError,
@@ -19,6 +20,7 @@ import {
   type SessionRuntime,
   type SessionEventEnvelope,
 } from './runtime.js';
+import type { AgentRunner } from './agent-runner.js';
 
 const SSE_PING_INTERVAL_MS = 15_000;
 
@@ -44,7 +46,7 @@ const waitForAbort = async (signal: AbortSignal): Promise<void> => {
 };
 
 export const createAgentApp = (
-  runtime: SessionRuntime = new InMemoryAgentRuntime(),
+  runtime: SessionRuntime | AgentRunner = new InMemoryAgentRuntime(),
   options: { apiToken?: string } = {},
 ): Hono => {
   const app = new Hono();
@@ -88,7 +90,7 @@ export const createAgentApp = (
   });
 
   app.post(agentLocalRoutes.sessionMessagesPattern, async (c) => {
-    const sessionId = c.req.param('sessionId');
+    const sessionId = c.req.param('sessionId') ?? '';
     const payload = await c.req.json().catch(() => null);
 
     if (!isSessionMessage(payload)) {
@@ -97,6 +99,28 @@ export const createAgentApp = (
 
     const result = await runtime.postMessage(sessionId, payload);
     return c.json(result);
+  });
+
+  app.post(agentLocalRoutes.sessionApprovePattern, async (c) => {
+    const sessionId = c.req.param('sessionId') ?? '';
+    const payload = await c.req.json().catch(() => null);
+
+    if (!isToolApprovalRequest(payload)) {
+      throw new ValidationError('Invalid ToolApprovalRequest payload.');
+    }
+
+    // Only AgentRunner (not the stub InMemoryAgentRuntime) exposes respondToApproval.
+    if (!('respondToApproval' in runtime)) {
+      throw new ValidationError('This runtime does not support tool approvals.');
+    }
+
+    const resolved = (runtime as AgentRunner).respondToApproval(
+      sessionId,
+      payload.toolCallId,
+      payload.approved,
+    );
+
+    return c.json({ resolved });
   });
 
   app.get(agentLocalRoutes.events, async (c) => {

--- a/apps/agent/src/chat.ts
+++ b/apps/agent/src/chat.ts
@@ -209,11 +209,25 @@ const writeToolResult = (
   stdout.write(`${label} ${tool} ${body}\n`);
 };
 
+export interface AssistantTurnOptions {
+  /**
+   * Called when the agent requires user approval before executing a tool.
+   * Return true to approve, false to deny.
+   * When undefined, approval requests are auto-denied.
+   */
+  onApprovalRequired?: (
+    toolName: string,
+    toolCallId: string,
+    args: unknown,
+  ) => Promise<boolean>;
+}
+
 export const waitForAssistantTurn = async (
   client: AgentLocalClient,
   token: string,
   sessionId: string,
   lastEventId: number,
+  options?: AssistantTurnOptions,
 ): Promise<number> => {
   const response = await fetch(client.buildEventsUrl(sessionId), {
     headers: {
@@ -262,6 +276,34 @@ export const waitForAssistantTurn = async (
           frame.data.length > 0
             ? (JSON.parse(frame.data) as Record<string, unknown>)
             : {};
+
+        if (frame.event === 'tool_approval_required') {
+          const toolName = String(payload.toolName ?? 'unknown');
+          const toolCallId = String(payload.toolCallId ?? '');
+
+          stdout.write(`\n[approval required] ${toolName}`);
+
+          if (payload.args !== undefined) {
+            const formatted = formatDebugValue(payload.args);
+
+            if (formatted) {
+              stdout.write(formatted.includes('\n') ? `\n${formatted}` : ` ${formatted}`);
+            }
+          }
+
+          stdout.write('\n');
+
+          let approved = false;
+
+          if (options?.onApprovalRequired) {
+            approved = await options.onApprovalRequired(toolName, toolCallId, payload.args);
+          } else {
+            stdout.write('[approval required] No approval handler configured — auto-denying.\n');
+          }
+
+          await client.submitApproval(sessionId, { toolCallId, approved });
+          continue;
+        }
 
         if (frame.event === 'tool_start') {
           writeToolCall(String(payload.tool ?? 'unknown'), payload.args);
@@ -358,12 +400,16 @@ export const main = async (): Promise<void> => {
 
       stdout.write('agent> ');
       await client.postMessage(sessionId, { text: input });
-      lastEventId = await waitForAssistantTurn(
-        client,
-        token,
-        sessionId,
-        lastEventId,
-      );
+      lastEventId = await waitForAssistantTurn(client, token, sessionId, lastEventId, {
+        onApprovalRequired: async (toolName, toolCallId, args) => {
+          // The approval prompt was already printed by waitForAssistantTurn.
+          // We just need to ask y/n here.
+          const answer = await rl.question('Approve? [y/N]: ');
+          const approved = answer.trim().toLowerCase() === 'y';
+          stdout.write(approved ? '[approved]\n' : '[denied]\n');
+          return approved;
+        },
+      });
       stdout.write('\n');
     }
   } finally {

--- a/apps/agent/src/chat.ts
+++ b/apps/agent/src/chat.ts
@@ -171,7 +171,23 @@ const formatDebugValue = (value: unknown): string => {
   return JSON.stringify(value, null, 2);
 };
 
-const writeToolCall = (tool: string, args: unknown): void => {
+const writeToolRequested = (tool: string, args: unknown): void => {
+  const formattedArgs = formatDebugValue(args);
+
+  if (!formattedArgs) {
+    stdout.write(`\n[tool requested] ${tool}\n`);
+    return;
+  }
+
+  if (formattedArgs.includes('\n')) {
+    stdout.write(`\n[tool requested] ${tool}\n${formattedArgs}\n`);
+    return;
+  }
+
+  stdout.write(`\n[tool requested] ${tool} ${formattedArgs}\n`);
+};
+
+const writeToolStarted = (tool: string, args: unknown): void => {
   const formattedArgs = formatDebugValue(args);
 
   if (!formattedArgs) {
@@ -305,8 +321,13 @@ export const waitForAssistantTurn = async (
           continue;
         }
 
-        if (frame.event === 'tool_start') {
-          writeToolCall(String(payload.tool ?? 'unknown'), payload.args);
+        if (frame.event === 'tool_requested') {
+          writeToolRequested(String(payload.tool ?? 'unknown'), payload.args);
+          continue;
+        }
+
+        if (frame.event === 'tool_started') {
+          writeToolStarted(String(payload.tool ?? 'unknown'), payload.args);
           continue;
         }
 

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -27,12 +27,28 @@ export type ApprovalCallback = (
   args: unknown,
 ) => Promise<ApprovalDecision>;
 
+export type ToolStartedCallback = (
+  toolName: string,
+  toolCallId: string,
+  args: unknown,
+) => Promise<void> | void;
+
+export type ToolRequestedCallback = (
+  toolName: string,
+  toolCallId: string,
+  args: unknown,
+) => Promise<void> | void;
+
 interface ToolContext {
   workspace: AgentWorkspace;
   security: AgentSecurity;
   containerManager: DockerContainerManager;
   /** When present, tools in security.require_approval_for pause for confirmation. */
   approvalCallback?: ApprovalCallback;
+  /** Called as soon as the agent decides to invoke the tool. */
+  onToolRequested?: ToolRequestedCallback;
+  /** Called immediately before the underlying tool.execute() runs. */
+  onToolStarted?: ToolStartedCallback;
 }
 
 const asTextContent = (text: string) => [
@@ -298,9 +314,27 @@ export const withApproval = (
   tool: AgentTool<any>,
   security: AgentSecurity,
   approvalCallback: ApprovalCallback | undefined,
+  onToolRequested?: ToolRequestedCallback,
+  onToolStarted?: ToolStartedCallback,
 ): AgentTool<any> => {
   if (!approvalCallback) {
-    return tool;
+    if (!onToolRequested && !onToolStarted) {
+      return tool;
+    }
+
+    return {
+      ...tool,
+      execute: async (
+        toolCallId: string,
+        args: unknown,
+        signal?: AbortSignal,
+        onUpdate?: Parameters<AgentTool<any>['execute']>[3],
+      ) => {
+        await onToolRequested?.(tool.name, toolCallId, args);
+        await onToolStarted?.(tool.name, toolCallId, args);
+        return tool.execute(toolCallId, args, signal, onUpdate);
+      },
+    };
   }
 
   return {
@@ -314,6 +348,8 @@ export const withApproval = (
       const needsApproval =
         security.getAutonomyLevel() !== 'full' &&
         security.requiresApproval(tool.name);
+
+      await onToolRequested?.(tool.name, toolCallId, args);
 
       if (needsApproval) {
         const decision = await approvalCallback(tool.name, toolCallId, args);
@@ -337,6 +373,7 @@ export const withApproval = (
         }
       }
 
+      await onToolStarted?.(tool.name, toolCallId, args);
       return tool.execute(toolCallId, args, signal, onUpdate);
     },
   };
@@ -345,7 +382,8 @@ export const withApproval = (
 export const createBuiltInTools = (
   context: ToolContext,
 ): AgentTool<any>[] => {
-  const { security, approvalCallback } = context;
+  const { security, approvalCallback, onToolStarted } = context;
+  const { onToolRequested } = context;
 
   const tools = [
     createReadFileTool(context),
@@ -356,5 +394,13 @@ export const createBuiltInTools = (
     createContainerStatusTool(context),
   ];
 
-  return tools.map((tool) => withApproval(tool, security, approvalCallback));
+  return tools.map((tool) =>
+    withApproval(
+      tool,
+      security,
+      approvalCallback,
+      onToolRequested,
+      onToolStarted,
+    ),
+  );
 };

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -292,7 +292,7 @@ export const summarizeContainerEntry = (
  * will pause and invoke the approval callback before executing.
  * In `full` autonomy mode or when no callback is provided, tools always proceed.
  */
-const withApproval = (
+export const withApproval = (
   tool: AgentTool<any>,
   security: AgentSecurity,
   approvalCallback: ApprovalCallback | undefined,
@@ -303,7 +303,12 @@ const withApproval = (
 
   return {
     ...tool,
-    execute: async (toolCallId: string, args: unknown) => {
+    execute: async (
+      toolCallId: string,
+      args: unknown,
+      signal?: AbortSignal,
+      onUpdate?: Parameters<AgentTool<any>['execute']>[3],
+    ) => {
       const needsApproval =
         security.getAutonomyLevel() !== 'full' &&
         security.requiresApproval(tool.name);
@@ -321,7 +326,7 @@ const withApproval = (
         }
       }
 
-      return tool.execute(toolCallId, args);
+      return tool.execute(toolCallId, args, signal, onUpdate);
     },
   };
 };

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -17,13 +17,15 @@ const READONLY_BLOCKED_TOOLS = new Set([
 
 /**
  * Called before a tool executes when approval is required.
- * Returns true to allow the call, false to reject it.
+ * Returns an explicit decision so timeout and user denial are distinguishable.
  */
+export type ApprovalDecision = 'approved' | 'rejected' | 'timed_out' | 'cancelled';
+
 export type ApprovalCallback = (
   toolName: string,
   toolCallId: string,
   args: unknown,
-) => Promise<boolean>;
+) => Promise<ApprovalDecision>;
 
 interface ToolContext {
   workspace: AgentWorkspace;
@@ -314,14 +316,23 @@ export const withApproval = (
         security.requiresApproval(tool.name);
 
       if (needsApproval) {
-        const approved = await approvalCallback(tool.name, toolCallId, args);
+        const decision = await approvalCallback(tool.name, toolCallId, args);
 
-        if (!approved) {
+        if (decision !== 'approved') {
+          const text =
+            decision === 'timed_out'
+              ? `Tool call "${tool.name}" timed out waiting for user approval.`
+              : decision === 'cancelled'
+                ? `Tool call "${tool.name}" was cancelled before approval was received.`
+                : `Tool call "${tool.name}" was rejected by the user.`;
+
           return {
-            content: asTextContent(
-              `Tool call "${tool.name}" was rejected by the user.`,
-            ),
-            details: { rejected: true, toolName: tool.name },
+            content: asTextContent(text),
+            details: {
+              rejected: true,
+              toolName: tool.name,
+              approvalStatus: decision,
+            },
           };
         }
       }

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -15,10 +15,22 @@ const READONLY_BLOCKED_TOOLS = new Set([
   'container_run',
 ]);
 
+/**
+ * Called before a tool executes when approval is required.
+ * Returns true to allow the call, false to reject it.
+ */
+export type ApprovalCallback = (
+  toolName: string,
+  toolCallId: string,
+  args: unknown,
+) => Promise<boolean>;
+
 interface ToolContext {
   workspace: AgentWorkspace;
   security: AgentSecurity;
   containerManager: DockerContainerManager;
+  /** When present, tools in security.require_approval_for pause for confirmation. */
+  approvalCallback?: ApprovalCallback;
 }
 
 const asTextContent = (text: string) => [
@@ -275,13 +287,58 @@ export const summarizeContainerEntry = (
   container: ContainerRegistryEntry,
 ): string => formatJson(container);
 
+/**
+ * Wraps a tool so that calls to tools listed in security.require_approval_for
+ * will pause and invoke the approval callback before executing.
+ * In `full` autonomy mode or when no callback is provided, tools always proceed.
+ */
+const withApproval = (
+  tool: AgentTool<any>,
+  security: AgentSecurity,
+  approvalCallback: ApprovalCallback | undefined,
+): AgentTool<any> => {
+  if (!approvalCallback) {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    execute: async (toolCallId: string, args: unknown) => {
+      const needsApproval =
+        security.getAutonomyLevel() !== 'full' &&
+        security.requiresApproval(tool.name);
+
+      if (needsApproval) {
+        const approved = await approvalCallback(tool.name, toolCallId, args);
+
+        if (!approved) {
+          return {
+            content: asTextContent(
+              `Tool call "${tool.name}" was rejected by the user.`,
+            ),
+            details: { rejected: true, toolName: tool.name },
+          };
+        }
+      }
+
+      return tool.execute(toolCallId, args);
+    },
+  };
+};
+
 export const createBuiltInTools = (
   context: ToolContext,
-): AgentTool<any>[] => [
-  createReadFileTool(context),
-  createWriteFileTool(context),
-  createListFilesTool(context),
-  createDeleteFileTool(context),
-  createContainerRunTool(context),
-  createContainerStatusTool(context),
-];
+): AgentTool<any>[] => {
+  const { security, approvalCallback } = context;
+
+  const tools = [
+    createReadFileTool(context),
+    createWriteFileTool(context),
+    createListFilesTool(context),
+    createDeleteFileTool(context),
+    createContainerRunTool(context),
+    createContainerStatusTool(context),
+  ];
+
+  return tools.map((tool) => withApproval(tool, security, approvalCallback));
+};

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -392,6 +392,243 @@ test('AgentRunner surfaces a missing API key as an error event instead of crashi
   );
 });
 
+test('AgentRunner pauses on require_approval_for and resumes after respondToApproval', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+    security: {
+      autonomy_level: 'supervised',
+      require_approval_for: ['write_file'],
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () =>
+        createToolCallResponseStream({
+          type: 'toolCall',
+          id: 'call-write',
+          name: 'write_file',
+          arguments: { path: 'files/out.txt', content: 'approved content' },
+        }),
+      () => createTextResponseStream('File written successfully.'),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:approval-session',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:approval-session', { text: 'Write a file.' });
+
+  // Wait until tool_approval_required is published (agent is paused waiting for gate)
+  await new Promise<void>((resolve) => {
+    const check = (): void => {
+      const backlog = runner.events.getBacklog('cli:approval-session');
+      if (backlog.some((e) => e.event.type === 'tool_approval_required')) {
+        resolve();
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+    check();
+  });
+
+  const backlogBefore = runner.events.getBacklog('cli:approval-session');
+  assert.ok(
+    backlogBefore.some((e) => e.event.type === 'tool_approval_required'),
+    'tool_approval_required event was published',
+  );
+  const approvalEvent = backlogBefore.find((e) => e.event.type === 'tool_approval_required');
+  assert.equal(approvalEvent?.event.type, 'tool_approval_required');
+
+  if (approvalEvent?.event.type === 'tool_approval_required') {
+    assert.equal(approvalEvent.event.toolName, 'write_file');
+
+    // Approve the tool call
+    const resolved = runner.respondToApproval(
+      'cli:approval-session',
+      approvalEvent.event.toolCallId,
+      true,
+    );
+    assert.equal(resolved, true, 'respondToApproval found the pending gate');
+  }
+
+  await runner.waitForSessionIdle('cli:approval-session');
+
+  const backlogAfter = runner.events.getBacklog('cli:approval-session');
+  assert.ok(
+    backlogAfter.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),
+    'write_file completed successfully after approval',
+  );
+  assert.ok(
+    backlogAfter.some((e) => e.event.type === 'text_final'),
+    'agent produced a final reply',
+  );
+  const fileContent = await workspace.readFile('files/out.txt');
+  assert.equal(fileContent, 'approved content');
+});
+
+test('AgentRunner rejects tool call when respondToApproval sends false', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+    security: {
+      autonomy_level: 'supervised',
+      require_approval_for: ['write_file'],
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () =>
+        createToolCallResponseStream({
+          type: 'toolCall',
+          id: 'call-write-denied',
+          name: 'write_file',
+          arguments: { path: 'files/blocked.txt', content: 'should not appear' },
+        }),
+      () => createTextResponseStream('The write was rejected by the user.'),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:deny-session',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:deny-session', { text: 'Write a file.' });
+
+  // Wait for approval event
+  await new Promise<void>((resolve) => {
+    const check = (): void => {
+      const backlog = runner.events.getBacklog('cli:deny-session');
+      if (backlog.some((e) => e.event.type === 'tool_approval_required')) {
+        resolve();
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+    check();
+  });
+
+  const approvalEvent = runner.events
+    .getBacklog('cli:deny-session')
+    .find((e) => e.event.type === 'tool_approval_required');
+
+  if (approvalEvent?.event.type === 'tool_approval_required') {
+    runner.respondToApproval('cli:deny-session', approvalEvent.event.toolCallId, false);
+  }
+
+  await runner.waitForSessionIdle('cli:deny-session');
+
+  // File must NOT have been created
+  const fileExists = await workspace.readFile('files/blocked.txt').then(() => true, () => false);
+  assert.equal(fileExists, false, 'rejected write_file must not create the file');
+
+  const backlog = runner.events.getBacklog('cli:deny-session');
+  const toolResult = backlog.find((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file');
+  assert.ok(toolResult, 'tool_result event was published');
+  assert.equal(
+    toolResult?.event.type === 'tool_result' ? toolResult.event.isError : undefined,
+    false,
+    'rejection is returned as a non-error tool result with a message',
+  );
+});
+
+test('AgentRunner skips approval for full autonomy level', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+    security: {
+      autonomy_level: 'full',
+      require_approval_for: ['write_file'],
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () =>
+        createToolCallResponseStream({
+          type: 'toolCall',
+          id: 'call-write-full',
+          name: 'write_file',
+          arguments: { path: 'files/auto.txt', content: 'no approval needed' },
+        }),
+      () => createTextResponseStream('Done.'),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:full-autonomy',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:full-autonomy', { text: 'Write a file.' });
+  await runner.waitForSessionIdle('cli:full-autonomy');
+
+  const backlog = runner.events.getBacklog('cli:full-autonomy');
+  assert.ok(
+    !backlog.some((e) => e.event.type === 'tool_approval_required'),
+    'no approval event for full autonomy',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),
+    'write_file ran without approval in full mode',
+  );
+  const content = await workspace.readFile('files/auto.txt');
+  assert.equal(content, 'no approval needed');
+});
+
+test('AgentRunner skips approval for non-interactive sessions', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+    security: {
+      autonomy_level: 'supervised',
+      require_approval_for: ['write_file'],
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () =>
+        createToolCallResponseStream({
+          type: 'toolCall',
+          id: 'call-write-heartbeat',
+          name: 'write_file',
+          arguments: { path: 'files/heartbeat.txt', content: 'from heartbeat' },
+        }),
+      () => createTextResponseStream('Heartbeat complete.'),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'heartbeat:1234',
+    source: { kind: 'heartbeat', interactive: false },
+  });
+  await runner.postMessage('heartbeat:1234', { text: 'Run maintenance.' });
+  await runner.waitForSessionIdle('heartbeat:1234');
+
+  const backlog = runner.events.getBacklog('heartbeat:1234');
+  assert.ok(
+    !backlog.some((e) => e.event.type === 'tool_approval_required'),
+    'no approval event for non-interactive session',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),
+    'write_file ran without approval in non-interactive mode',
+  );
+  const content = await workspace.readFile('files/heartbeat.txt');
+  assert.equal(content, 'from heartbeat');
+});
+
 test('AgentRunner publishes detailed tool failure messages', async (t) => {
   const { workspace, security } = await createSecurityFixture(t, {
     secrets: {

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -28,6 +28,14 @@ const zeroUsage: Usage = {
   },
 };
 
+const trackedToolEventTypes = new Set([
+  'tool_requested',
+  'tool_approval_requested',
+  'tool_approval_resolved',
+  'tool_started',
+  'tool_result',
+]);
+
 const createAssistantMessage = (
   content: AssistantMessage['content'],
   stopReason: AssistantMessage['stopReason'],
@@ -301,7 +309,16 @@ test('AgentRunner executes built-in tools through pi-agent-core', async (t) => {
   assert.ok(
     backlog.some(
       (entry) =>
-        entry.event.type === 'tool_start' &&
+        entry.event.type === 'tool_requested' &&
+        entry.event.tool === 'read_file' &&
+        'args' in entry.event &&
+        JSON.stringify(entry.event.args) === JSON.stringify({ path: 'files/fact.txt' }),
+      ),
+  );
+  assert.ok(
+    backlog.some(
+      (entry) =>
+        entry.event.type === 'tool_started' &&
         entry.event.tool === 'read_file' &&
         'args' in entry.event &&
         JSON.stringify(entry.event.args) === JSON.stringify({ path: 'files/fact.txt' }),
@@ -334,6 +351,15 @@ test('AgentRunner executes built-in tools through pi-agent-core', async (t) => {
     sessionEntries.some(
       (entry) =>
         entry.role === 'tool_call' &&
+        entry.type === 'tool_requested' &&
+        entry.name === 'read_file',
+    ),
+  );
+  assert.ok(
+    sessionEntries.some(
+      (entry) =>
+        entry.role === 'tool_call' &&
+        entry.type === 'tool_started' &&
         entry.name === 'read_file',
     ),
   );
@@ -441,6 +467,14 @@ test('AgentRunner pauses on require_approval_for and resumes after respondToAppr
     backlogBefore.some((e) => e.event.type === 'tool_approval_required'),
     'tool_approval_required event was published',
   );
+  assert.ok(
+    backlogBefore.some((e) => e.event.type === 'tool_requested' && e.event.tool === 'write_file'),
+    'tool_requested is published before approval resolves',
+  );
+  assert.ok(
+    !backlogBefore.some((e) => e.event.type === 'tool_started' && e.event.tool === 'write_file'),
+    'tool_started is not published before approval resolves',
+  );
   const approvalEvent = backlogBefore.find((e) => e.event.type === 'tool_approval_required');
   assert.equal(approvalEvent?.event.type, 'tool_approval_required');
 
@@ -459,6 +493,10 @@ test('AgentRunner pauses on require_approval_for and resumes after respondToAppr
   await runner.waitForSessionIdle('cli:approval-session');
 
   const backlogAfter = runner.events.getBacklog('cli:approval-session');
+  assert.ok(
+    backlogAfter.some((e) => e.event.type === 'tool_started' && e.event.tool === 'write_file'),
+    'write_file only starts after approval',
+  );
   assert.ok(
     backlogAfter.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),
     'write_file completed successfully after approval',
@@ -514,6 +552,16 @@ test('AgentRunner pauses on require_approval_for and resumes after respondToAppr
         entry.data.decision === 'approved',
     ),
   );
+  const approvalFlow = episodicEntries
+    .map((entry) => String(entry.type))
+    .filter((type) => trackedToolEventTypes.has(type));
+  assert.deepEqual(approvalFlow, [
+    'tool_requested',
+    'tool_approval_requested',
+    'tool_approval_resolved',
+    'tool_started',
+    'tool_result',
+  ]);
 });
 
 test('AgentRunner rejects tool call when respondToApproval sends false', async (t) => {
@@ -575,6 +623,14 @@ test('AgentRunner rejects tool call when respondToApproval sends false', async (
   assert.equal(fileExists, false, 'rejected write_file must not create the file');
 
   const backlog = runner.events.getBacklog('cli:deny-session');
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_requested' && e.event.tool === 'write_file'),
+    'tool_requested is still published before a denied approval',
+  );
+  assert.ok(
+    !backlog.some((e) => e.event.type === 'tool_started' && e.event.tool === 'write_file'),
+    'tool_started is not published when approval is denied',
+  );
   const toolResult = backlog.find((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file');
   assert.ok(toolResult, 'tool_result event was published');
   assert.equal(
@@ -623,6 +679,15 @@ test('AgentRunner rejects tool call when respondToApproval sends false', async (
         entry.data.decision === 'rejected',
     ),
   );
+  const deniedFlow = episodicEntries
+    .map((entry) => String(entry.type))
+    .filter((type) => trackedToolEventTypes.has(type));
+  assert.deepEqual(deniedFlow, [
+    'tool_requested',
+    'tool_approval_requested',
+    'tool_approval_resolved',
+    'tool_result',
+  ]);
 });
 
 test('AgentRunner skips approval for full autonomy level', async (t) => {
@@ -661,6 +726,14 @@ test('AgentRunner skips approval for full autonomy level', async (t) => {
   assert.ok(
     !backlog.some((e) => e.event.type === 'tool_approval_required'),
     'no approval event for full autonomy',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_requested' && e.event.tool === 'write_file'),
+    'tool_requested is published for full autonomy',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_started' && e.event.tool === 'write_file'),
+    'tool_started is published for full autonomy',
   );
   assert.ok(
     backlog.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),
@@ -706,6 +779,14 @@ test('AgentRunner skips approval for non-interactive sessions', async (t) => {
   assert.ok(
     !backlog.some((e) => e.event.type === 'tool_approval_required'),
     'no approval event for non-interactive session',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_requested' && e.event.tool === 'write_file'),
+    'tool_requested is published for non-interactive sessions',
+  );
+  assert.ok(
+    backlog.some((e) => e.event.type === 'tool_started' && e.event.tool === 'write_file'),
+    'tool_started is published for non-interactive sessions',
   );
   assert.ok(
     backlog.some((e) => e.event.type === 'tool_result' && e.event.tool === 'write_file' && !e.event.isError),

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -537,6 +537,12 @@ test('AgentRunner rejects tool call when respondToApproval sends false', async (
     false,
     'rejection is returned as a non-error tool result with a message',
   );
+  assert.match(
+    toolResult?.event.type === 'tool_result' && typeof toolResult.event.text === 'string'
+      ? toolResult.event.text
+      : '',
+    /rejected by the user/,
+  );
 });
 
 test('AgentRunner skips approval for full autonomy level', async (t) => {

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -469,6 +469,51 @@ test('AgentRunner pauses on require_approval_for and resumes after respondToAppr
   );
   const fileContent = await workspace.readFile('files/out.txt');
   assert.equal(fileContent, 'approved content');
+
+  const sessionEntries = await readJsonl(
+    (relativePath) => workspace.readFile(relativePath),
+    runner.getSessionLogRelativePath('cli:approval-session'),
+  );
+  const episodicEntries = await readJsonl(
+    (relativePath) => workspace.readFile(relativePath),
+    runner.getEpisodicLogRelativePath('cli:approval-session'),
+  );
+
+  assert.ok(
+    sessionEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_requested' &&
+        entry.toolName === 'write_file',
+    ),
+  );
+  assert.ok(
+    sessionEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_resolved' &&
+        entry.toolName === 'write_file' &&
+        entry.decision === 'approved',
+    ),
+  );
+  assert.ok(
+    episodicEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_requested' &&
+        entry.data &&
+        typeof entry.data === 'object' &&
+        'toolName' in entry.data &&
+        entry.data.toolName === 'write_file',
+    ),
+  );
+  assert.ok(
+    episodicEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_resolved' &&
+        entry.data &&
+        typeof entry.data === 'object' &&
+        'decision' in entry.data &&
+        entry.data.decision === 'approved',
+    ),
+  );
 });
 
 test('AgentRunner rejects tool call when respondToApproval sends false', async (t) => {
@@ -542,6 +587,41 @@ test('AgentRunner rejects tool call when respondToApproval sends false', async (
       ? toolResult.event.text
       : '',
     /rejected by the user/,
+  );
+
+  const sessionEntries = await readJsonl(
+    (relativePath) => workspace.readFile(relativePath),
+    runner.getSessionLogRelativePath('cli:deny-session'),
+  );
+  const episodicEntries = await readJsonl(
+    (relativePath) => workspace.readFile(relativePath),
+    runner.getEpisodicLogRelativePath('cli:deny-session'),
+  );
+
+  assert.ok(
+    sessionEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_requested' &&
+        entry.toolName === 'write_file',
+    ),
+  );
+  assert.ok(
+    sessionEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_resolved' &&
+        entry.toolName === 'write_file' &&
+        entry.decision === 'rejected',
+    ),
+  );
+  assert.ok(
+    episodicEntries.some(
+      (entry) =>
+        entry.type === 'tool_approval_resolved' &&
+        entry.data &&
+        typeof entry.data === 'object' &&
+        'decision' in entry.data &&
+        entry.data.decision === 'rejected',
+    ),
   );
 });
 

--- a/apps/agent/test/chat.test.ts
+++ b/apps/agent/test/chat.test.ts
@@ -159,10 +159,11 @@ test('waitForAssistantTurn prints tool calls and tool results for debugging', as
             encoder.encode(
               [
                 'event: ready\ndata: {"sessionId":"cli:test"}\n\n',
-                'id: 1\nevent: tool_start\ndata: {"tool":"write_file","args":{"path":"files/test.py","content":"print(1)"}}\n\n',
-                'id: 2\nevent: tool_result\ndata: {"tool":"write_file","isError":false,"text":"Wrote files/test.py","details":{"path":"files/test.py","bytes":8}}\n\n',
-                'id: 3\nevent: text_final\ndata: {"text":"Done."}\n\n',
-                'id: 4\nevent: agent_end\ndata: {"sessionId":"cli:test"}\n\n',
+                'id: 1\nevent: tool_requested\ndata: {"tool":"write_file","args":{"path":"files/test.py","content":"print(1)"}}\n\n',
+                'id: 2\nevent: tool_started\ndata: {"tool":"write_file","args":{"path":"files/test.py","content":"print(1)"}}\n\n',
+                'id: 3\nevent: tool_result\ndata: {"tool":"write_file","isError":false,"text":"Wrote files/test.py","details":{"path":"files/test.py","bytes":8}}\n\n',
+                'id: 4\nevent: text_final\ndata: {"text":"Done."}\n\n',
+                'id: 5\nevent: agent_end\ndata: {"sessionId":"cli:test"}\n\n',
               ].join(''),
             ),
           );
@@ -187,7 +188,8 @@ test('waitForAssistantTurn prints tool calls and tool results for debugging', as
       0,
     );
 
-    assert.equal(nextEventId, 4);
+    assert.equal(nextEventId, 5);
+    assert.match(stdoutChunks.join(''), /\[tool requested\] write_file/);
     assert.match(stdoutChunks.join(''), /\[tool\] write_file/);
     assert.match(stdoutChunks.join(''), /"path":"files\/test.py"/);
     assert.match(stdoutChunks.join(''), /\[tool result\] write_file/);

--- a/apps/agent/test/helpers.ts
+++ b/apps/agent/test/helpers.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { TestContext } from 'node:test';
 
 import { AgentSecurity, AgentWorkspace } from '../src/core/index.js';
-import type { SecretsMap } from '../src/core/types.js';
+import type { SecretsMap, SecurityPolicy } from '../src/core/types.js';
 
 export interface WorkspaceFixture {
   root: string;
@@ -49,6 +49,7 @@ export const createSecurityFixture = async (
   t: TestContext,
   options?: {
     secrets?: SecretsMap;
+    security?: Partial<SecurityPolicy>;
   },
 ): Promise<SecurityFixture> => {
   const workspaceFixture = await createWorkspaceFixture(t);
@@ -65,6 +66,18 @@ export const createSecurityFixture = async (
     await fs.writeFile(
       security.secretsFilePath,
       `${JSON.stringify(options.secrets, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  if (options?.security) {
+    const existing = JSON.parse(
+      await fs.readFile(security.securityFilePath, 'utf8'),
+    ) as SecurityPolicy;
+    const merged: SecurityPolicy = { ...existing, ...options.security };
+    await fs.writeFile(
+      security.securityFilePath,
+      `${JSON.stringify(merged, null, 2)}\n`,
       'utf8',
     );
   }

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -7,6 +7,13 @@ import { Type } from '@mariozechner/pi-ai';
 import { withApproval } from '../src/tools.js';
 import { createSecurityFixture } from './helpers.js';
 
+const getFirstText = (result: {
+  content: Array<{ type: string; text?: string }>;
+}): string => {
+  const first = result.content.find((entry) => entry.type === 'text');
+  return typeof first?.text === 'string' ? first.text : '';
+};
+
 test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) => {
   const { security } = await createSecurityFixture(t, {
     security: {
@@ -46,7 +53,7 @@ test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) 
 
   const wrapped = withApproval(tool, security, async (_toolName, _toolCallId, args) => {
     approvalArgs = args;
-    return true;
+    return 'approved';
   });
 
   const abortController = new AbortController();
@@ -66,4 +73,48 @@ test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) 
   assert.deepEqual(approvalArgs, { value: 'payload' });
   assert.deepEqual(updates, [{ status: 'midway' }]);
   assert.deepEqual(result.details, { status: 'done' });
+});
+
+test('withApproval distinguishes timeout from explicit rejection', async (t) => {
+  const { security } = await createSecurityFixture(t, {
+    security: {
+      autonomy_level: 'supervised',
+      require_approval_for: ['dangerous_tool'],
+    },
+  });
+  await security.load();
+
+  const Params = Type.Object({
+    value: Type.String(),
+  });
+
+  const tool: AgentTool<typeof Params, { status: string }> = {
+    name: 'dangerous_tool',
+    label: 'Dangerous Tool',
+    description: 'Tool used to verify approval decisions.',
+    parameters: Params,
+    execute: async () => {
+      throw new Error('should not execute when approval is not granted');
+    },
+  };
+
+  const timedOut = withApproval(tool, security, async () => 'timed_out');
+  const rejected = withApproval(tool, security, async () => 'rejected');
+
+  const timedOutResult = await timedOut.execute('call-timeout', { value: 'payload' });
+  const rejectedResult = await rejected.execute('call-rejected', { value: 'payload' });
+
+  assert.match(getFirstText(timedOutResult), /timed out waiting for user approval/);
+  assert.deepEqual(timedOutResult.details, {
+    rejected: true,
+    toolName: 'dangerous_tool',
+    approvalStatus: 'timed_out',
+  });
+
+  assert.match(getFirstText(rejectedResult), /rejected by the user/);
+  assert.deepEqual(rejectedResult.details, {
+    rejected: true,
+    toolName: 'dangerous_tool',
+    approvalStatus: 'rejected',
+  });
 });

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { AgentTool, AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
+import { Type } from '@mariozechner/pi-ai';
+
+import { withApproval } from '../src/tools.js';
+import { createSecurityFixture } from './helpers.js';
+
+test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) => {
+  const { security } = await createSecurityFixture(t, {
+    security: {
+      autonomy_level: 'supervised',
+      require_approval_for: ['dangerous_tool'],
+    },
+  });
+  await security.load();
+
+  const Params = Type.Object({
+    value: Type.String(),
+  });
+
+  let capturedSignal: AbortSignal | undefined;
+  let capturedOnUpdate: AgentToolUpdateCallback<{ status: string }> | undefined;
+  let approvalArgs: unknown;
+
+  const tool: AgentTool<typeof Params, { status: string }> = {
+    name: 'dangerous_tool',
+    label: 'Dangerous Tool',
+    description: 'Tool used to verify approval forwarding.',
+    parameters: Params,
+    execute: async (_toolCallId, args, signal, onUpdate) => {
+      capturedSignal = signal;
+      capturedOnUpdate = onUpdate;
+      onUpdate?.({
+        content: [{ type: 'text', text: `updating ${args.value}` }],
+        details: { status: 'midway' },
+      });
+
+      return {
+        content: [{ type: 'text', text: `done ${args.value}` }],
+        details: { status: 'done' },
+      };
+    },
+  };
+
+  const wrapped = withApproval(tool, security, async (_toolName, _toolCallId, args) => {
+    approvalArgs = args;
+    return true;
+  });
+
+  const abortController = new AbortController();
+  const updates: Array<{ status: string }> = [];
+
+  const result = await wrapped.execute(
+    'call-1',
+    { value: 'payload' },
+    abortController.signal,
+    ((partial) => {
+      updates.push(partial.details);
+    }) as AgentToolUpdateCallback<{ status: string }>,
+  );
+
+  assert.equal(capturedSignal, abortController.signal);
+  assert.ok(capturedOnUpdate);
+  assert.deepEqual(approvalArgs, { value: 'payload' });
+  assert.deepEqual(updates, [{ status: 'midway' }]);
+  assert.deepEqual(result.details, { status: 'done' });
+});

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -30,6 +30,8 @@ test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) 
   let capturedSignal: AbortSignal | undefined;
   let capturedOnUpdate: AgentToolUpdateCallback<{ status: string }> | undefined;
   let approvalArgs: unknown;
+  const requestedCalls: Array<{ toolName: string; toolCallId: string; args: unknown }> = [];
+  const startedCalls: Array<{ toolName: string; toolCallId: string; args: unknown }> = [];
 
   const tool: AgentTool<typeof Params, { status: string }> = {
     name: 'dangerous_tool',
@@ -51,10 +53,20 @@ test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) 
     },
   };
 
-  const wrapped = withApproval(tool, security, async (_toolName, _toolCallId, args) => {
-    approvalArgs = args;
-    return 'approved';
-  });
+  const wrapped = withApproval(
+    tool,
+    security,
+    async (_toolName, _toolCallId, args) => {
+      approvalArgs = args;
+      return 'approved';
+    },
+    async (toolName, toolCallId, args) => {
+      requestedCalls.push({ toolName, toolCallId, args });
+    },
+    async (toolName, toolCallId, args) => {
+      startedCalls.push({ toolName, toolCallId, args });
+    },
+  );
 
   const abortController = new AbortController();
   const updates: Array<{ status: string }> = [];
@@ -71,6 +83,20 @@ test('withApproval forwards signal and onUpdate to the wrapped tool', async (t) 
   assert.equal(capturedSignal, abortController.signal);
   assert.ok(capturedOnUpdate);
   assert.deepEqual(approvalArgs, { value: 'payload' });
+  assert.deepEqual(requestedCalls, [
+    {
+      toolName: 'dangerous_tool',
+      toolCallId: 'call-1',
+      args: { value: 'payload' },
+    },
+  ]);
+  assert.deepEqual(startedCalls, [
+    {
+      toolName: 'dangerous_tool',
+      toolCallId: 'call-1',
+      args: { value: 'payload' },
+    },
+  ]);
   assert.deepEqual(updates, [{ status: 'midway' }]);
   assert.deepEqual(result.details, { status: 'done' });
 });
@@ -98,8 +124,31 @@ test('withApproval distinguishes timeout from explicit rejection', async (t) => 
     },
   };
 
-  const timedOut = withApproval(tool, security, async () => 'timed_out');
-  const rejected = withApproval(tool, security, async () => 'rejected');
+  const requestedCalls: string[] = [];
+  const startedCalls: string[] = [];
+
+  const timedOut = withApproval(
+    tool,
+    security,
+    async () => 'timed_out',
+    async (toolName) => {
+      requestedCalls.push(toolName);
+    },
+    async (toolName) => {
+      startedCalls.push(toolName);
+    },
+  );
+  const rejected = withApproval(
+    tool,
+    security,
+    async () => 'rejected',
+    async (toolName) => {
+      requestedCalls.push(toolName);
+    },
+    async (toolName) => {
+      startedCalls.push(toolName);
+    },
+  );
 
   const timedOutResult = await timedOut.execute('call-timeout', { value: 'payload' });
   const rejectedResult = await rejected.execute('call-rejected', { value: 'payload' });
@@ -117,4 +166,6 @@ test('withApproval distinguishes timeout from explicit rejection', async (t) => 
     toolName: 'dangerous_tool',
     approvalStatus: 'rejected',
   });
+  assert.deepEqual(requestedCalls, ['dangerous_tool', 'dangerous_tool']);
+  assert.deepEqual(startedCalls, []);
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,7 @@ Three layers, all stored as plain files in the workspace:
 
 #### Episodic Memory — `memory/episodic/{YYYY-MM}.jsonl`
 - Append-only JSONL log, one event per line, **split by month** to avoid unbounded file growth
-- Events: `message_received`, `tool_called`, `tool_result`, `session_started`, `session_ended`, `note_updated`, `heartbeat_run`, `hook_fired`
+- Events: `message_received`, `tool_requested`, `tool_started`, `tool_result`, `session_started`, `session_ended`, `note_updated`, `heartbeat_run`, `hook_fired`
 - Used for reviewing history, understanding what happened and when
 - Format: `{"ts": "ISO8601", "type": "...", "session": "...", "data": {...}}`
 - Current month file is active; older files are read-only archives
@@ -519,7 +519,8 @@ type SessionMessage = {
 type OutboundEvent =
   | { type: "text_delta"; sessionId: string; text: string }
   | { type: "text_final"; sessionId: string; text: string }
-  | { type: "tool_start"; sessionId: string; tool: string }
+  | { type: "tool_requested"; sessionId: string; tool: string; args?: unknown }
+  | { type: "tool_started"; sessionId: string; tool: string; args?: unknown }
   | { type: "error"; sessionId: string; message: string }
 ```
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -176,7 +176,7 @@ The agent still exposes an HTTP API (Hono) as its sole **external** communicatio
 **External HTTP API contract**:
 - `POST /sessions` — accepts `SessionSpec` JSON, creates or resumes the session, returns `{ sessionId }`
 - `POST /sessions/{sessionId}/messages` — accepts `SessionMessage` JSON, appends one inbound message, returns `{ sessionId, messageId? }`
-- `GET /events?sessionId=xxx` — SSE stream of `OutboundEvent` (`text_delta | text_final | tool_start | error`)
+- `GET /events?sessionId=xxx` — SSE stream of `OutboundEvent` (`text_delta | text_final | tool_requested | tool_started | tool_result | error`)
 - The HTTP API is agent-local, not a multi-agent gateway: each agent already has its own port, so the URL does not repeat `{agentId}`
 - `POST /sessions` is metadata-only: it establishes session state, but agent execution advances only when a `SessionMessage` is appended
 - Auth: bearer token generated at startup, stored at `runtime/api.token`, injected into bridge containers as `CLOUDMIND_API_KEY`

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -120,7 +120,7 @@ Phase 7 — Polish (CLI, multi-agent, SQLite upgrade)
 - [ ] `source.platform` captures adapter-specific detail when needed, e.g. `telegram | discord | feishu`
 - [ ] `source.interactive` determines whether the caller subscribes to SSE or the run is treated as a non-interactive scheduled session
 - [ ] `POST /sessions` is metadata-only: it creates or resumes session state, but the runner should not advance until the first `SessionMessage` is posted
-- [ ] Define `OutboundEvent` SSE types: `text_delta | text_final | tool_start | error`
+- [ ] Define `OutboundEvent` SSE types: `text_delta | text_final | tool_requested | tool_started | tool_result | error`
 - [ ] Expose `AgentRunner.openSession(spec)` and `AgentRunner.postMessage(sessionId, message)` inside the agent process; all adapters call this lifecycle interface
 - [ ] Implement Hono HTTP adapter inside the agent process:
   - `POST /sessions` — validates bearer token, accepts `SessionSpec`, creates or resumes the session, returns `{ sessionId }`
@@ -318,7 +318,8 @@ Phase 7 — Polish (CLI, multi-agent, SQLite upgrade)
 ```jsonl
 {"ts":"2026-03-07T10:00:00Z","session":"s1","type":"session_started","data":{}}
 {"ts":"2026-03-07T10:00:05Z","session":"s1","type":"message_received","data":{"role":"user","content":"hello"}}
-{"ts":"2026-03-07T10:00:08Z","session":"s1","type":"tool_called","data":{"tool":"read_file","args":{"path":"memory/notes/facts.md"}}}
+{"ts":"2026-03-07T10:00:08Z","session":"s1","type":"tool_requested","data":{"tool":"read_file","args":{"path":"memory/notes/facts.md"}}}
+{"ts":"2026-03-07T10:00:08Z","session":"s1","type":"tool_started","data":{"tool":"read_file","args":{"path":"memory/notes/facts.md"}}}
 {"ts":"2026-03-07T10:00:09Z","session":"s1","type":"tool_result","data":{"tool":"read_file","result":"..."}}
 {"ts":"2026-03-07T10:00:12Z","session":"s1","type":"message_sent","data":{"role":"assistant","content":"Hi!"}}
 {"ts":"2026-03-07T10:00:12Z","session":"s1","type":"session_ended","data":{"turns":2}}
@@ -329,9 +330,11 @@ Phase 7 — Polish (CLI, multi-agent, SQLite upgrade)
 ```jsonl
 {"ts":"2026-03-07T10:00:05Z","role":"user","content":"Write me a fibonacci script"}
 {"ts":"2026-03-07T10:00:08Z","role":"assistant","type":"thought","content":"I should write the script to a file then run it"}
-{"ts":"2026-03-07T10:00:08Z","role":"tool_call","name":"write_file","args":{"path":"containers/run-1/data/fib.py","content":"..."}}
+{"ts":"2026-03-07T10:00:08Z","role":"tool_call","type":"tool_requested","name":"write_file","args":{"path":"containers/run-1/data/fib.py","content":"..."}}
+{"ts":"2026-03-07T10:00:08Z","role":"tool_call","type":"tool_started","name":"write_file","args":{"path":"containers/run-1/data/fib.py","content":"..."}}
 {"ts":"2026-03-07T10:00:09Z","role":"tool_result","name":"write_file","content":"ok"}
-{"ts":"2026-03-07T10:00:09Z","role":"tool_call","name":"container_run","args":{"image":"python:3.12","command":"python /workspace/fib.py","mount":"containers/run-1/data"}}
+{"ts":"2026-03-07T10:00:09Z","role":"tool_call","type":"tool_requested","name":"container_run","args":{"image":"python:3.12","command":"python /workspace/fib.py","mount":"containers/run-1/data"}}
+{"ts":"2026-03-07T10:00:09Z","role":"tool_call","type":"tool_started","name":"container_run","args":{"image":"python:3.12","command":"python /workspace/fib.py","mount":"containers/run-1/data"}}
 {"ts":"2026-03-07T10:00:14Z","role":"tool_result","name":"container_run","content":{"stdout":"1 1 2 3 5...","exitCode":0}}
 {"ts":"2026-03-07T10:00:15Z","role":"assistant","type":"answer","content":"Here are the first 20 Fibonacci numbers: ..."}
 ```

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,7 +32,8 @@ export interface SessionMessage {
 export type OutboundEvent =
   | { type: 'text_delta'; sessionId: string; text: string }
   | { type: 'text_final'; sessionId: string; text: string }
-  | { type: 'tool_start'; sessionId: string; tool: string; args?: unknown }
+  | { type: 'tool_requested'; sessionId: string; tool: string; args?: unknown }
+  | { type: 'tool_started'; sessionId: string; tool: string; args?: unknown }
   | {
       type: 'tool_result';
       sessionId: string;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -41,8 +41,20 @@ export type OutboundEvent =
       text?: string;
       details?: unknown;
     }
+  | {
+      type: 'tool_approval_required';
+      sessionId: string;
+      toolName: string;
+      toolCallId: string;
+      args?: unknown;
+    }
   | { type: 'agent_end'; sessionId: string }
   | { type: 'error'; sessionId: string; message: string };
+
+export interface ToolApprovalRequest {
+  toolCallId: string;
+  approved: boolean;
+}
 
 export const agentLocalRoutes = {
   health: '/health',
@@ -50,6 +62,9 @@ export const agentLocalRoutes = {
   sessionMessagesPattern: '/sessions/:sessionId/messages',
   sessionMessages: (sessionId: string): string =>
     `/sessions/${encodeURIComponent(sessionId)}/messages`,
+  sessionApprovePattern: '/sessions/:sessionId/approve',
+  sessionApprove: (sessionId: string): string =>
+    `/sessions/${encodeURIComponent(sessionId)}/approve`,
   events: '/events',
   eventsUrl: (sessionId: string): string =>
     `/events?sessionId=${encodeURIComponent(sessionId)}`,
@@ -157,3 +172,16 @@ export const createAgentEndEvent = (sessionId: string): OutboundEvent => ({
   type: 'agent_end',
   sessionId,
 });
+
+export const isToolApprovalRequest = (
+  value: unknown,
+): value is ToolApprovalRequest => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.toolCallId === 'string' &&
+    typeof value.approved === 'boolean'
+  );
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ import {
   agentLocalRoutes,
   type SessionMessage,
   type SessionSpec,
+  type ToolApprovalRequest,
 } from '@cloudmind/protocol';
 import {
   CloudMindError,
@@ -33,6 +34,13 @@ export class AgentLocalClient {
     message: SessionMessage,
   ): Promise<{ sessionId: string; messageId?: string }> {
     return this.postJson(agentLocalRoutes.sessionMessages(sessionId), message);
+  }
+
+  async submitApproval(
+    sessionId: string,
+    request: ToolApprovalRequest,
+  ): Promise<{ resolved: boolean }> {
+    return this.postJson(agentLocalRoutes.sessionApprove(sessionId), request);
   }
 
   buildEventsUrl(sessionId: string): string {


### PR DESCRIPTION
feat: implement tool approval gate for supervised autonomy mode

Add a full beforeToolCall approval flow so that tools listed in
security.require_approval_for actually pause for user confirmation
in interactive sessions.

- ApprovalGate class: per-session Promise registry keyed by toolCallId;
  auto-denies after 2-minute timeout
- withApproval wrapper in tools.ts: gates every built-in tool; skips
  when autonomy_level is full or no callback is registered
- AgentRunner.respondToApproval(): resolves the gate; called by HTTP layer
- makeApprovalCallback(): publishes tool_approval_required SSE event then
  suspends on the gate; wired only for interactive sessions so heartbeat
  and cron jobs are never interrupted
- POST /sessions/:id/approve endpoint in app.ts
- AgentLocalClient.submitApproval() in SDK
- chat.ts: handles tool_approval_required SSE, prints tool + args,
  prompts y/N, submits answer back to the agent
- protocol: add tool_approval_required OutboundEvent, ToolApprovalRequest
  type + isToolApprovalRequest guard, sessionApprove routes
- 4 new tests: approve, deny, full autonomy, non-interactive session
