### PR TITLE
feat: lazy-hydrate agents (Phase 1)

### DIFF
--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -78,10 +78,38 @@ export const registerAgentsCommand = (program: Command): void => {
       }
     });
 
+  // --- enable ---
+  agents
+    .command('enable <agentId>')
+    .description('Enable an agent (accept incoming requests)')
+    .action(async (agentId: string) => {
+      try {
+        const gateway = createGateway();
+        const result = await gateway.manageAgent(agentId, 'enable');
+        console.log(`Agent ${result.agentId}: ${result.status}`);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  // --- disable ---
+  agents
+    .command('disable <agentId>')
+    .description('Disable an agent (reject requests, evict from memory)')
+    .action(async (agentId: string) => {
+      try {
+        const gateway = createGateway();
+        const result = await gateway.manageAgent(agentId, 'disable');
+        console.log(`Agent ${result.agentId}: ${result.status}`);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
   // --- start ---
   agents
     .command('start <agentId>')
-    .description('Start a stopped agent')
+    .description('Hydrate the agent runner into memory (cache management; agents auto-hydrate on demand)')
     .action(async (agentId: string) => {
       try {
         const gateway = createGateway();
@@ -95,7 +123,7 @@ export const registerAgentsCommand = (program: Command): void => {
   // --- stop ---
   agents
     .command('stop <agentId>')
-    .description('Stop a running agent')
+    .description('Evict the runner from memory (cache management; agent stays enabled)')
     .action(async (agentId: string) => {
       try {
         const gateway = createGateway();
@@ -109,7 +137,7 @@ export const registerAgentsCommand = (program: Command): void => {
   // --- restart ---
   agents
     .command('restart <agentId>')
-    .description('Restart an agent')
+    .description('Evict and re-hydrate the runner (cache management)')
     .action(async (agentId: string) => {
       try {
         const gateway = createGateway();
@@ -123,17 +151,10 @@ export const registerAgentsCommand = (program: Command): void => {
   // --- delete ---
   agents
     .command('delete <agentId>')
-    .description('Delete an agent and all its data (must be stopped first)')
+    .description('Delete an agent and all its data (must be disabled first)')
     .action(async (agentId: string) => {
       try {
         const gateway = createGateway();
-
-        const health = await gateway.agentHealth(agentId);
-        if (health.status === 'running') {
-          console.error(`Agent ${agentId} is still running. Stop it first with: hermit agents stop ${agentId}`);
-          process.exit(1);
-        }
-
         await gateway.deleteAgent(agentId);
         console.log(`Agent deleted: ${agentId}`);
       } catch (error) {

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -24,6 +24,12 @@ interface ChannelHandle {
 
 export class AgentInstanceManager {
   private runners = new Map<string, AgentRunner>();
+  /**
+   * In-flight hydrations. Concurrent {@link getOrHydrate} calls for the
+   * same cold agent share one start() invocation rather than racing —
+   * the first caller installs a Promise here, others await it.
+   */
+  private hydrating = new Map<string, Promise<AgentRunner>>();
   private langfuseClients = new Map<string, LangfuseClientLike>();
   private channelHandles = new Map<string, ChannelHandle[]>();
   private channelStatuses = new Map<string, ChannelStatus[]>();
@@ -243,16 +249,70 @@ export class AgentInstanceManager {
     return this.runners.get(agentId);
   }
 
+  /**
+   * Resolve an AgentRunner for a cold-path request, hydrating on demand.
+   *
+   * Returns:
+   *   - the existing runner if already hydrated;
+   *   - the in-flight hydration Promise if another caller is mid-start;
+   *   - a freshly hydrated runner if `agents.status = 'active'`;
+   *   - `undefined` if the agent doesn't exist or is not active.
+   *
+   * Concurrent callers for the same cold agent share one hydration via
+   * {@link hydrating}, so we never race two `start()` calls.
+   *
+   * Callers that only want to check liveness without triggering work
+   * should keep using {@link getRunner}.
+   */
+  async getOrHydrate(agentId: string): Promise<AgentRunner | undefined> {
+    const existing = this.runners.get(agentId);
+    if (existing) return existing;
+
+    const inFlight = this.hydrating.get(agentId);
+    if (inFlight) return inFlight;
+
+    if (!this.agentStore) {
+      throw new Error(
+        'AgentInstanceManager.getOrHydrate requires agentStore (call setAgentStore at startup).',
+      );
+    }
+    const record = await this.agentStore.get(agentId);
+    if (!record) return undefined;
+    if (record.status !== 'active') return undefined;
+
+    // Re-check after the await — another caller may have hydrated meanwhile.
+    const reCheck = this.runners.get(agentId);
+    if (reCheck) return reCheck;
+    const reInFlight = this.hydrating.get(agentId);
+    if (reInFlight) return reInFlight;
+
+    const promise = this.start(agentId, record.workspaceDir);
+    this.hydrating.set(agentId, promise);
+    try {
+      return await promise;
+    } finally {
+      this.hydrating.delete(agentId);
+    }
+  }
+
   getChannelStatuses(agentId: string): ChannelStatus[] {
     return this.channelStatuses.get(agentId) ?? [];
   }
 
   /**
    * Dispatch an incoming webhook request to the named channel adapter
-   * for `agentId`. Returns 404 if the agent isn't running, the channel
-   * isn't enabled, or the adapter doesn't accept webhooks.
+   * for `agentId`. Hydrates the agent on demand if the request is for
+   * an `active` agent that isn't currently running. Returns 404 if the
+   * agent doesn't exist / is disabled / the channel isn't enabled / the
+   * adapter doesn't accept webhooks.
    */
   async dispatchWebhook(agentId: string, channelName: string, req: WebhookRequest): Promise<WebhookResponse> {
+    if (!this.runners.has(agentId)) {
+      const runner = await this.getOrHydrate(agentId);
+      if (!runner) {
+        return { status: 404, body: 'agent not available' };
+      }
+    }
     const handles = this.channelHandles.get(agentId) ?? [];
     const handle = handles.find((h) => h.name === channelName);
     if (!handle || !handle.handleWebhook) {

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -727,6 +727,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       agentId: body.agentId,
       ...(body.name ? { name: body.name } : {}),
       workspaceDir: body.workspaceDir ?? `${homeDir}/workspaces/${body.agentId}`,
+      status: 'active',
       createdAt: now,
       updatedAt: now,
     });

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -906,6 +906,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
 
     switch (action) {
       case 'start': {
+        if (record.status !== 'active') {
+          throw new ValidationError(`Agent ${agentId} is disabled. Run \`hermit agents enable ${agentId}\` first.`);
+        }
         if (instances.getRunner(agentId)) {
           throw new ValidationError(`Agent ${agentId} is already running.`);
         }
@@ -919,6 +922,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       }
 
       case 'restart': {
+        if (record.status !== 'active') {
+          throw new ValidationError(`Agent ${agentId} is disabled. Run \`hermit agents enable ${agentId}\` first.`);
+        }
         await instances.stop(agentId);
         await instances.start(agentId, record.workspaceDir);
         return c.json({ agentId, status: 'running' });

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -188,7 +188,7 @@ const enforceSessionNamespace = (auth: AuthContext, sessionId: string): void => 
  */
 const requireSessionAccessHttp = async (
   auth: AuthContext,
-  runtime: ReturnType<typeof resolveRunner>,
+  runtime: AgentRunner,
   sessionId: string,
 ): Promise<string | undefined> => {
   if (auth.mode === 'admin') return undefined;
@@ -232,13 +232,19 @@ export interface GatewayAppOptions {
 
 // ─── Resolve runner helper ────────────────────────────────────────────────────
 
-const resolveRunner = (
+/**
+ * Resolve a runner for a request handler. Lazily hydrates the agent if
+ * `agents.status = 'active'` and no runner is in memory; rejects with
+ * 404 if the agent doesn't exist or is disabled. Concurrent callers for
+ * the same cold agent share one hydration via the manager's single-flight.
+ */
+const resolveRunner = async (
   instances: AgentInstanceManager,
   agentId: string,
-): AgentRunner => {
-  const runner = instances.getRunner(agentId);
+): Promise<AgentRunner> => {
+  const runner = await instances.getOrHydrate(agentId);
   if (!runner) {
-    throw new NotFoundError(`Agent ${agentId} is not running.`);
+    throw new NotFoundError(`Agent ${agentId} is not available.`);
   }
   return runner;
 };
@@ -927,9 +933,36 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         return c.json({ agentId, status: 'deleted' });
       }
 
+      case 'enable': {
+        const updated = await agentStore.setStatus(agentId, 'active');
+        log(`agent enabled: ${agentId}`);
+        return c.json({ agentId, status: updated?.status ?? 'active' });
+      }
+
+      case 'disable': {
+        await agentStore.setStatus(agentId, 'disabled');
+        // Actively evict the runner so the change takes effect immediately.
+        // No multi-gateway propagation here yet — single-gateway deployment
+        // assumed for v1; LISTEN/NOTIFY can be wired later.
+        if (instances.getRunner(agentId)) {
+          await instances.stop(agentId);
+        }
+        log(`agent disabled: ${agentId}`);
+        return c.json({ agentId, status: 'disabled' });
+      }
+
+      case 'archive': {
+        await agentStore.setStatus(agentId, 'archived');
+        if (instances.getRunner(agentId)) {
+          await instances.stop(agentId);
+        }
+        log(`agent archived: ${agentId}`);
+        return c.json({ agentId, status: 'archived' });
+      }
+
       default:
         throw new ValidationError(
-          `Unknown lifecycle action: ${action}. Valid actions: start, stop, restart, delete`,
+          `Unknown lifecycle action: ${action}. Valid actions: start, stop, restart, delete, enable, disable, archive`,
         );
     }
   });
@@ -939,7 +972,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
   app.post(gatewayRoutes.agentSessionsPattern, async (c) => {
     const agentId = c.req.param('agentId') ?? '';
     const auth = requireAuth(c, agentId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     const payload = await c.req.json().catch(() => null);
 
     if (!isSessionSpec(payload)) {
@@ -962,7 +995,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
   app.get(gatewayRoutes.agentSessionsPattern, async (c) => {
     const agentId = c.req.param('agentId') ?? '';
     const auth = requireAuth(c, agentId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     const query = parseSessionListQuery(c.req.raw);
     return c.json(await listSessionsForCaller(runtime, auth, query));
   });
@@ -974,7 +1007,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const auth = requireAuth(c, agentId);
     enforceSessionNamespace(auth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
 
     // Verify caller is a participant (user mode only; channels handle identity per-message)
     if (auth.mode === 'user') {
@@ -1160,7 +1193,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const auth = requireAuth(c, agentId);
     enforceSessionNamespace(auth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
 
     if (auth.mode === 'admin') {
       return c.json(await runtime.listSessionMessages(sessionId));
@@ -1179,7 +1212,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const approveAuth = requireAuth(c, agentId);
     enforceSessionNamespace(approveAuth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     await requireSessionAccessHttp(approveAuth, runtime, sessionId);
     const payload = await c.req.json().catch(() => null);
 
@@ -1203,7 +1236,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const cpAuth = requireAuth(c, agentId);
     enforceSessionNamespace(cpAuth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     await requireSessionAccessHttp(cpAuth, runtime, sessionId);
     const payload = await c.req.json().catch(() => ({}));
 
@@ -1226,7 +1259,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const auth = requireAuth(c, agentId);
     enforceSessionNamespace(auth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     const callerUserId = await runtime.resolveCallerUserId({ channel: auth.channel, channelUserId: auth.channelUserId });
     await runtime.deleteSession(sessionId, callerUserId ?? undefined);
     return c.json({ deleted: true });
@@ -1239,7 +1272,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const sessionId = c.req.param('sessionId') ?? '';
     const auth = requireAuth(c, agentId);
     enforceSessionNamespace(auth, sessionId);
-    const runtime = resolveRunner(instances, agentId);
+    const runtime = await resolveRunner(instances, agentId);
     // Verify caller is a participant (user mode only; channels use namespace enforcement above).
     if (auth.mode === 'user') {
       await requireSessionAccessHttp(auth, runtime, sessionId);

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -925,8 +925,11 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       }
 
       case 'delete': {
+        if (record.status !== 'disabled') {
+          throw new ValidationError(`Agent ${agentId} must be disabled before deletion. Run \`hermit agents disable ${agentId}\` first.`);
+        }
         if (instances.getRunner(agentId)) {
-          throw new ValidationError(`Agent ${agentId} is still running. Stop it first.`);
+          await instances.stop(agentId);
         }
         await agentStore.delete(agentId);
         log(`agent deleted: ${agentId}`);
@@ -951,18 +954,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         return c.json({ agentId, status: 'disabled' });
       }
 
-      case 'archive': {
-        await agentStore.setStatus(agentId, 'archived');
-        if (instances.getRunner(agentId)) {
-          await instances.stop(agentId);
-        }
-        log(`agent archived: ${agentId}`);
-        return c.json({ agentId, status: 'archived' });
-      }
-
       default:
         throw new ValidationError(
-          `Unknown lifecycle action: ${action}. Valid actions: start, stop, restart, delete, enable, disable, archive`,
+          `Unknown lifecycle action: ${action}. Valid actions: start, stop, restart, delete, enable, disable`,
         );
     }
   });

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -330,22 +330,9 @@ export const attachGatewayWs = (
     }
 
     const agentId = decodeURIComponent(match[1]!);
-    let runner;
-    try {
-      runner = await instances.getOrHydrate(agentId);
-    } catch (err) {
-      socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n');
-      socket.destroy();
-      return;
-    }
 
-    if (!runner) {
-      socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
-      socket.destroy();
-      return;
-    }
-
-    // Resolve auth from the upgrade request (headers + query param).
+    // Resolve auth BEFORE hydration so unauthenticated upgrades cannot
+    // trigger expensive cold-starts.
     let auth: AuthContext | undefined;
     if (options.auth) {
       const headers = new Headers();
@@ -358,9 +345,23 @@ export const attachGatewayWs = (
       if (resolved) auth = resolved;
     }
 
-    // Reject unauthenticated WS connections
     if (!auth) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    let runner;
+    try {
+      runner = await instances.getOrHydrate(agentId);
+    } catch (err) {
+      socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    if (!runner) {
+      socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
       socket.destroy();
       return;
     }

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -330,7 +330,14 @@ export const attachGatewayWs = (
     }
 
     const agentId = decodeURIComponent(match[1]!);
-    const runner = instances.getRunner(agentId);
+    let runner;
+    try {
+      runner = await instances.getOrHydrate(agentId);
+    } catch (err) {
+      socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n');
+      socket.destroy();
+      return;
+    }
 
     if (!runner) {
       socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -61,7 +61,7 @@ runners.get(agentId)?
 
 ```sql
 ALTER TABLE agents ADD COLUMN status text NOT NULL DEFAULT 'active';
--- 'active' | 'disabled' | 'archived'
+-- 'active' | 'disabled'
 ```
 
 - Single source of truth; survives gateway restart with no recovery state.

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -1,0 +1,217 @@
+# Lazy Hydration & Multi-Tenant Scaling Design
+
+**Status:** Draft — not yet implemented
+**Goal:** Support 1000–2000 agents per gateway instance on a 64 GB Railway container
+
+---
+
+## Background
+
+Today the gateway eagerly hydrates every agent at boot:
+
+- `apps/gateway/src/index.ts:375-420` — on startup (when `autoStartAgents=true`), iterates every row in `agents` and calls `instances.start()`.
+- `AgentInstanceManager.runners: Map<agentId, AgentRunner>` is populated forever; there is no idle eviction, no LRU, no TTL.
+- Per-agent in-process resources held by the runner: scheduler timers, MCP client connections, channel adapters (Slack Socket Mode WebSocket, Discord WebSocket, Telegram polling loop), session event broker, workspace/container manager.
+
+Per-agent baseline ≈ 6–15 MB. With 1000–2000 agents this is 10–20 GB of always-hot memory plus full event-loop pressure even when most agents are idle.
+
+## Target Architecture
+
+```
+┌─ Gateway (long-lived) ──────────────────────────────────┐
+│                                                         │
+│  • agents.status read-through (DB is source of truth)   │
+│  • Runner LRU cache + idle eviction                     │
+│  • Single-flight hydration (Map<agentId, Promise<R>>)   │
+│  • Central cron scheduler (scans schedules.next_run_at) │
+│  • Channel connection pool                              │
+│      - Telegram: webhook routing + polling loop pool    │
+│      - Slack:    Socket Mode connection pool            │
+│      - Discord:  Gateway WebSocket connection pool      │
+│  • Inbound router → hydrate-on-demand                   │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+              ↓ hydrate when needed
+        AgentRunner (short-lived, LRU)
+        • Session + Claude streaming
+        • MCP clients (loaded async; observable status)
+        • Tool execution
+        • Workspace / container
+```
+
+### Core principle
+
+`agents.status` (DB column, source of truth) determines whether the gateway accepts requests for an agent. The in-memory `runners` Map is purely a hydration cache — its presence is an optimization, never a policy decision.
+
+```
+request arrives
+  ↓
+runners.get(agentId)?
+  ├─ present → handle directly
+  └─ absent  → SELECT status, config_json, security_json, workspace_dir
+                FROM agents WHERE agent_id = ?
+                ├─ active   → hydrate runner, handle
+                ├─ disabled → 403
+                └─ missing  → 404
+```
+
+## Design Decisions
+
+### 1. `agents.status` column (replaces in-memory start/stop)
+
+```sql
+ALTER TABLE agents ADD COLUMN status text NOT NULL DEFAULT 'active';
+-- 'active' | 'disabled' | 'archived'
+```
+
+- Single source of truth; survives gateway restart with no recovery state.
+- `PATCH /api/agents/:id { status: 'disabled' }` updates DB, then in-process actively evicts the runner if hot.
+- Multi-gateway later: pub/sub via Postgres `LISTEN/NOTIFY` to broadcast disable events. Out of scope for v1.
+- Migration must be registered in `packages/store/drizzle/meta/_journal.json` (drizzle silently skips unregistered migrations).
+
+### 2. Lazy hydration with single-flight
+
+- `runners` map stores `Promise<Runner>` (not `Runner`) so concurrent requests for a cold agent share one hydration.
+- Idle TTL (default 30 min). A periodic ticker evicts runners whose `lastActivityAt` is older than the TTL **and** which have no active sessions / WS subscribers / in-flight work.
+- Hydration cost budget: DB read + AgentRunner construction + (deferred) MCP. The sandbox/container is already lazy-provisioned on first `exec` or file I/O, so it does not contribute to hydration latency. With async MCP loading, cold start is sub-second; the first tool call that touches the sandbox pays the existing provision cost (unchanged from today).
+
+### 3. Central cron scheduler
+
+The `schedules` and `schedule_runs` tables already exist (`packages/store/src/schema.ts:287-325`) with all needed fields: `cron_expression`, `next_run_at`, `last_run_at`, `status`, `consecutive_errors`, `run_count`. Index `idx_schedules_next_run` on `(agent_id, next_run_at)` already supports the central scan.
+
+What changes:
+- Remove the per-runner `Scheduler` instance from `apps/agent/src/agent-runner.ts:216`.
+- Add a single gateway-level `CentralScheduler` that scans `schedules WHERE status='active' AND next_run_at <= now()` every N seconds.
+- On hit: hydrate the agent → fire one schedule run → update `last_run_at` / `next_run_at` / `consecutive_errors` → optionally evict if no other activity.
+
+Side benefits:
+- Catchup semantics on gateway restart become explicit (rows with overdue `next_run_at` are visible in the DB; current `setInterval` model loses these silently).
+- Central observability: schedule runs, failures, retries all flow through one code path.
+
+### 4. MCP async loading
+
+- Runner becomes responsive without waiting for MCP servers to connect.
+- Tool list is dynamic: connected MCP tools are merged in as connections come up.
+- Agent has visible MCP connection state (e.g. agent can answer "the GitHub MCP server is still connecting, try again in a moment").
+- On rehydration after eviction, reconnect cost is paid once on first tool call (acceptable).
+
+This is independently valuable beyond lazy hydration: it also fixes "one bad MCP server kills the entire agent boot" today.
+
+### 5. Channel connection pooling
+
+All three channel adapters currently hold per-agent in-process state and (for Slack/Discord/Telegram-polling) a per-agent persistent connection. This blocks lazy eviction. Channel adapters get refactored so the **connection holder lives in the gateway**, independent of any runner.
+
+#### 5.1 Telegram
+
+Keep both webhook and polling modes.
+
+- **Webhook**: already gateway-routed via `/api/agents/:agentId/channels/telegram/webhook` (`apps/gateway/src/app.ts:2031-2048`). No changes.
+- **Polling**: move the `getUpdates` loop out of the runner into a gateway-level pool: `Map<botToken, PollLoop>`. Loop runs regardless of runner state; on each batch, route updates → hydrate agent → dispatch.
+
+Webhook is preferred for memory efficiency; polling stays available for deployments without a public URL.
+
+#### 5.2 Slack
+
+Keep Socket Mode for now. Move the `SocketModeClient` from per-runner to gateway-level pool: `Map<appToken, SocketModeClient>`. Inbound events route via `(team_id, channel_id) → agent_id` lookup → hydrate → dispatch.
+
+If per-tenant bots scale poorly (one socket per agent), a future migration to Slack Events API (HTTP webhook) can be considered. Out of scope for v1.
+
+#### 5.3 Discord
+
+Discord has no inbound webhook mechanism — Gateway WebSocket is mandatory. Same pattern: gateway-level pool `Map<botToken, DiscordClient>`, inbound `MessageCreate` → routing table → hydrate.
+
+**Open question:** Is a Discord bot per-agent, or do multiple agents share one bot? This determines whether Discord is the scaling ceiling.
+
+#### 5.4 Channel state externalization
+
+Per-agent in-memory state currently held by adapters must move to Postgres so it survives runner eviction:
+
+- `chatSessions` (Telegram), `channelSessions` (Slack/Discord) — in-flight conversation state
+- `lastEventIds` — SSE dedup cursors
+- `pendingApprovals`, `pendingAsyncApprovals` — approval flow state
+- `chatLocks`, `turnQueues` — serialization primitives (these become DB-backed advisory locks or rely on agent-level single-flight)
+
+This is the largest hidden cost of Phase 4 — bigger than the connection pooling itself.
+
+### 6. Remove `autoStartAgents`
+
+Once lazy hydration, central cron, and channel pooling are in place, `autoStartAgents` has no purpose. **Drop it entirely** in the same branch (Option A — no transitional flag, no deprecation period). Since all phases ship together, there is no window where socket-mode channels need a runner kept alive.
+
+## Memory Projection (64 GB container, post-refactor)
+
+Assumptions: idle TTL 30 min, ~5 % of agents active in a 30 min window, average hot runner ~30 MB (with sessions + MCP).
+
+| Total registered agents | Hot runners | Memory |
+|------|------|------|
+| 1000 | ~50  | ~1.5 GB |
+| 2000 | ~100 | ~3 GB |
+| 5000 | ~250 | ~7.5 GB |
+
+64 GB easily supports 5000–10000 registered agents under this profile, plus headroom for connection pools, Node heap, and traffic bursts.
+
+## Implementation Plan
+
+### Prerequisite (separate PR, lands on `main` first)
+
+**MCP async loading.** Independently valuable — fixes today's "one bad MCP server stalls agent boot" and slow gateway startup, in the same spirit as the existing lazy sandbox provisioning. Not coupled to the lazy-hydration refactor and shipped as its own PR.
+
+1. Runner construction returns immediately without awaiting MCP `connect()`.
+2. Each MCP client connects in the background; tool list is recomputed as connections complete.
+3. Agent observes connection state (`pending` / `connected` / `failed`); system prompt / tool surface reflects what is currently available.
+4. Tool calls against a not-yet-connected server return a clear, recoverable error ("MCP server X still connecting").
+
+This PR lands first because it is the prerequisite for sub-second hydration latency in the lazy branch — without it, every cold hydration would block on synchronous MCP `connect()`, exposing users to slow first messages.
+
+### Lazy-hydration branch
+
+One long-lived feature branch `feat/lazy-hydration` off `main` (after the MCP async PR is merged). All phases below land together; no partial merges.
+
+### Phase 1 — `agents.status` + lazy hydration (HTTP / WS / webhook)
+
+1. Migration: add `agents.status` column (register in `_journal.json`).
+2. Schema: update `packages/store/src/schema.ts`.
+3. Store: add `getStatus` / `setStatus` to `agentStore` (or surface via existing `get`).
+4. `AgentInstanceManager.getOrHydrate(agentId)` — if absent, look up DB; if `active`, start; cache `Promise<Runner>` for single-flight.
+5. Replace `resolveRunner` call sites in HTTP / WS / webhook handlers with `getOrHydrate`.
+6. `PATCH /api/agents/:id { status }` endpoint; on transition to `disabled`, actively `instances.stop(agentId)` in-process.
+
+### Phase 2 — Central cron scheduler
+
+1. Add `CentralScheduler` in gateway; scan `schedules` every 5–10 s.
+2. On hit: `getOrHydrate(agentId)` → invoke fire → update row.
+3. Remove per-runner `Scheduler` from `agent-runner.ts`.
+4. Verify catchup behavior across gateway restart.
+
+### Phase 3 — LRU eviction
+
+1. Track `lastActivityAt` on each runner.
+2. Eviction ticker: every minute, evict runners idle > TTL with no active sessions / WS subscribers / pending tool calls.
+3. Active-aware: never evict a runner that holds a streaming session or open WS subscription.
+
+### Phase 4 — Channel connection pooling
+
+1. Telegram polling loop moves to gateway-level pool.
+2. Slack Socket Mode client moves to gateway-level pool.
+3. Discord client moves to gateway-level pool.
+4. Channel routing table `(channel_kind, connection_id, conversation_id) → agent_id`.
+5. Externalize per-agent channel state (`chatSessions`, `lastEventIds`, approvals) to Postgres.
+
+### Phase 5 — Cleanup
+
+1. Delete `autoStartAgents` config and the boot-time iteration in `index.ts`.
+2. Update `docs/architecture.md`, `docs/channel-adapter.md`, `docs/storage-model.md`.
+3. End-to-end test: 100+ agents hydrating concurrently, evicting, re-hydrating; cron fires across restart; channel pools survive runner churn.
+
+## Open Questions
+
+1. **Discord bot deployment model** — per-agent independent bot, or multiple agents sharing one bot? Determines Discord scaling ceiling.
+2. **Channel state backend** — Postgres (assumed default) vs Redis. Postgres preferred unless contention shows up in load testing.
+3. **Branch strategy** — long feature branch will drift from `main`. Either freeze `main` to critical fixes only during the refactor, or rebase periodically. Need to pick one.
+4. **Disable propagation across multiple gateways** — out of scope for v1 (single-gateway deployment); revisit when multi-gateway lands.
+
+## Risks
+
+- **Cold-start latency** on hydration is dominated by AgentRunner construction and DB reads (sandbox provisioning is already lazy and unchanged). MCP async loading keeps this sub-second. Per-agent "warm" pinning can be added later if specific latency-sensitive agents need it.
+- **Channel state migration** is invasive — existing in-flight approvals and dedup cursors must be migrated, not just truncated.
+- **Long-lived feature branch** risks merge conflicts. Mitigation: rebase weekly, keep phases independently testable.
+- **Cron drift across restart** — central scheduler must implement a clear catchup policy (run-once-on-recovery vs skip-overdue) and document it.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -317,7 +317,7 @@ export class GatewayClient {
 
   async manageAgent(
     agentId: string,
-    action: 'start' | 'stop' | 'restart',
+    action: 'start' | 'stop' | 'restart' | 'enable' | 'disable',
   ): Promise<AgentInfo> {
     return this.postJson(gatewayRoutes.agentManage(agentId, action), {});
   }

--- a/packages/store/drizzle/0016_agents_status.sql
+++ b/packages/store/drizzle/0016_agents_status.sql
@@ -1,0 +1,12 @@
+-- Per-agent status flag. The gateway treats this column as the source
+-- of truth for whether an agent accepts incoming requests; the
+-- in-memory runner Map is only a hydration cache.
+--
+-- Values:
+--   'active'   — accept requests; hydrate runner on demand
+--   'disabled' — reject requests; existing runner (if any) is stopped
+--   'archived' — soft-deleted; not exposed in lists / not reachable
+ALTER TABLE "agents"
+  ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';
+
+CREATE INDEX IF NOT EXISTS "idx_agents_status" ON "agents" ("status");

--- a/packages/store/drizzle/0016_agents_status.sql
+++ b/packages/store/drizzle/0016_agents_status.sql
@@ -5,7 +5,6 @@
 -- Values:
 --   'active'   — accept requests; hydrate runner on demand
 --   'disabled' — reject requests; existing runner (if any) is stopped
---   'archived' — soft-deleted; not exposed in lists / not reachable
 ALTER TABLE "agents"
   ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';
 

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778300000000,
       "tag": "0015_sessions_user_ids_gin",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778400000000,
+      "tag": "0016_agents_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/agent-store.ts
+++ b/packages/store/src/impl/agent-store.ts
@@ -3,7 +3,7 @@ import { and, eq, gt, inArray, sql } from 'drizzle-orm';
 import pg from 'pg';
 
 import type { AgentStore } from '../interfaces.js';
-import type { AgentRecord } from '../types.js';
+import type { AgentRecord, AgentStatus } from '../types.js';
 import * as schema from '../schema.js';
 import {
   agents,
@@ -50,6 +50,7 @@ export class DbAgentStore implements AgentStore {
       agentId: agent.agentId,
       name: agent.name ?? null,
       workspaceDir: agent.workspaceDir,
+      status: agent.status,
       createdAt: agent.createdAt,
       updatedAt: agent.updatedAt,
     }).returning();
@@ -75,6 +76,14 @@ export class DbAgentStore implements AgentStore {
     if (patch.workspaceDir !== undefined) data.workspaceDir = patch.workspaceDir;
 
     const rows = await this.db.update(agents).set(data).where(eq(agents.agentId, agentId)).returning();
+    return rows[0] ? this.toRecord(rows[0]) : undefined;
+  }
+
+  async setStatus(agentId: string, status: AgentStatus): Promise<AgentRecord | undefined> {
+    const rows = await this.db.update(agents)
+      .set({ status, updatedAt: new Date().toISOString() })
+      .where(eq(agents.agentId, agentId))
+      .returning();
     return rows[0] ? this.toRecord(rows[0]) : undefined;
   }
 
@@ -280,6 +289,7 @@ export class DbAgentStore implements AgentStore {
       agentId: row.agentId,
       ...(row.name ? { name: row.name } : {}),
       workspaceDir: row.workspaceDir,
+      status: row.status as AgentStatus,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -18,6 +18,7 @@ export type {
 
 export type {
   AgentRecord,
+  AgentStatus,
   AgentMcpServerRecord,
   AgentSkillRecord,
   McpServerRecord,

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -3,6 +3,7 @@ import type { SessionHistoryMessage, SessionSpec } from '@openhermit/protocol';
 import type {
   AgentMcpServerRecord,
   AgentRecord,
+  AgentStatus,
   AgentSkillRecord,
   ApprovalRequestCreateInput,
   ApprovalRequestRecord,
@@ -164,6 +165,12 @@ export interface AgentStore {
   get(agentId: string): Promise<AgentRecord | undefined>;
   list(): Promise<AgentRecord[]>;
   update(agentId: string, patch: Partial<Pick<AgentRecord, 'name' | 'workspaceDir'>>): Promise<AgentRecord | undefined>;
+  /**
+   * Update the agent's status. Returns the updated record, or undefined
+   * if the agent doesn't exist. The gateway uses this to disable/archive
+   * an agent without deleting it.
+   */
+  setStatus(agentId: string, status: AgentStatus): Promise<AgentRecord | undefined>;
   delete(agentId: string): Promise<void>;
   getBackendState(agentId: string): Promise<Record<string, unknown> | null>;
   setBackendState(agentId: string, state: Record<string, unknown>): Promise<void>;

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -166,9 +166,9 @@ export interface AgentStore {
   list(): Promise<AgentRecord[]>;
   update(agentId: string, patch: Partial<Pick<AgentRecord, 'name' | 'workspaceDir'>>): Promise<AgentRecord | undefined>;
   /**
-   * Update the agent's status. Returns the updated record, or undefined
-   * if the agent doesn't exist. The gateway uses this to disable/archive
-   * an agent without deleting it.
+   * Update the agent's status to 'active' or 'disabled'. Returns the
+   * updated record, or undefined if the agent doesn't exist. The gateway
+   * uses this to disable an agent without deleting it.
    */
   setStatus(agentId: string, status: AgentStatus): Promise<AgentRecord | undefined>;
   delete(agentId: string): Promise<void>;

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -26,7 +26,7 @@ export const agents = pgTable('agents', {
   /**
    * Source of truth for whether this agent accepts requests. The gateway's
    * in-memory runner Map is just a hydration cache; this column decides
-   * policy. Values: 'active' | 'disabled' | 'archived'.
+   * policy. Values: 'active' | 'disabled'.
    */
   status: text('status').default('active').notNull(),
   createdAt: text('created_at').notNull(),

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -23,6 +23,12 @@ export const agents = pgTable('agents', {
   /** Canonical agent security policy (JSON-stringified). Replaces security.json. */
   securityJson: text('security_json'),
   backendState: jsonb('backend_state').$type<Record<string, unknown>>(),
+  /**
+   * Source of truth for whether this agent accepts requests. The gateway's
+   * in-memory runner Map is just a hydration cache; this column decides
+   * policy. Values: 'active' | 'disabled' | 'archived'.
+   */
+  status: text('status').default('active').notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 });

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -31,7 +31,9 @@ export const agents = pgTable('agents', {
   status: text('status').default('active').notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_agents_status').on(table.status),
+]);
 
 export const sessions = pgTable('sessions', {
   agentId: text('agent_id').notNull(),

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -11,10 +11,14 @@ export interface StoreScope {
   agentId: string;
 }
 
+export type AgentStatus = 'active' | 'disabled' | 'archived';
+
 export interface AgentRecord {
   agentId: string;
   name?: string;
   workspaceDir: string;
+  /** Source of truth for whether the gateway accepts requests for this agent. */
+  status: AgentStatus;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -11,7 +11,7 @@ export interface StoreScope {
   agentId: string;
 }
 
-export type AgentStatus = 'active' | 'disabled' | 'archived';
+export type AgentStatus = 'active' | 'disabled';
 
 export interface AgentRecord {
   agentId: string;


### PR DESCRIPTION
## Summary

Phase 1 of the [lazy-hydration plan](docs/lazy-hydration-design.md): make the gateway scale to 1000s of agents per instance by hydrating runners on demand and using the DB as source of truth for whether an agent accepts requests.

- **`agents.status` column** (`'active' | 'disabled'`, migration `0016`) — DB is the source of truth; the in-memory runner Map is just a hydration cache.
- **Lazy hydration with single-flight** — cold-path requests (HTTP, WS, webhooks) hit `getOrHydrate(agentId)`, which boots the runner from DB on first use. Concurrent requests for the same cold agent share one in-flight `Promise<Runner>`.
- **CLI**: new `agents enable` / `agents disable` (policy verbs). `start`/`stop`/`restart` kept but redocumented as cache-management verbs — users normally don't need them since hydration is automatic.
- **`agents delete`**: now requires `status='disabled'` first (gateway-enforced guardrail), then auto-evicts any hot runner before deletion.

This is the first of 5 phases. Follow-ups (separate PRs):
2. Central cron scheduler (drop per-runner `Scheduler`).
3. LRU eviction with idle TTL.
4. Channel connection pooling (Telegram polling, Slack Socket Mode, Discord WS).
5. Cleanup — drop `autoStartAgents`, update docs.

## Test plan

- [ ] `pnpm install && pnpm build` clean
- [ ] Migration `0016_agents_status` applies on a fresh DB
- [ ] `hermit agents disable <id>` → subsequent HTTP/WS/webhook requests rejected; runner evicted if hot
- [ ] `hermit agents enable <id>` → next request hydrates the runner on demand
- [ ] Concurrent webhooks against a cold agent share one hydration (no duplicate `start()`)
- [ ] `hermit agents delete <id>` blocked when `status='active'`; works after disable
- [ ] Existing autoStart-on-boot still works (cleanup deferred to Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added enable/disable agent subcommands; SDK now supports enable/disable actions.
  * Agents lazily hydrate on demand and have status (active/disabled) to control request acceptance.

* **Behavior Changes**
  * Deleting an agent now requires it be disabled first; start/restart operations enforce active status.
  * WebSocket/connection handling now guards hydration behind authentication.

* **Documentation**
  * Added lazy-hydration design document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->