### PR TITLE
feat(sdk): add registerMcpServer client method

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -479,6 +479,17 @@ export class GatewayClient {
     return this.getJson(`/api/admin/mcp-servers`);
   }
 
+  async registerMcpServer(input: {
+    id: string;
+    name: string;
+    description: string;
+    url: string;
+    headers?: Record<string, string>;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.postJson(`/api/admin/mcp-servers`, input);
+  }
+
   async listMcpAssignments(): Promise<Array<{ agentId: string; mcpServerId: string; enabled: boolean }>> {
     return this.getJson(`/api/admin/mcp-servers/assignments`);
   }


### PR DESCRIPTION
## Summary

Adds a thin client wrapper around the existing `POST /api/admin/mcp-servers` admin endpoint, mirroring the shape of the other admin helpers on `GatewayClient` (`listMcpServers`, `listMcpAssignments`, etc.).

```ts
await client.registerMcpServer({
  id: 'filesystem',
  name: 'Filesystem',
  description: 'Local filesystem access',
  url: 'http://...',
  headers: { Authorization: 'Bearer ...' },
});
```

## Why

External tooling (CLI templates, provisioners, scripts) currently has to drop down to raw `fetch` to register MCP servers because the SDK only exposes the read side. This closes that gap with a 1:1 wrapper.

## Notes

- 11 lines, single file (`packages/sdk/src/index.ts`).
- No public API breakage; purely additive.
- Endpoint already exists (`apps/gateway/src/app.ts` line ~2432).