### PR TITLE
feat(agent): pluggable exec backend architecture

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -15,6 +15,7 @@ import {
   AgentWorkspace,
   DEFAULT_INTROSPECTION_CONFIG,
   DockerContainerManager,
+  ExecBackendManager,
   type AgentConfig,
 } from './core/index.js';
 import { ApprovalGate } from './agent-runner/approval-gate.js';
@@ -75,6 +76,8 @@ export class AgentRunner implements SessionRuntime {
 
   private readonly containerManager: DockerContainerManager;
 
+  private execBackendManager: ExecBackendManager | undefined;
+
   private readonly store: InternalStateStore;
 
   private readonly scope: StoreScope;
@@ -117,6 +120,21 @@ export class AgentRunner implements SessionRuntime {
     return new AgentRunner(options, store);
   }
 
+  private getOrCreateExecBackendManager(config: AgentConfig): ExecBackendManager {
+    if (!this.execBackendManager) {
+      this.execBackendManager = ExecBackendManager.fromConfig(
+        config.exec,
+        config.workspace_container,
+        {
+          containerManager: this.containerManager,
+          agentId: this.scope.agentId,
+          workspaceDir: this.options.workspace.root,
+        },
+      );
+    }
+    return this.execBackendManager;
+  }
+
   resetWorkspaceIdleTimer(config: import('./core/types.js').WorkspaceContainerConfig): void {
     if (this.workspaceIdleTimer) {
       clearTimeout(this.workspaceIdleTimer);
@@ -152,8 +170,13 @@ export class AgentRunner implements SessionRuntime {
       config.workspace_container &&
       (config.workspace_container.lifecycle?.stop ?? 'idle') === 'session'
     ) {
-      await this.containerManager.stopWorkspaceContainer(this.scope.agentId);
-      this.logRuntime('workspace container stopped (session end)');
+      if (this.execBackendManager) {
+        await this.execBackendManager.shutdownAll();
+        this.logRuntime('exec backends shut down (session end)');
+      } else {
+        await this.containerManager.stopWorkspaceContainer(this.scope.agentId);
+        this.logRuntime('workspace container stopped (session end)');
+      }
     }
   }
 
@@ -1009,10 +1032,13 @@ export class AgentRunner implements SessionRuntime {
         ...(isOwnerOrUnresolved || input.userId ? { sessionStore: this.store.sessions } : {}),
         ...(!isOwnerOrUnresolved && input.userId ? { currentUserId: input.userId } : {}),
         storeScope: this.scope,
-        ...(!isGuestRole && input.config.workspace_container ? {
+        ...(!isGuestRole ? {
           agentId: this.scope.agentId,
-          workspaceContainerConfig: input.config.workspace_container,
-          onExec: () => this.resetWorkspaceIdleTimer(input.config.workspace_container!),
+          execBackendManager: this.getOrCreateExecBackendManager(input.config),
+          ...(input.config.workspace_container ? {
+            workspaceContainerConfig: input.config.workspace_container,
+            onExec: () => this.resetWorkspaceIdleTimer(input.config.workspace_container!),
+          } : {}),
         } : {}),
         ...(input.approvalCallback ? { approvalCallback: input.approvalCallback } : {}),
         ...(input.approvedCache ? { approvedCache: input.approvedCache } : {}),

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -1,0 +1,371 @@
+import { spawn } from 'node:child_process';
+
+import { NotFoundError, ValidationError } from '@openhermit/shared';
+
+import type { ContainerProcessResult, WorkspaceContainerConfig, WorkspaceContainerLifecycle } from './types.js';
+import type { DockerContainerManager } from './container-manager.js';
+
+// ── Result type (re-uses existing ContainerProcessResult) ─────────────────
+
+export type ExecResult = ContainerProcessResult;
+
+// ── Backend interface ─────────────────────────────────────────────────────
+
+export interface ExecBackend {
+  /** Unique instance id, e.g. "docker", "local", "prod-ssh". */
+  readonly id: string;
+  /** Backend type: "docker" | "local" | "ssh" | custom. */
+  readonly type: string;
+  /** Human-readable label for the LLM. */
+  readonly label: string;
+  /** Idempotent setup (start container, verify SSH, etc.). */
+  ensure(): Promise<void>;
+  /** Execute a shell command and return the result. */
+  exec(command: string): Promise<ExecResult>;
+  /** Teardown (stop container, etc.). No-op if nothing to clean up. */
+  shutdown(): Promise<void>;
+}
+
+// ── Config types ──────────────────────────────────────────────────────────
+
+export interface DockerExecBackendConfig {
+  id?: string;
+  type: 'docker';
+  label?: string;
+  image: string;
+  memory_limit?: string;
+  cpu_shares?: number;
+  lifecycle?: WorkspaceContainerLifecycle;
+}
+
+export interface LocalExecBackendConfig {
+  id?: string;
+  type: 'local';
+  label?: string;
+  cwd?: string;
+  shell?: string;
+  env?: Record<string, string>;
+}
+
+export interface SshExecBackendConfig {
+  id?: string;
+  type: 'ssh';
+  label?: string;
+  host: string;
+  port?: number;
+  user?: string;
+  identity_file?: string;
+  cwd?: string;
+}
+
+export type ExecBackendConfig =
+  | DockerExecBackendConfig
+  | LocalExecBackendConfig
+  | SshExecBackendConfig;
+
+export interface ExecConfig {
+  backends: ExecBackendConfig[];
+  default_backend?: string;
+}
+
+// ── Backend factory registry ──────────────────────────────────────────────
+
+export interface BackendFactoryContext {
+  containerManager: DockerContainerManager;
+  agentId: string;
+  workspaceDir: string;
+}
+
+type BackendFactory = (config: ExecBackendConfig, context: BackendFactoryContext) => ExecBackend;
+
+const factories = new Map<string, BackendFactory>();
+
+export const registerExecBackend = (type: string, factory: BackendFactory): void => {
+  factories.set(type, factory);
+};
+
+export const createExecBackend = (config: ExecBackendConfig, context: BackendFactoryContext): ExecBackend => {
+  const factory = factories.get(config.type);
+  if (!factory) {
+    throw new ValidationError(`Unknown exec backend type: ${config.type}`);
+  }
+  return factory(config, context);
+};
+
+// ── Docker backend ────────────────────────────────────────────────────────
+
+class DockerExecBackend implements ExecBackend {
+  readonly id: string;
+  readonly type = 'docker';
+  readonly label: string;
+  private readonly config: WorkspaceContainerConfig;
+
+  constructor(
+    config: DockerExecBackendConfig,
+    private readonly containerManager: DockerContainerManager,
+    private readonly agentId: string,
+  ) {
+    this.id = config.id ?? 'docker';
+    this.label = config.label ?? `Docker (${config.image})`;
+    this.config = {
+      image: config.image,
+      ...(config.memory_limit ? { memory_limit: config.memory_limit } : {}),
+      ...(config.cpu_shares ? { cpu_shares: config.cpu_shares } : {}),
+      ...(config.lifecycle ? { lifecycle: config.lifecycle } : {}),
+    };
+  }
+
+  async ensure(): Promise<void> {
+    await this.containerManager.ensureWorkspaceContainer(this.agentId, this.config);
+  }
+
+  async exec(command: string): Promise<ExecResult> {
+    return this.containerManager.execInWorkspace(this.agentId, command);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.containerManager.stopWorkspaceContainer(this.agentId);
+  }
+}
+
+// ── Local backend ─────────────────────────────────────────────────────────
+
+class LocalExecBackend implements ExecBackend {
+  readonly id: string;
+  readonly type = 'local';
+  readonly label: string;
+  private readonly cwd: string;
+  private readonly shell: string;
+  private readonly env: Record<string, string> | undefined;
+
+  constructor(config: LocalExecBackendConfig, workspaceDir: string) {
+    this.id = config.id ?? 'local';
+    this.label = config.label ?? 'Local shell';
+    this.cwd = config.cwd ?? workspaceDir;
+    this.shell = config.shell ?? 'sh';
+    this.env = config.env;
+  }
+
+  async ensure(): Promise<void> {
+    // No-op — local shell is always ready.
+  }
+
+  async exec(command: string): Promise<ExecResult> {
+    const startedAt = Date.now();
+
+    return new Promise<ExecResult>((resolve, reject) => {
+      const child = spawn(this.shell, ['-lc', command], {
+        cwd: this.cwd,
+        env: { ...process.env, ...(this.env ?? {}) },
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+      child.on('error', (error) => {
+        reject(new Error(`Failed to execute local command: ${error.message}`));
+      });
+
+      child.on('close', (code) => {
+        resolve({
+          stdout,
+          stderr,
+          exitCode: code ?? 1,
+          durationMs: Date.now() - startedAt,
+        });
+      });
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    // No-op.
+  }
+}
+
+// ── SSH backend ───────────────────────────────────────────────────────────
+
+class SshExecBackend implements ExecBackend {
+  readonly id: string;
+  readonly type = 'ssh';
+  readonly label: string;
+  private readonly host: string;
+  private readonly port: number;
+  private readonly user: string | undefined;
+  private readonly identityFile: string | undefined;
+  private readonly cwd: string | undefined;
+
+  constructor(config: SshExecBackendConfig) {
+    this.id = config.id ?? 'ssh';
+    this.label = config.label ?? `SSH (${config.user ? `${config.user}@` : ''}${config.host})`;
+    this.host = config.host;
+    this.port = config.port ?? 22;
+    this.user = config.user;
+    this.identityFile = config.identity_file;
+    this.cwd = config.cwd;
+  }
+
+  private buildSshArgs(remoteCommand: string): string[] {
+    const args: string[] = [
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'BatchMode=yes',
+      '-p', String(this.port),
+    ];
+    if (this.identityFile) {
+      args.push('-i', this.identityFile);
+    }
+    const target = this.user ? `${this.user}@${this.host}` : this.host;
+    args.push(target, '--', remoteCommand);
+    return args;
+  }
+
+  async ensure(): Promise<void> {
+    // Verify connectivity with a quick echo.
+    const result = await this.exec('echo ok');
+    if (result.exitCode !== 0) {
+      throw new ValidationError(
+        `SSH connectivity check failed for ${this.host}: ${result.stderr.trim()}`,
+      );
+    }
+  }
+
+  async exec(command: string): Promise<ExecResult> {
+    const wrappedCommand = this.cwd
+      ? `cd ${shellEscape(this.cwd)} && ${command}`
+      : command;
+    const startedAt = Date.now();
+
+    return new Promise<ExecResult>((resolve, reject) => {
+      const child = spawn('ssh', this.buildSshArgs(wrappedCommand), {
+        env: process.env,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+      child.on('error', (error) => {
+        reject(new Error(`Failed to execute SSH command: ${error.message}`));
+      });
+
+      child.on('close', (code) => {
+        resolve({
+          stdout,
+          stderr,
+          exitCode: code ?? 1,
+          durationMs: Date.now() - startedAt,
+        });
+      });
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    // No-op — no persistent connection.
+  }
+}
+
+/** Minimal shell-safe escaping for a single argument. */
+const shellEscape = (s: string): string => `'${s.replace(/'/g, "'\\''")}'`;
+
+// ── Register built-in backends ────────────────────────────────────────────
+
+registerExecBackend('docker', (config, context) =>
+  new DockerExecBackend(config as DockerExecBackendConfig, context.containerManager, context.agentId),
+);
+
+registerExecBackend('local', (config, context) =>
+  new LocalExecBackend(config as LocalExecBackendConfig, context.workspaceDir),
+);
+
+registerExecBackend('ssh', (config) =>
+  new SshExecBackend(config as SshExecBackendConfig),
+);
+
+// ── ExecBackendManager ────────────────────────────────────────────────────
+
+export class ExecBackendManager {
+  private readonly backends: Map<string, ExecBackend>;
+  private readonly defaultId: string;
+
+  constructor(backends: ExecBackend[], defaultId?: string) {
+    this.backends = new Map(backends.map((b) => [b.id, b]));
+    if (backends.length === 0) {
+      throw new ValidationError('At least one exec backend must be configured.');
+    }
+    this.defaultId = defaultId ?? backends[0]!.id;
+    if (!this.backends.has(this.defaultId)) {
+      throw new ValidationError(`Default exec backend not found: ${this.defaultId}`);
+    }
+  }
+
+  /** Create from config, normalizing legacy workspace_container if needed. */
+  static fromConfig(
+    execConfig: ExecConfig | undefined,
+    legacyContainer: WorkspaceContainerConfig | undefined,
+    context: BackendFactoryContext,
+  ): ExecBackendManager {
+    let configs: ExecBackendConfig[];
+    let defaultId: string | undefined;
+
+    if (execConfig && execConfig.backends.length > 0) {
+      configs = execConfig.backends;
+      defaultId = execConfig.default_backend;
+    } else if (legacyContainer) {
+      configs = [{
+        type: 'docker' as const,
+        id: 'docker',
+        image: legacyContainer.image,
+        ...(legacyContainer.memory_limit ? { memory_limit: legacyContainer.memory_limit } : {}),
+        ...(legacyContainer.cpu_shares ? { cpu_shares: legacyContainer.cpu_shares } : {}),
+        ...(legacyContainer.lifecycle ? { lifecycle: legacyContainer.lifecycle } : {}),
+      }];
+    } else {
+      // No exec config at all — create a local backend as fallback.
+      configs = [{ type: 'local', id: 'local' }];
+    }
+
+    // Assign default ids for configs without explicit id.
+    const usedIds = new Set<string>();
+    for (const config of configs) {
+      if (!config.id) {
+        let candidate: string = config.type;
+        let counter = 2;
+        while (usedIds.has(candidate)) {
+          candidate = `${config.type}-${counter++}`;
+        }
+        (config as { id?: string }).id = candidate;
+      }
+      usedIds.add(config.id!);
+    }
+
+    const backends = configs.map((c) => createExecBackend(c, context));
+    return new ExecBackendManager(backends, defaultId);
+  }
+
+  get(id?: string): ExecBackend {
+    const targetId = id ?? this.defaultId;
+    const backend = this.backends.get(targetId);
+    if (!backend) {
+      throw new NotFoundError(`Exec backend not found: ${targetId}`);
+    }
+    return backend;
+  }
+
+  getDefault(): ExecBackend {
+    return this.get(this.defaultId);
+  }
+
+  list(): ExecBackend[] {
+    return [...this.backends.values()];
+  }
+
+  async shutdownAll(): Promise<void> {
+    await Promise.allSettled(
+      [...this.backends.values()].map((b) => b.shutdown()),
+    );
+  }
+}

--- a/apps/agent/src/core/index.ts
+++ b/apps/agent/src/core/index.ts
@@ -2,3 +2,4 @@ export * from './types.js';
 export * from './workspace.js';
 export * from './security.js';
 export * from './container-manager.js';
+export * from './exec-backend.js';

--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -114,6 +114,7 @@ export interface AgentRuntimeConfig {
   http_api: HttpApiConfig;
   memory: MemoryConfig;
   workspace_container?: WorkspaceContainerConfig;
+  exec?: import('./exec-backend.js').ExecConfig;
   web?: WebConfig;
   channels?: ChannelsConfig;
 }

--- a/apps/agent/src/tools/shared.ts
+++ b/apps/agent/src/tools/shared.ts
@@ -2,7 +2,7 @@ import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { ValidationError } from '@openhermit/shared';
 import type { InstructionStore, MemoryProvider, MessageStore, SessionStore, StoreScope, UserStore } from '@openhermit/store';
 
-import { AgentSecurity, type DockerContainerManager, type WorkspaceContainerConfig } from '../core/index.js';
+import { AgentSecurity, type DockerContainerManager, type ExecBackendManager, type WorkspaceContainerConfig } from '../core/index.js';
 import type { WebProvider } from '../web/index.js';
 
 export interface Toolset {
@@ -63,6 +63,7 @@ export interface ToolContext {
   storeScope?: StoreScope;
   agentId?: string;
   workspaceContainerConfig?: WorkspaceContainerConfig;
+  execBackendManager?: ExecBackendManager;
   onExec?: () => void;
   approvalCallback?: ApprovalCallback;
   approvedCache?: Set<string>;

--- a/apps/agent/src/tools/workspace-exec.ts
+++ b/apps/agent/src/tools/workspace-exec.ts
@@ -11,8 +11,13 @@ import {
 
 const WorkspaceExecParams = Type.Object({
   command: Type.String({
-    description: 'Shell command to execute inside the workspace container.',
+    description: 'Shell command to execute.',
   }),
+  backend: Type.Optional(
+    Type.String({
+      description: 'Execution backend id. Omit to use the default backend.',
+    }),
+  ),
 });
 
 type WorkspaceExecArgs = Static<typeof WorkspaceExecParams>;
@@ -22,16 +27,39 @@ export const createWorkspaceExecTool = (
 ): AgentTool<typeof WorkspaceExecParams> => ({
   name: 'exec',
   label: 'Exec',
-  description:
-    'Execute a shell command. The workspace is at /workspace. Use this for all file operations (read, write, search, delete), build tools, language runtimes, tests, and any other shell task.',
+  description: buildExecDescription(context),
   parameters: WorkspaceExecParams,
   execute: async (_toolCallId, args: WorkspaceExecArgs) => {
     ensureAutonomyAllows(context.security, 'exec');
 
+    // Prefer ExecBackendManager if available, fall back to legacy containerManager.
+    if (context.execBackendManager) {
+      const backend = context.execBackendManager.get(args.backend);
+      await backend.ensure();
+      context.onExec?.();
+      const result = await backend.exec(args.command);
+
+      const details = {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+        ...(result.parsedOutput !== undefined
+          ? { parsedOutput: result.parsedOutput }
+          : {}),
+      };
+
+      return {
+        content: asTextContent(formatJson(details)),
+        details,
+      };
+    }
+
+    // Legacy path: direct containerManager usage.
     if (!context.agentId || !context.workspaceContainerConfig) {
       return {
         content: asTextContent(
-          'exec is unavailable: no workspace container configured for this agent.',
+          'exec is unavailable: no execution backend configured for this agent.',
         ),
         details: {},
       };
@@ -66,14 +94,28 @@ export const createWorkspaceExecTool = (
   },
 });
 
+function buildExecDescription(context: ToolContext): string {
+  if (!context.execBackendManager) {
+    return 'Execute a shell command. The workspace is at /workspace. Use this for all file operations (read, write, search, delete), build tools, language runtimes, tests, and any other shell task.';
+  }
+  const backends = context.execBackendManager.list();
+  if (backends.length === 1) {
+    return `Execute a shell command on ${backends[0]!.label}. Use this for all file operations, build tools, language runtimes, tests, and any other shell task.`;
+  }
+  const backendList = backends
+    .map((b) => `- \`${b.id}\`: ${b.label}`)
+    .join('\n');
+  return `Execute a shell command. Use the \`backend\` parameter to choose an execution environment.\n\nAvailable backends:\n${backendList}\n\nUse this for all file operations, build tools, language runtimes, tests, and any other shell task.`;
+}
+
 // ── Toolset ────────────────────────────────────────────────────────
 
 const EXEC_DESCRIPTION = `\
 ### Execution
 
-Use \`exec\` to run any shell command. The workspace is at \`/workspace\`. This is how you do everything: read files, write files, search, build, test, install packages, run scripts.
+Use \`exec\` to run any shell command. This is how you do everything: read files, write files, search, build, test, install packages, run scripts.
 
-The execution environment is a persistent Linux container. Installed packages and state survive between calls.`;
+The execution environment is persistent. Installed packages and state survive between calls.`;
 
 export const createExecToolset = (context: ToolContext): Toolset => ({
   id: 'exec',

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -327,8 +327,8 @@ test('AgentRunner builds dynamic system prompt based on available tools', async 
   // Container section absent (container tools are currently disabled)
   assert.doesNotMatch(capturedSystemPrompt, /Service Containers/);
 
-  // Exec section absent (no workspace_container configured in test fixture)
-  assert.doesNotMatch(capturedSystemPrompt, /### Execution/);
+  // Exec section present (local backend is always available as fallback)
+  assert.match(capturedSystemPrompt, /### Execution/);
 
   // Memory section present (memoryProvider is always provided)
   assert.match(capturedSystemPrompt, /memory_recall/);


### PR DESCRIPTION
## Summary

- Introduces `ExecBackend` interface decoupling the `exec` tool from Docker containers
- Three initial backends: **docker** (wraps existing ContainerManager), **local** (host shell), **ssh** (remote host)
- One agent can have multiple execution environments simultaneously
- Factory registry pattern (`registerExecBackend`) for adding new backend types
- Backward compatible: `workspace_container` config auto-normalizes to a docker backend

### New files
- `apps/agent/src/core/exec-backend.ts` — ExecBackend interface, 3 implementations, factory registry, ExecBackendManager

### Modified files
- `apps/agent/src/core/types.ts` — `exec?: ExecConfig` in AgentRuntimeConfig
- `apps/agent/src/tools/shared.ts` — `execBackendManager` in ToolContext
- `apps/agent/src/tools/workspace-exec.ts` — optional `backend` param, dynamic description
- `apps/agent/src/agent-runner.ts` — lazy ExecBackendManager init, lifecycle wiring
- `apps/agent/test/agent-runner.test.ts` — updated assertion (local backend always available)

## Test plan

- [x] TypeScript build passes
- [x] All 135 tests pass
- [ ] Manual: verify exec works with default local backend (no workspace_container)
- [ ] Manual: verify exec works with docker backend (workspace_container config)
- [ ] Future: add SSH backend integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)