### PR TITLE
fix(gateway): require auth on agent mcp-servers, redact header values

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1769,10 +1769,16 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
 
   app.get('/api/agents/:agentId/mcp-servers', async (c) => {
     const agentId = c.req.param('agentId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
     // Pure DB read — no runner needed. Lets admin inspect a stopped agent.
     const store = requireMcpServerStore();
     const servers = await store.listEnabled(agentId);
-    return c.json(servers);
+    // Strip header values — they may contain bearer tokens. Expose only the
+    // key names so the UI can show that auth is configured without leaking secrets.
+    return c.json(servers.map(({ headers, ...rest }) => ({
+      ...rest,
+      headerKeys: headers ? Object.keys(headers) : [],
+    })));
   });
 
   // --- agent-level: owner management endpoints ---

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1739,6 +1739,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
 
   app.get('/api/agents/:agentId/skills', async (c) => {
     const agentId = c.req.param('agentId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
     const store = requireSkillStore();
     const runner = instances.getRunner(agentId);
 

--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -35,6 +35,7 @@ interface McpServerInfo {
   name: string;
   description: string;
   url: string;
+  headerKeys?: string[];
 }
 
 const REFRESH_MS = 10_000;
@@ -693,6 +694,11 @@ function AgentMcpDialog({ agentId, onClose }: { agentId: string; onClose: () => 
               <span className="skill-card__id">{s.id}</span>
               <div className="skill-card__desc">{s.description}</div>
               <div className="skill-card__path">{s.url}</div>
+              {s.headerKeys && s.headerKeys.length > 0 && (
+                <div className="skill-card__path">
+                  Auth headers: {s.headerKeys.join(', ')}
+                </div>
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

`GET /api/agents/:agentId/mcp-servers` had no auth enforcement and returned plaintext bearer tokens in the response. Anyone with HTTP access to the gateway port could enumerate agents' MCP servers and read their `Authorization` headers in cleartext.

- Add `requireOwnerOrAdmin` to the route handler
- Replace `headers` in the response with `headerKeys: string[]` so the UI can indicate that auth is configured without exposing the values
- Update the gateway UI's `AgentMcpDialog` to surface header key names

## Test plan

- [ ] Unauthenticated request to `/api/agents/:agentId/mcp-servers` is rejected
- [ ] Owner/admin request returns servers with `headerKeys` populated and no `headers` field
- [ ] Fleet panel \"MCP Servers\" dialog renders header key names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MCP server responses now expose headerKeys (names only) instead of raw header values.
* **Security**
  * Access to per-agent skills and MCP servers endpoints now requires owner or admin authentication.
* **UI**
  * Fleet panel will conditionally display authentication header names when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->