### PR TITLE
feat(cli): agent templates with 'coder' preset

### DIFF
--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -1,6 +1,84 @@
 import type { Command } from 'commander';
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { createGateway, handleError, printTable } from './shared.js';
+
+interface AgentTemplate {
+  id: string;
+  label?: string;
+  description?: string;
+  model?: { provider?: string; name?: string; fallbacks?: string[] };
+  instructions?: Record<string, string>;
+  mcpServers?: Array<{ id: string; name: string; description: string; url: string }>;
+}
+
+const TEMPLATES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../templates');
+
+async function loadTemplate(nameOrPath: string): Promise<AgentTemplate> {
+  const path = isAbsolute(nameOrPath) || nameOrPath.includes('/')
+    ? nameOrPath
+    : resolve(TEMPLATES_DIR, `${nameOrPath}.json`);
+  const raw = await readFile(path, 'utf8');
+  return JSON.parse(raw) as AgentTemplate;
+}
+
+type GatewayClient = ReturnType<typeof createGateway>;
+
+async function applyTemplateToAgent(
+  gateway: GatewayClient,
+  agentId: string,
+  tmpl: AgentTemplate,
+): Promise<void> {
+  // 1. Instructions
+  if (tmpl.instructions) {
+    for (const [key, content] of Object.entries(tmpl.instructions)) {
+      await gateway.setInstruction(agentId, key, content);
+      console.log(`  · instructions/${key} set`);
+    }
+  }
+
+  // 2. Model — merge into existing config so we don't clobber other fields.
+  if (tmpl.model) {
+    try {
+      const cfg = await gateway.getAgentConfig(agentId);
+      const next = { ...cfg, model: { ...(cfg.model as object | undefined ?? {}), ...tmpl.model } };
+      await gateway.putAgentConfig(agentId, next);
+      console.log(`  · model set to ${tmpl.model.name ?? '(unspecified)'}`);
+    } catch (err) {
+      console.warn(`  · could not update model config: ${(err as Error).message}`);
+    }
+  }
+
+  // 3. MCP servers — register each (idempotent upsert) and enable for this agent.
+  if (tmpl.mcpServers && tmpl.mcpServers.length > 0) {
+    for (const server of tmpl.mcpServers) {
+      try {
+        await gateway.registerMcpServer({
+          id: server.id,
+          name: server.name,
+          description: server.description,
+          url: server.url,
+        });
+      } catch (err) {
+        // Ignore conflict (already registered); surface other errors.
+        const msg = (err as Error).message ?? '';
+        if (!/conflict|exists|409/i.test(msg)) {
+          console.warn(`  · could not register MCP "${server.id}": ${msg}`);
+          continue;
+        }
+      }
+      try {
+        await gateway.enableMcpServer(server.id, agentId);
+        console.log(`  · mcp/${server.id} enabled`);
+      } catch (err) {
+        console.warn(`  · could not enable MCP "${server.id}": ${(err as Error).message}`);
+      }
+    }
+    console.log('  · note: MCP servers using stdio:// URLs require a stdio-capable transport in your gateway. Edit URLs as needed.');
+  }
+}
 
 export const registerAgentsCommand = (program: Command): void => {
   const agents = program
@@ -49,16 +127,16 @@ export const registerAgentsCommand = (program: Command): void => {
     .option('--owner <userId>', 'Owner user ID')
     .option('--sandbox <preset>', 'Sandbox preset to provision (defaults to gateway autoProvisionSandbox)')
     .option('--no-sandbox', 'Skip sandbox provisioning entirely')
+    .option('--template <nameOrPath>', 'Apply a built-in template (e.g. "coder") or a path to a template JSON file after creation')
     .action(async (agentId: string, opts: {
       name?: string;
       workspaceDir?: string;
       owner?: string;
       sandbox?: string | false;
+      template?: string;
     }) => {
       try {
         const gateway = createGateway();
-        // Commander turns `--no-sandbox` into `sandbox: false`; map both
-        // forms onto the API's `sandbox: string | null` field.
         const sandboxField: { sandbox: string | null } | object =
           opts.sandbox === false
             ? { sandbox: null }
@@ -73,6 +151,27 @@ export const registerAgentsCommand = (program: Command): void => {
           ...sandboxField,
         });
         console.log(`Agent created: ${result.agentId} (${result.status})`);
+
+        if (opts.template) {
+          const tmpl = await loadTemplate(opts.template);
+          await applyTemplateToAgent(gateway, agentId, tmpl);
+          console.log(`Template applied: ${tmpl.label ?? tmpl.id}`);
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  // --- apply-template ---
+  agents
+    .command('apply-template <agentId> <nameOrPath>')
+    .description('Apply a template to an existing agent (sets instructions, model, registers MCP servers)')
+    .action(async (agentId: string, nameOrPath: string) => {
+      try {
+        const gateway = createGateway();
+        const tmpl = await loadTemplate(nameOrPath);
+        await applyTemplateToAgent(gateway, agentId, tmpl);
+        console.log(`Template "${tmpl.label ?? tmpl.id}" applied to ${agentId}.`);
       } catch (error) {
         handleError(error);
       }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -479,6 +479,17 @@ export class GatewayClient {
     return this.getJson(`/api/admin/mcp-servers`);
   }
 
+  async registerMcpServer(input: {
+    id: string;
+    name: string;
+    description: string;
+    url: string;
+    headers?: Record<string, string>;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.postJson(`/api/admin/mcp-servers`, input);
+  }
+
   async listMcpAssignments(): Promise<Array<{ agentId: string; mcpServerId: string; enabled: boolean }>> {
     return this.getJson(`/api/admin/mcp-servers/assignments`);
   }

--- a/templates/coder.json
+++ b/templates/coder.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "./schema.json",
+  "id": "coder",
+  "label": "Coder",
+  "description": "Autonomous coding agent for vibecoding-style work: edits files in its workspace, runs tests, commits, opens PRs. Pairs well with MCP filesystem/git/github servers.",
+
+  "model": {
+    "provider": "openrouter",
+    "name": "anthropic/claude-sonnet-4.5",
+    "fallbacks": [
+      "anthropic/claude-opus-4.5",
+      "google/gemini-3-pro",
+      "openai/gpt-5"
+    ]
+  },
+
+  "instructions": {
+    "identity": "You are a senior software engineer agent.\n\nYour job is to take a coding goal expressed in natural language and make it real in the user's codebase: edit files, run tests, fix failures, and report back with a clear summary of what changed and why.\n\nYou work primarily inside your assigned workspace directory. Treat it as a real project — discover its conventions before assuming anything.",
+
+    "soul": "You think in small, reversible steps. You read before you write, run before you assume, and explain before you commit.\n\nWhen given a vague request, you ask one targeted clarifying question only if proceeding would meaningfully waste time; otherwise you make the most reasonable interpretation and proceed, flagging your assumption.\n\nYou are direct and concise. You favor showing diffs and outputs over describing them. When you are uncertain, you say so.",
+
+    "rules": "1. Always inspect the workspace structure (package.json / pyproject.toml / Cargo.toml / go.mod / etc.) before making changes — match the project's existing language, framework, and style.\n2. Prefer minimal, focused diffs. Do not refactor unrelated code unless asked.\n3. Run the project's tests / typecheck / lint commands after non-trivial changes. If tests are missing, propose adding them rather than silently skipping verification.\n4. Never force-push, rewrite shared history, or run destructive shell commands (rm -rf outside workspace, dropping databases, etc.) without explicit confirmation.\n5. When using git: prefer feature branches over committing to the default branch. Commit messages follow Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`).\n6. Surface every secret you'd need (API keys, deploy tokens) by name rather than guessing — ask the user to add them via the Manage → Secrets panel.\n7. When you finish a task, end with: a one-paragraph summary, the list of files changed, and the next action you'd recommend (run/test/deploy/review)."
+  },
+
+  "mcpServers": [
+    {
+      "id": "filesystem",
+      "name": "Filesystem",
+      "description": "Read/write files within the agent's workspace.",
+      "url": "stdio:npx -y @modelcontextprotocol/server-filesystem ${WORKSPACE_DIR}",
+      "notes": "Replace ${WORKSPACE_DIR} with the agent's workspace path. Stdio MCP servers require a runner that supports stdio transport — adjust the URL to match your gateway's MCP transport (HTTP or stdio bridge)."
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "description": "Run git commands in the workspace (status, diff, branch, commit, log).",
+      "url": "stdio:npx -y @modelcontextprotocol/server-git --repository ${WORKSPACE_DIR}"
+    },
+    {
+      "id": "github",
+      "name": "GitHub",
+      "description": "Manage issues, PRs, and code on GitHub. Requires GITHUB_PERSONAL_ACCESS_TOKEN secret on the agent.",
+      "url": "stdio:npx -y @modelcontextprotocol/server-github",
+      "secretsRequired": ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    },
+    {
+      "id": "shell",
+      "name": "Shell",
+      "description": "Run shell commands inside the agent's sandbox/workspace.",
+      "url": "stdio:npx -y @modelcontextprotocol/server-shell --cwd ${WORKSPACE_DIR}",
+      "notes": "Optional. Builtin OpenHermit shell skill already covers most cases — only enable this if you want a separate MCP-managed shell."
+    }
+  ],
+
+  "secrets": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": {
+      "description": "Required by the GitHub MCP server. Create a fine-scoped PAT at https://github.com/settings/personal-access-tokens with repo / pull-requests / issues access for the repos you want this agent to touch.",
+      "required": false
+    },
+    "OPENROUTER_API_KEY": {
+      "description": "Required if model.provider is 'openrouter'. Get one at https://openrouter.ai/keys.",
+      "required": true
+    }
+  },
+
+  "suggestedSkills": [
+    "files",
+    "shell",
+    "search",
+    "memory"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an opt-in template system to the `hermit agents` CLI so common agent personas can be bootstrapped with one command instead of clicking through the manage UI.

```
hermit agents create --template coder
hermit agents apply-template <agentId> ./my-template.json
```

## What's in this PR

- **`templates/coder.json`** \u2014 new preset for autonomous coding agents:
  - Default model: `anthropic/claude-sonnet-4.5` via OpenRouter, with fallbacks to Opus 4.5 / Gemini 3 Pro / GPT-5.
  - Identity / soul / rules tuned for vibecoding-style workflows (small reversible diffs, run tests, conventional commits, never force-push).
  - Suggested MCP servers: filesystem, git, github, shell.
  - Declares required secrets (`GITHUB_PERSONAL_ACCESS_TOKEN`, `OPENROUTER_API_KEY`).
  - Suggested skills: files, shell, search, memory.
- **`apps/cli/src/commands/agents.ts`**:
  - New `--template <nameOrPath>` flag on `agents create`.
  - New `agents apply-template <agentId> <nameOrPath>` subcommand.
  - Helper applies model config, instructions (identity/soul/rules), and registers + enables MCP servers idempotently (treats 409 conflicts as 'already registered').

## Dependency

This PR uses `GatewayClient.registerMcpServer()`, which is added in **#16 (`feat(sdk): add registerMcpServer client method`)**. Recommend landing #16 first \u2014 the SDK commit (`65d9573`) is included here so this branch builds standalone, but it will be a no-op merge if #16 has already landed.

## Notes

- `templates/coder.json` is just a starter \u2014 happy to genericize the model defaults (e.g. point at a free-tier OpenRouter model) if that fits the project direction better.
- All template behavior is opt-in; no change to existing `agents create` flow without the `--template` flag.
- Idempotent: `apply-template` can be re-run safely; MCP registration treats conflicts as success.