### PR TITLE
feat(web): show access-token panel + restore-from-key flow on welcome screen

### DIFF
--- a/apps/web/ui/src/api.ts
+++ b/apps/web/ui/src/api.ts
@@ -189,6 +189,48 @@ export const setConnection = (conn: Connection): void => {
 export const getApiBase = (): string => apiBase;
 export const getGatewayBase = (): string => gatewayBase;
 
+// ─── Device key export (for backup / multi-device) ─────────────────────────
+
+/**
+ * Export the device's JWK keypair as a JSON string. This is the FULL
+ * private key — anyone who has it can authenticate as this device.
+ * Treat it like a password and never paste into untrusted forms.
+ */
+export const exportDeviceKey = (): string | null => {
+  const stored = readDeviceStorage();
+  if (!stored) return null;
+  return JSON.stringify({
+    publicKey: stored.publicKey,
+    privateKey: stored.privateKey,
+    ...(stored.displayName ? { displayName: stored.displayName } : {}),
+  }, null, 2);
+};
+
+/**
+ * Restore a device key from a previously exported JSON string. Returns
+ * `true` on success. Caller should then call `exchangeToken()` to get a
+ * fresh JWT.
+ */
+export const importDeviceKey = (json: string): boolean => {
+  try {
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== 'object') return false;
+    if (!parsed.publicKey || !parsed.privateKey) return false;
+    writeDeviceStorage({
+      publicKey: parsed.publicKey,
+      privateKey: parsed.privateKey,
+      ...(parsed.displayName ? { displayName: parsed.displayName } : {}),
+    });
+    deviceKeyPair = null; // force reload on next use
+    jwtToken = null;
+    jwtExpiresAt = 0;
+    localStorage.removeItem(JWT_STORAGE);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // ─── Display name ──────────────────────────────────────────────────────────
 
 export const getDisplayName = (): string | null => readDeviceStorage()?.displayName ?? null;

--- a/apps/web/ui/src/components/PickAgentScreen.tsx
+++ b/apps/web/ui/src/components/PickAgentScreen.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import {
+  exportDeviceKey,
+  getDeviceFingerprint,
   getDisplayName,
+  getJwt,
   getUserId,
   joinAgent,
   listMyAgents,
@@ -28,6 +31,12 @@ export function PickAgentScreen({ gatewayUrl, onPick, onSignOut }: Props) {
   const [joinToken, setJoinToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [joinOpen, setJoinOpen] = useState(false);
+  const [tokensOpen, setTokensOpen] = useState(false);
+  const [accessToken, setAccessToken] = useState('');
+  const [deviceKeyJson, setDeviceKeyJson] = useState('');
+  const [fingerprint, setFingerprint] = useState('');
+  const [showDeviceKey, setShowDeviceKey] = useState(false);
+  const [copyMsg, setCopyMsg] = useState('');
 
   const refresh = async (): Promise<void> => {
     try {
@@ -38,6 +47,30 @@ export function PickAgentScreen({ gatewayUrl, onPick, onSignOut }: Props) {
   };
 
   useEffect(() => { void refresh(); }, []);
+
+  const openTokens = async (): Promise<void> => {
+    setTokensOpen((v) => !v);
+    if (!accessToken) {
+      try {
+        const [jwt, fp] = await Promise.all([getJwt(), getDeviceFingerprint()]);
+        setAccessToken(jwt);
+        setFingerprint(fp);
+        setDeviceKeyJson(exportDeviceKey() ?? '');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+  };
+
+  const copy = async (value: string, label: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyMsg(`${label} copied`);
+      setTimeout(() => setCopyMsg(''), 1800);
+    } catch {
+      setCopyMsg('Copy failed — select and copy manually');
+    }
+  };
 
   const enter = async (m: AgentMembership): Promise<void> => {
     setError('');
@@ -154,7 +187,7 @@ export function PickAgentScreen({ gatewayUrl, onPick, onSignOut }: Props) {
                 />
               </label>
               <label className="field">
-                <span className="field__label">Access Token</span>
+                <span className="field__label">Agent invite token</span>
                 <input
                   className="field__input"
                   type="password"
@@ -162,6 +195,11 @@ export function PickAgentScreen({ gatewayUrl, onPick, onSignOut }: Props) {
                   value={joinToken}
                   onChange={(e) => setJoinToken(e.target.value)}
                 />
+                <span className="field__help">
+                  Per-agent shared secret from the agent's owner (set with
+                  <code> hermit agents create --access-token …</code>). This is
+                  <strong> not</strong> your bearer token.
+                </span>
               </label>
               <div style={{ display: 'flex', gap: 8 }}>
                 <button
@@ -187,6 +225,112 @@ export function PickAgentScreen({ gatewayUrl, onPick, onSignOut }: Props) {
               </div>
             </form>
           </>
+        )}
+
+        <button
+          className="btn btn--ghost btn--sm"
+          type="button"
+          onClick={() => void openTokens()}
+          style={{ marginTop: 16 }}
+        >
+          {tokensOpen ? 'Hide access tokens' : 'Show access tokens'}
+        </button>
+        {tokensOpen && (
+          <div
+            style={{
+              marginTop: 8,
+              padding: 12,
+              border: '1px solid var(--border, #e4e4e7)',
+              borderRadius: 8,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+              fontSize: 13,
+            }}
+          >
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <strong>API bearer token (your JWT)</strong>
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  onClick={() => void copy(accessToken, 'Bearer token')}
+                  disabled={!accessToken}
+                >
+                  Copy
+                </button>
+              </div>
+              <p className="hint" style={{ margin: '0 0 6px' }}>
+                Short-lived (~24h). Use as <code>Authorization: Bearer &lt;token&gt;</code> for the
+                CLI, curl, or any HTTP integration. Auto-refreshes from your device key when it
+                expires. <strong>Don't paste this into the "Agent invite token" field</strong> when joining an agent — that field is a separate per-agent secret.
+              </p>
+              <code
+                style={{
+                  display: 'block',
+                  fontSize: 11,
+                  padding: '8px 10px',
+                  background: 'var(--surface, #f4f4f5)',
+                  borderRadius: 6,
+                  wordBreak: 'break-all',
+                  maxHeight: 80,
+                  overflow: 'auto',
+                }}
+              >
+                {accessToken || 'Loading…'}
+              </code>
+            </div>
+
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                <strong>Device key</strong>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--sm"
+                    onClick={() => setShowDeviceKey((v) => !v)}
+                    disabled={!deviceKeyJson}
+                  >
+                    {showDeviceKey ? 'Hide' : 'Reveal'}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--sm"
+                    onClick={() => void copy(deviceKeyJson, 'Device key')}
+                    disabled={!deviceKeyJson}
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+              <p className="hint" style={{ margin: '0 0 6px' }}>
+                Fingerprint: <code style={{ fontSize: 11 }}>{fingerprint ? `${fingerprint.slice(0, 8)}…${fingerprint.slice(-8)}` : '—'}</code>
+                <br />
+                <span style={{ color: 'var(--danger, #b91c1c)' }}>
+                  ⚠ This is your private key. Anyone with it can sign in as you. Save it to a
+                  password manager to add another device — never paste it into chat or email.
+                </span>
+              </p>
+              {showDeviceKey && (
+                <code
+                  style={{
+                    display: 'block',
+                    fontSize: 11,
+                    padding: '8px 10px',
+                    background: 'var(--surface, #f4f4f5)',
+                    borderRadius: 6,
+                    whiteSpace: 'pre',
+                    maxHeight: 160,
+                    overflow: 'auto',
+                  }}
+                >
+                  {deviceKeyJson || 'Loading…'}
+                </code>
+              )}
+            </div>
+
+            {copyMsg && <p className="hint" style={{ margin: 0, color: 'var(--success, #166534)' }}>{copyMsg}</p>}
+          </div>
         )}
 
         <button

--- a/apps/web/ui/src/components/SetupScreen.tsx
+++ b/apps/web/ui/src/components/SetupScreen.tsx
@@ -3,6 +3,7 @@ import {
   exchangeToken,
   getDeviceFingerprint,
   getDisplayName,
+  importDeviceKey,
   isNewDevice,
   loadGatewayUrl,
   saveGatewayUrl,
@@ -30,6 +31,8 @@ export function SetupScreen({ onComplete }: Props) {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const [mode, setMode] = useState<'new' | 'restore'>('new');
+  const [restoreKey, setRestoreKey] = useState('');
 
   useEffect(() => {
     (async () => {
@@ -47,15 +50,28 @@ export function SetupScreen({ onComplete }: Props) {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const url = gatewayUrl.trim().replace(/\/+$/, '');
-    const dn = name.trim();
-    if (!url || !dn) return;
+    if (!url) return;
     setError('');
     setSubmitting(true);
     try {
-      setDisplayName(dn);
       saveGatewayUrl(url);
       setGateway(url);
-      await exchangeToken(dn);
+      if (mode === 'restore') {
+        const ok = importDeviceKey(restoreKey.trim());
+        if (!ok) throw new Error('That doesn\'t look like a valid device key. Paste the full JSON you exported.');
+        // Use the imported display name if present, otherwise fall back to
+        // whatever the user typed (or the existing one).
+        const importedName = getDisplayName();
+        const dn = importedName || name.trim();
+        if (!dn) throw new Error('Display name is required.');
+        if (!importedName) setDisplayName(dn);
+        await exchangeToken(dn);
+      } else {
+        const dn = name.trim();
+        if (!dn) throw new Error('Display name is required.');
+        setDisplayName(dn);
+        await exchangeToken(dn);
+      }
       onComplete();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -72,7 +88,9 @@ export function SetupScreen({ onComplete }: Props) {
         <p className="eyebrow">OpenHermit</p>
         <h1>{isNew ? 'Welcome' : 'Connect to Gateway'}</h1>
         <p className="hint">
-          {isNew
+          {mode === 'restore'
+            ? 'Paste a device key you previously exported to restore access on this browser.'
+            : isNew
             ? 'A new device key has been generated for this browser. Tell us where the gateway is and what to call you.'
             : 'Sign in to your gateway with this device key.'}
         </p>
@@ -81,6 +99,46 @@ export function SetupScreen({ onComplete }: Props) {
           <span className="field__label">Device Key Fingerprint</span>
           <code className="device-key-value">{shortFp}</code>
         </div>
+
+        <div className="welcome-tabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'new'}
+            className={`welcome-tab${mode === 'new' ? ' welcome-tab--active' : ''}`}
+            onClick={() => { setMode('new'); setError(''); }}
+          >
+            New device
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'restore'}
+            className={`welcome-tab${mode === 'restore' ? ' welcome-tab--active' : ''}`}
+            onClick={() => { setMode('restore'); setError(''); }}
+          >
+            Restore from key
+          </button>
+        </div>
+
+        {mode === 'restore' && (
+          <label className="field">
+            <span className="field__label">Device key (JSON)</span>
+            <textarea
+              className="field__input"
+              rows={6}
+              placeholder='{"publicKey":{…},"privateKey":{…},"displayName":"…"}'
+              required
+              value={restoreKey}
+              onChange={(e) => setRestoreKey(e.target.value)}
+              style={{ fontFamily: 'monospace', fontSize: 12, resize: 'vertical' }}
+            />
+            <span className="field__help">
+              Paste the full JSON you copied from <strong>Show access tokens → Device key</strong> on
+              another browser. Display name will be restored from the file.
+            </span>
+          </label>
+        )}
 
         <label className="field">
           <span className="field__label">Gateway URL</span>
@@ -94,27 +152,40 @@ export function SetupScreen({ onComplete }: Props) {
           />
         </label>
 
-        <label className="field">
-          <span className="field__label">Display Name</span>
-          <input
-            className="field__input"
-            type="text"
-            placeholder="Your name"
-            required
-            autoFocus={isNew}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-        </label>
+        {mode === 'new' && (
+          <label className="field">
+            <span className="field__label">Display Name</span>
+            <input
+              className="field__input"
+              type="text"
+              placeholder="Your name"
+              required
+              autoFocus={isNew}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+        )}
 
         {error && <p className="form-error">{error}</p>}
 
         <button
           className="btn btn--primary btn--full"
           type="submit"
-          disabled={!name.trim() || !gatewayUrl.trim() || submitting}
+          disabled={
+            !gatewayUrl.trim() ||
+            submitting ||
+            (mode === 'new' && !name.trim()) ||
+            (mode === 'restore' && !restoreKey.trim())
+          }
         >
-          {submitting ? 'Connecting...' : 'Continue'}
+          {submitting
+            ? 'Connecting...'
+            : mode === 'restore'
+            ? 'Restore device'
+            : isNew
+            ? 'Get started'
+            : 'Continue'}
         </button>
       </form>
     </div>

--- a/apps/web/ui/src/styles.css
+++ b/apps/web/ui/src/styles.css
@@ -1325,3 +1325,31 @@ h2 { font-size: 14px; font-weight: 600; }
   .policies-row { grid-template-columns: 1fr; }
   .policies-row__actions { justify-content: flex-end; }
 }
+/* ─── Setup screen tabs ────────────────────────────────────────────────── */
+.welcome-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--panel-muted, color-mix(in srgb, var(--panel) 80%, transparent));
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  margin: 0 0 18px;
+}
+.welcome-tab {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.welcome-tab:hover { color: var(--text); }
+.welcome-tab--active {
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}


### PR DESCRIPTION
## Summary

Two related self-service UX fixes for the web client. Today, the only way to get your gateway JWT or to recover access on a new browser is to manually pull values out of devtools / localStorage. This PR exposes both as proper UI affordances.

## 1. Access-token panel on PickAgentScreen

`apps/web/ui/src/components/PickAgentScreen.tsx`, `apps/web/ui/src/api.ts`

Adds a collapsible **Show access tokens** section to the agent-picker screen with:

- **API bearer token (your JWT)** \u2014 one-click copy. For users wiring up CLI / scripts / external integrations against the gateway.
- **Device key** \u2014 reveal + copy of the full ECDSA JWK (publicKey + privateKey + displayName) as JSON. Required for the restore-from-key flow below; carries an explicit "this is sensitive, treat it like a password" warning.
- **Device fingerprint** displayed next to the key for verification.

Also clarifies the **agent-join field** below: the input previously labeled "Access Token" is actually the per-agent invite secret minted by an agent's owner, not the user's bearer token. People kept pasting their own JWT into it and bouncing. Renamed to **"Agent invite token"** with a one-line help text spelling out what it is and what it isn't.

New helpers in `api.ts`:

- `exportDeviceKey(): string | null` \u2014 serializes the local JWK + display name to a pretty-printed JSON string (or null if no key exists).
- `importDeviceKey(json: string): boolean` \u2014 validates the structure, writes it to local storage, clears the in-memory keypair / cached JWT so the next exchange uses the imported identity. Returns `false` on malformed input.

## 2. Restore-from-key flow on SetupScreen

`apps/web/ui/src/components/SetupScreen.tsx`, `apps/web/ui/src/styles.css`

Adds a small segmented-control at the top of the welcome card with two modes:

- **New device** (default) \u2014 unchanged behavior: generate a fresh ECDSA key, prompt for display name, exchange for JWT.
- **Restore from key** \u2014 paste the JSON exported via #1 above, hydrate the device key, restore display name from the file, exchange for JWT.

This closes the "signed out on a new browser, can't get back in to my agents" dead-end. No server changes \u2014 the gateway already accepts whatever device key signs the JWT exchange.

## Verification

- Token panel: copy buttons fire `navigator.clipboard.writeText`, show "Copied" confirmation for 1.8s.
- Restore flow: exporting on browser A and pasting on browser B successfully re-authenticates as the same user, with the same agent memberships visible.
- Agent invite token: relabeled field still routes to `joinAgent()` unchanged; no behavioral diff.

## Notes

- Source only \u2014 no built artifacts under `apps/web/public/assets/` are touched in this PR; they should be regenerated as part of the normal release flow.
- New CSS is scoped (`.welcome-tabs`, `.welcome-tab`, `.welcome-tab--active`); uses existing CSS variables so it adopts the project palette automatically.
- No new dependencies.