### PR TITLE
perf(mcp): connect MCP servers asynchronously

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -247,9 +247,9 @@ export class AgentRunner implements SessionRuntime {
     const mcpServers = await this.options.mcpServerStore.listEnabled(this.scope.agentId);
     if (mcpServers.length > 0) {
       this.mcpClientManager = new McpClientManager();
-      await this.mcpClientManager.connectAll(mcpServers);
+      this.mcpClientManager.connectAll(mcpServers);
     }
-    this.logRuntime(`mcp: reloaded (${mcpServers.length} server(s) enabled)`);
+    this.logRuntime(`mcp: reloading (${mcpServers.length} server(s) enabled, connecting in background)`);
   }
 
   /** Register a channel outbound adapter (called after channel startup). */
@@ -1604,7 +1604,12 @@ export class AgentRunner implements SessionRuntime {
           this.mcpClientManager = new McpClientManager();
           const mcpServers = await this.options.mcpServerStore.listEnabled(this.scope.agentId);
           if (mcpServers.length > 0) {
-            await this.mcpClientManager.connectAll(mcpServers);
+            // Fire-and-forget: connections proceed in the background. The
+            // current turn will only see tools from servers that have
+            // already finished connecting; subsequent turns pick up the
+            // rest as they become ready. The mcp_status tool surfaces
+            // pending/failed connections so the agent can explain delays.
+            this.mcpClientManager.connectAll(mcpServers);
           }
         }
         const toolHookCtx = {

--- a/apps/agent/src/mcp-client.ts
+++ b/apps/agent/src/mcp-client.ts
@@ -6,10 +6,12 @@ import type { AgentTool } from '@mariozechner/pi-agent-core';
 import type { McpServerRecord } from '@openhermit/store';
 import { asTextContent, type Toolset } from './tools/shared.js';
 
+export type McpConnectionStatusValue = 'connecting' | 'connected' | 'disconnected' | 'error';
+
 export interface McpConnectionStatus {
   serverId: string;
   serverName: string;
-  status: 'connected' | 'disconnected' | 'error';
+  status: McpConnectionStatusValue;
   toolCount: number;
   lastError?: string;
   connectedAt?: string;
@@ -24,59 +26,86 @@ interface McpToolInfo {
 interface McpConnectionState {
   serverId: string;
   serverName: string;
-  status: 'connected' | 'disconnected' | 'error';
+  status: McpConnectionStatusValue;
   client?: Client;
   transport?: StreamableHTTPClientTransport;
   tools: McpToolInfo[];
   lastError?: string;
   connectedAt?: string;
+  /** Resolves when the in-flight connect attempt for this state finishes (success or error). */
+  ready?: Promise<void>;
 }
 
 export class McpClientManager {
   private connections = new Map<string, McpConnectionState>();
 
-  async connectAll(servers: McpServerRecord[]): Promise<void> {
-    await Promise.all(servers.map((s) => this.connect(s)));
+  /**
+   * Start connecting to all servers in parallel. Returns immediately —
+   * connections continue in the background. Each server's status moves
+   * through `connecting` → `connected` | `error` and is observable via
+   * {@link getStatus}. Callers that want to await completion can use
+   * {@link connect} per-server or {@link whenAllSettled}.
+   */
+  connectAll(servers: McpServerRecord[]): void {
+    for (const s of servers) void this.connect(s);
   }
 
+  /**
+   * Connect (or reconnect) to a single server. Returns a Promise that
+   * resolves once the attempt has settled. Errors are captured into the
+   * connection state rather than thrown, so `await connect()` never
+   * rejects — the caller should inspect {@link getStatus} after.
+   */
   async connect(server: McpServerRecord): Promise<void> {
     await this.disconnect(server.id);
 
     const state: McpConnectionState = {
       serverId: server.id,
       serverName: server.name,
-      status: 'disconnected',
+      status: 'connecting',
       tools: [],
     };
     this.connections.set(server.id, state);
 
-    try {
-      const headers: Record<string, string> = {
-        ...server.headers,
-      };
-      const transport = new StreamableHTTPClientTransport(
-        new URL(server.url),
-        { requestInit: { headers } },
-      );
-      const client = new Client({ name: 'openhermit', version: '0.2.0' });
-      await client.connect(transport as Transport);
+    state.ready = (async () => {
+      try {
+        const headers: Record<string, string> = {
+          ...server.headers,
+        };
+        const transport = new StreamableHTTPClientTransport(
+          new URL(server.url),
+          { requestInit: { headers } },
+        );
+        const client = new Client({ name: 'openhermit', version: '0.2.0' });
+        await client.connect(transport as Transport);
 
-      const { tools } = await client.listTools();
+        const { tools } = await client.listTools();
 
-      state.client = client;
-      state.transport = transport;
-      state.status = 'connected';
-      state.connectedAt = new Date().toISOString();
-      state.tools = tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        inputSchema: t.inputSchema as Record<string, unknown>,
-      }));
-    } catch (err) {
-      state.status = 'error';
-      state.lastError = err instanceof Error ? err.message : String(err);
-      console.warn(`[mcp] failed to connect to ${server.id}: ${state.lastError}`);
-    }
+        if (this.connections.get(server.id) !== state) return;
+
+        state.client = client;
+        state.transport = transport;
+        state.status = 'connected';
+        state.connectedAt = new Date().toISOString();
+        state.tools = tools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema as Record<string, unknown>,
+        }));
+      } catch (err) {
+        if (this.connections.get(server.id) !== state) return;
+        state.status = 'error';
+        state.lastError = err instanceof Error ? err.message : String(err);
+        console.warn(`[mcp] failed to connect to ${server.id}: ${state.lastError}`);
+      }
+    })();
+
+    await state.ready;
+  }
+
+  /** Await all in-flight connection attempts (does not throw). Useful for tests. */
+  async whenAllSettled(): Promise<void> {
+    await Promise.all([...this.connections.values()].map((s) => s.ready ?? Promise.resolve()));
   }
 
   async disconnect(serverId: string): Promise<void> {
@@ -136,9 +165,18 @@ export class McpClientManager {
       description: mcpTool.description ?? `MCP tool from ${state.serverName}`,
       parameters: Type.Unsafe(mcpTool.inputSchema),
       execute: async (_toolCallId, params) => {
-        if (!state.client || state.status !== 'connected') {
+        if (state.status === 'connecting') {
           return {
-            content: asTextContent(`MCP server "${state.serverName}" is not connected.`),
+            content: asTextContent(
+              `MCP server "${state.serverName}" is still connecting. Try again in a moment.`,
+            ),
+            details: {},
+          };
+        }
+        if (!state.client || state.status !== 'connected') {
+          const detail = state.lastError ? ` (last error: ${state.lastError})` : '';
+          return {
+            content: asTextContent(`MCP server "${state.serverName}" is not connected${detail}.`),
             details: {},
           };
         }


### PR DESCRIPTION
## Summary

- `McpClientManager.connectAll()` is now fire-and-forget — connections proceed in the background instead of blocking the first session message on `Promise.all` over every enabled MCP server.
- New `'connecting'` status visible via `mcp_status`, so the agent can answer "the GitHub MCP server is still connecting, try again in a moment."
- Tool `execute()` returns a recoverable message when invoked against a server still connecting; failed servers now include the last error in the response.
- Mirrors the existing lazy-provisioning behavior of the sandbox: a slow or unreachable MCP server no longer stalls agent boot or the first message of a session.

This also makes single-server `connect()` (used by the `mcp_enable` tool) still awaitable so explicit user actions report a final result.

## Why now

Independent improvement, but also a prerequisite for upcoming lazy-hydration work: with on-demand runner hydration, every cold start would otherwise pay the full synchronous MCP connect cost on the first inbound message.

## Test plan

- [ ] Start gateway with one healthy and one unreachable MCP server; confirm first session message no longer blocks on the unreachable one.
- [ ] Call `mcp_status` mid-connect; confirm `connecting` status is reported.
- [ ] Invoke a tool from a server still in `connecting` state; confirm a recoverable "still connecting" message rather than a hard error.
- [ ] `mcp_enable` of a single server still awaits and returns final status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server connections now execute in the background without blocking agent operations.
  * Added "connecting" status state for servers establishing initial connections.
  * Tool requests on unavailable servers return "try again" responses with relevant connection error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->