### PR TITLE
fix(security): timing-safe admin token, JWT alg pinning, sanitize markdown HTML

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -59,6 +59,7 @@ import {
   type UserAuthProvider,
   resolveAuth,
   signJwt,
+  tokensMatch,
   verifyAdminToken,
 } from './auth.js';
 
@@ -642,7 +643,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     // No JWT auth configured, but admin token exists — resolve admin auth for per-agent management routes
     const adminMiddleware = async (c: any, next: any) => {
       const authorization = c.req.header('authorization');
-      if (authorization?.startsWith('Bearer ') && authorization.slice(7) === adminToken) {
+      if (authorization?.startsWith('Bearer ') && tokensMatch(authorization.slice(7), adminToken)) {
         c.set('auth' as never, { mode: 'admin', channel: 'admin', channelUserId: 'admin' } as never);
       }
       await next();

--- a/apps/gateway/src/auth.ts
+++ b/apps/gateway/src/auth.ts
@@ -18,6 +18,7 @@
  */
 
 import { SignJWT, jwtVerify, type JWTPayload } from 'jose';
+import { timingSafeEqual } from 'node:crypto';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -286,17 +287,36 @@ export const verifyJwt = async (
   token: string,
 ): Promise<JwtTokenPayload | null> => {
   try {
-    const { payload } = await jwtVerify(token, config.secret);
+    // Pin algorithm to prevent `alg:none` and algorithm-confusion attacks.
+    const { payload } = await jwtVerify(token, config.secret, { algorithms: ['HS256'] });
     if (!payload.sub || !payload.channel || !payload.channelUserId) {
       return null;
     }
     return payload as JwtTokenPayload;
-  } catch {
+  } catch (err) {
+    if (process.env.OPENHERMIT_LOG_AUTH === '1') {
+      console.debug('[auth] JWT verify failed:', (err as Error).message);
+    }
     return null;
   }
 };
 
 // ── Admin token ───────────────────────────────────────────────────────────
+
+/**
+ * Constant-time comparison of two strings. Returns false on length mismatch
+ * without leaking length info via timing.
+ */
+export const tokensMatch = (a: string, b: string): boolean => {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) {
+    // Still run a comparison against itself to keep timing roughly constant.
+    timingSafeEqual(aBuf, aBuf);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+};
 
 export const verifyAdminToken = (
   adminToken: string | undefined,
@@ -304,7 +324,7 @@ export const verifyAdminToken = (
 ): boolean => {
   if (!adminToken) return false;
   if (!authorization?.startsWith('Bearer ')) return false;
-  return authorization.slice(7) === adminToken;
+  return tokensMatch(authorization.slice(7), adminToken);
 };
 
 // ── Auth resolution ────────────────────────────────────────────────────────
@@ -354,8 +374,8 @@ export const resolveAuth = async (
   }
 
   if (bearerToken) {
-    // 0. Admin token — full access
-    if (options.adminToken && bearerToken === options.adminToken) {
+    // 0. Admin token — full access (timing-safe comparison)
+    if (options.adminToken && tokensMatch(bearerToken, options.adminToken)) {
       return { mode: 'admin' as const, channel: 'admin', channelUserId: 'admin' };
     }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
+    "dompurify": "^3.4.2",
     "katex": "^0.16.45",
     "marked": "^15.0.12",
     "react": "^19.1.0",

--- a/apps/web/ui/src/components/ChatMessages.tsx
+++ b/apps/web/ui/src/components/ChatMessages.tsx
@@ -3,6 +3,7 @@ import { marked, type TokenizerExtension, type RendererExtension } from 'marked'
 import katex from 'katex';
 import 'katex/dist/katex.min.css';
 import remend from 'remend';
+import DOMPurify from 'dompurify';
 import { apiFetch } from '../api';
 
 // ─── KaTeX extension for marked ────────────────────────────────────────────
@@ -51,9 +52,19 @@ marked.use({ extensions: [mathBlock, mathInline] });
 
 // ─── Markdown renderer ─────────────────────────────────────────────────────
 
+// Allow common markdown/KaTeX output but strip <script>, event handlers, and
+// unsafe URI schemes. Agent output is untrusted; never inject raw HTML.
+const SANITIZE_CONFIG: DOMPurify.Config = {
+  ADD_TAGS: ['math', 'mrow', 'mi', 'mo', 'mn', 'ms', 'mtext', 'mfrac', 'msqrt', 'mroot', 'msub', 'msup', 'msubsup', 'munder', 'mover', 'munderover', 'mtable', 'mtr', 'mtd', 'semantics', 'annotation'],
+  ADD_ATTR: ['target', 'rel'],
+  FORBID_TAGS: ['style'],
+  FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onmouseenter', 'onmouseleave'],
+};
+
 const renderMarkdown = (text: string, streaming = false): string => {
   const src = streaming ? remend(text, { linkMode: 'text-only' }) : text;
-  return marked.parse(src, { async: false }) as string;
+  const raw = marked.parse(src, { async: false }) as string;
+  return DOMPurify.sanitize(raw, SANITIZE_CONFIG);
 };
 
 // ─── Types ─────────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,7 @@
       "name": "@openhermit/web",
       "version": "0.2.0",
       "dependencies": {
+        "dompurify": "^3.4.2",
         "katex": "^0.16.45",
         "marked": "^15.0.12",
         "react": "^19.1.0",
@@ -5155,6 +5156,13 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6029,6 +6037,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {


### PR DESCRIPTION
## Summary

Three small, defensive hardening fixes for the gateway and web client.

### 1. Timing-safe admin-token comparison
`apps/gateway/src/auth.ts` + `apps/gateway/src/app.ts`

Today the admin Bearer token is checked with strict equality (`===`),
which leaks length/prefix information through string-compare timing.
This PR introduces a small `tokensMatch()` helper that:

- Rejects fast on length mismatch.
- Falls through to `crypto.timingSafeEqual()` on equal-length inputs.

Used in both `resolveAuth()` and `verifyAdminToken()` so every admin
code path goes through the constant-time check.

### 2. Pin JWT algorithm to HS256
`apps/gateway/src/auth.ts`

`jwtVerify(token, secret)` without an explicit `algorithms` list will
trust whatever `alg` the incoming token claims, which historically
opens the door to `alg=none` confusion attacks against jose-style
libraries when secrets get rotated or when middleware order changes.

This pins verification to `['HS256']` to match how we sign tokens, and
gates the noisy verify-failure log behind `OPENHERMIT_LOG_AUTH=1` so
we don't print rejected tokens by default.

### 3. Sanitize markdown HTML before `dangerouslySetInnerHTML`
`apps/web/ui/src/components/ChatMessages.tsx` + `apps/web/package.json`

Tool/agent output is rendered through `marked` and dropped into the DOM
via `dangerouslySetInnerHTML`. If a tool result ever surfaces user-
controlled HTML (e.g. an inline `<img onerror>` or `javascript:` URI),
this would execute in the browser session.

This PR pipes the marked output through DOMPurify before render:

- Allows the KaTeX MathML output (`ADD_TAGS`) so equations still render.
- Strips `<script>`, inline event handlers, `<style>`, and
  `javascript:` URIs.
- Adds `dompurify` to `apps/web/package.json`.

## Verification

Tested locally against a running gateway:
- Valid admin Bearer  -> 200
- Same-length wrong token  -> 401 (no fast path leak)
- Forged `alg=none` JWT  -> 401
- Markdown with `<img src=x onerror=...>` renders the `<img>` but the
  handler is stripped.

## Notes

- No changes to built artifacts under `apps/web/public/assets/` \u2014 those
  should be rebuilt as part of the normal release flow.
- No public API changes; all changes are internal hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Implemented client-side content sanitization for chat messages
  * Enhanced admin token verification with improved comparison methods
  * Strengthened JWT validation with explicit algorithm enforcement and enhanced error logging

* **Dependencies**
  * Added new dependency for content sanitization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->