### PR TITLE
[codex] Serialize Discord channel turns

### DIFF
--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -21,6 +21,7 @@ export class DiscordBridge implements ChannelOutbound {
   private readonly log: (message: string) => void;
   private readonly lastEventIds = new Map<string, number>();
   private readonly channelSessions = new Map<string, string>();
+  private readonly turnQueues = new Map<string, Promise<void>>();
 
   constructor(
     private readonly discord: DiscordApi,
@@ -83,7 +84,34 @@ export class DiscordBridge implements ChannelOutbound {
     if (!text) return;
 
     const sessionId = await this.getSessionId(event.channelId);
-    await this.sendToAgent(event, sessionId, text);
+    await this.runInChannelQueue(event.channelId, () => this.sendToAgent(event, sessionId, text));
+  }
+
+  private async runInChannelQueue(channelId: string, task: () => Promise<void>): Promise<void> {
+    const previousTurn = this.turnQueues.get(channelId);
+    const currentTurn = this.runAfterPreviousTurn(previousTurn, task).finally(() => {
+      if (this.turnQueues.get(channelId) === currentTurn) {
+        this.turnQueues.delete(channelId);
+      }
+    });
+
+    this.turnQueues.set(channelId, currentTurn);
+    await currentTurn;
+  }
+
+  private async runAfterPreviousTurn(
+    previousTurn: Promise<void> | undefined,
+    task: () => Promise<void>,
+  ): Promise<void> {
+    if (previousTurn) {
+      try {
+        await previousTurn;
+      } catch {
+        // Keep later Discord messages flowing after a failed turn.
+      }
+    }
+
+    await task();
   }
 
   async handleNewSession(channelId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Serializes Discord bridge message handling per Discord channel before posting a message to the agent and waiting for the response stream.

## Why

The Discord bridge keeps one OpenHermit session per Discord channel. If two users mention the bot in the same channel at nearly the same time, both handlers can post into the same session and open response event streams concurrently. That lets multiple waiters observe the same assistant event and can duplicate or misroute replies.

Queueing by channel preserves message order and ensures only one response waiter consumes a channel session stream at a time.

## Implementation note

The queueing code is admittedly a little awkward because Discord delivers messages as independent callbacks, while the bridge needs to process those callbacks as ordered turns for each shared channel session. This keeps the fix scoped to the Discord bridge without redesigning the broader channel/session runtime.

A cleaner long-term route may be to add explicit turn/message correlation to the session protocol so a channel can post concurrent messages and then wait only for the response belonging to its own turn. That would avoid per-channel serialization, but it would touch the core runtime, SDK, event stream payloads, and channel integrations rather than just the Discord bridge.

## Example
<img width="896" height="243" alt="Screenshot 2026-05-03 at 1 42 59 PM" src="https://github.com/user-attachments/assets/643d9a5c-9517-4f0e-8bf6-d389beaf4241" />

## Validation

- `npm run typecheck -w @openhermit/channel-discord`
- `npm run build -w @openhermit/channel-discord`