### PR TITLE
feat(gateway): LRU eviction (Phase 3)

### DIFF
--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -22,6 +22,14 @@ interface ChannelHandle {
   handleWebhook?: (req: WebhookRequest) => Promise<WebhookResponse>;
 }
 
+export interface EvictionOptions {
+  /** Idle threshold; runners untouched for this long are evictable. */
+  idleTTLMs: number;
+  /** How often to scan. */
+  tickIntervalMs: number;
+  log?: (message: string) => void;
+}
+
 export class AgentInstanceManager {
   private runners = new Map<string, AgentRunner>();
   /**
@@ -33,6 +41,14 @@ export class AgentInstanceManager {
   private langfuseClients = new Map<string, LangfuseClientLike>();
   private channelHandles = new Map<string, ChannelHandle[]>();
   private channelStatuses = new Map<string, ChannelStatus[]>();
+
+  /** Last activity timestamp per agent, used by LRU eviction. */
+  private lastActivityAt = new Map<string, number>();
+  /** Live WebSocket connection count per agent. */
+  private wsConnections = new Map<string, number>();
+  /** Per-agent busy counter — long-running ops increment to fence eviction. */
+  private busy = new Map<string, number>();
+  private evictionTimer: ReturnType<typeof setInterval> | undefined;
 
   /** Gateway base URL used for channel adapters to connect back. */
   private gatewayBaseUrl: string | undefined;
@@ -254,12 +270,53 @@ export class AgentInstanceManager {
     //    firing happens at the gateway level (see CentralScheduler).
     runner.startBackgroundTimers();
 
+    this.touch(agentId);
     return runner;
   }
 
   /** Retrieve a running AgentRunner by agent ID, if one exists. */
   getRunner(agentId: string): AgentRunner | undefined {
-    return this.runners.get(agentId);
+    const runner = this.runners.get(agentId);
+    if (runner) this.touch(agentId);
+    return runner;
+  }
+
+  /** Mark the agent as recently active so eviction skips it. */
+  touch(agentId: string): void {
+    if (this.runners.has(agentId)) {
+      this.lastActivityAt.set(agentId, Date.now());
+    }
+  }
+
+  /** Increment the live WS connection count for `agentId` (also touches). */
+  wsConnect(agentId: string): void {
+    this.wsConnections.set(agentId, (this.wsConnections.get(agentId) ?? 0) + 1);
+    this.touch(agentId);
+  }
+
+  /** Decrement the live WS connection count for `agentId`. */
+  wsDisconnect(agentId: string): void {
+    const current = this.wsConnections.get(agentId) ?? 0;
+    if (current <= 1) this.wsConnections.delete(agentId);
+    else this.wsConnections.set(agentId, current - 1);
+  }
+
+  /**
+   * Run `fn` while marking the agent busy so eviction skips it. Use for
+   * long ops (scheduled jobs, batch tool calls) that hold the runner
+   * past the idle TTL without producing per-step touch events.
+   */
+  async withBusy<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
+    this.busy.set(agentId, (this.busy.get(agentId) ?? 0) + 1);
+    this.touch(agentId);
+    try {
+      return await fn();
+    } finally {
+      const n = this.busy.get(agentId) ?? 0;
+      if (n <= 1) this.busy.delete(agentId);
+      else this.busy.set(agentId, n - 1);
+      this.touch(agentId);
+    }
   }
 
   /**
@@ -279,7 +336,10 @@ export class AgentInstanceManager {
    */
   async getOrHydrate(agentId: string): Promise<AgentRunner | undefined> {
     const existing = this.runners.get(agentId);
-    if (existing) return existing;
+    if (existing) {
+      this.touch(agentId);
+      return existing;
+    }
 
     const inFlight = this.hydrating.get(agentId);
     if (inFlight) return inFlight;
@@ -326,6 +386,7 @@ export class AgentInstanceManager {
     if (!handle || !handle.handleWebhook) {
       return { status: 404, body: 'channel not active or does not accept webhooks' };
     }
+    this.touch(agentId);
     return handle.handleWebhook(req);
   }
 
@@ -465,7 +526,71 @@ export class AgentInstanceManager {
     }
 
     this.runners.delete(agentId);
+    this.lastActivityAt.delete(agentId);
+    this.wsConnections.delete(agentId);
+    this.busy.delete(agentId);
     log(`[${agentId}] runner stopped`);
+  }
+
+  /**
+   * Start the LRU eviction ticker. Periodically scans hydrated runners
+   * and stops those idle longer than `idleTTLMs`.
+   *
+   * Skipped (kept warm):
+   *   - agents with active channel handles (telegram/slack/discord polling
+   *     loops would lose messages if torn down);
+   *   - agents with live WebSocket connections.
+   *
+   * Schedules don't keep agents warm — the central scheduler hydrates on
+   * demand at fire time, so an evicted scheduled agent re-hydrates within
+   * one tick.
+   */
+  startEviction(options: EvictionOptions): void {
+    if (this.evictionTimer) return;
+    const log = options.log ?? (() => {});
+    const tick = (): void => void this.evictionTick(options.idleTTLMs, log);
+    this.evictionTimer = setInterval(tick, options.tickIntervalMs);
+    this.evictionTimer.unref?.();
+  }
+
+  stopEviction(): void {
+    if (this.evictionTimer) {
+      clearInterval(this.evictionTimer);
+      this.evictionTimer = undefined;
+    }
+  }
+
+  private async evictionTick(
+    idleTTLMs: number,
+    log: (message: string) => void,
+  ): Promise<void> {
+    const now = Date.now();
+    const candidates: string[] = [];
+    for (const agentId of this.runners.keys()) {
+      const handles = this.channelHandles.get(agentId);
+      if (handles && handles.length > 0) continue;
+      if ((this.wsConnections.get(agentId) ?? 0) > 0) continue;
+      if ((this.busy.get(agentId) ?? 0) > 0) continue;
+      const last = this.lastActivityAt.get(agentId) ?? now;
+      if (now - last < idleTTLMs) continue;
+      candidates.push(agentId);
+    }
+    for (const agentId of candidates) {
+      // Re-check guards immediately before stopping in case a request
+      // arrived between the scan and now.
+      const handles = this.channelHandles.get(agentId);
+      if (handles && handles.length > 0) continue;
+      if ((this.wsConnections.get(agentId) ?? 0) > 0) continue;
+      if ((this.busy.get(agentId) ?? 0) > 0) continue;
+      const last = this.lastActivityAt.get(agentId) ?? now;
+      if (now - last < idleTTLMs) continue;
+      log(`[${agentId}] evicting idle runner (idle ${Math.round((now - last) / 1000)}s)`);
+      try {
+        await this.stop(agentId);
+      } catch (err) {
+        log(`[${agentId}] eviction failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
   }
 
   /** Stop every managed agent. */

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -299,8 +299,10 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
   const requireOwnerOrAdmin = async (c: any, agentId: string): Promise<AuthContext> => {
     const auth = requireAuth(c, agentId);
     if (auth.mode === 'admin') return auth;
-    const runtime = instances.getRunner(agentId);
-    if (!runtime) throw new NotFoundError(`Agent ${agentId} is not running.`);
+    // Hydrate on demand: the agent may be persistently active but
+    // currently evicted from memory. Owner role checks must still work.
+    const runtime = await instances.getOrHydrate(agentId);
+    if (!runtime) throw new NotFoundError(`Agent ${agentId} is not available.`);
     const role = await runtime.resolveCallerRole({ channel: auth.channel, channelUserId: auth.channelUserId });
     if (role !== 'owner') throw new UnauthorizedError('Owner role required.');
     return auth;
@@ -459,13 +461,17 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       // Enrich with agent display info from agentStore.
       const records = agentStore ? await agentStore.list() : [];
       const byId = new Map(records.map((r) => [r.agentId, r]));
+      // `status` reflects the agent's persistent availability, not whether
+      // it currently has an in-memory runner — with lazy hydration + LRU
+      // eviction, an evicted agent is still available to chat (re-hydrates
+      // on demand).
       const result = memberships.map((m) => {
         const rec = byId.get(m.agentId);
         return {
           agentId: m.agentId,
           role: m.role,
           ...(rec?.name ? { name: rec.name } : {}),
-          status: instances.getRunner(m.agentId) ? 'running' as const : 'stopped' as const,
+          status: rec?.status === 'active' ? 'running' as const : 'stopped' as const,
         };
       });
       return c.json(result);
@@ -695,7 +701,8 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       const records = await agentStore.list();
       const agents = records.map((record) => ({
         agentId: record.agentId,
-        status: instances.getRunner(record.agentId) ? 'running' as const : 'stopped' as const,
+        // Persistent availability — see /api/users/me/agents above.
+        status: record.status === 'active' ? 'running' as const : 'stopped' as const,
         ...(record.name ? { name: record.name } : {}),
         workspaceDir: record.workspaceDir,
       }));
@@ -1520,7 +1527,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     return c.json({
       agentId,
       name: record?.name ?? agentId,
-      status: instances.getRunner(agentId) ? 'running' : 'stopped',
+      status: record?.status === 'active' ? 'running' : 'stopped',
     });
   });
 

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1329,7 +1329,6 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       const stat = stats.get(record.agentId) ?? {
         sessions24h: 0, errors24h: 0, skillsCount: 0, mcpCount: 0,
       };
-      const runner = instances.getRunner(record.agentId);
       const channelStatuses = instances.getChannelStatuses(record.agentId);
       const channelsEnabled = channelStatuses
         .filter((s) => s.status === 'connected')
@@ -1337,7 +1336,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       return {
         agentId: record.agentId,
         ...(record.name ? { name: record.name } : {}),
-        status: runner ? 'running' as const : 'stopped' as const,
+        status: record.status === 'active' ? 'running' as const : 'stopped' as const,
         sessions24h: stat.sessions24h,
         errors24h: stat.errors24h,
         ...(stat.lastActivity ? { lastActivity: stat.lastActivity } : {}),

--- a/apps/gateway/src/central-scheduler.ts
+++ b/apps/gateway/src/central-scheduler.ts
@@ -152,7 +152,7 @@ export class CentralScheduler {
       const run = await this.store.startRun(scope, fresh.scheduleId, sessionId, fresh.prompt);
 
       try {
-        await runner.runScheduledJob(fresh, sessionId);
+        await this.instances.withBusy(schedule.agentId, () => runner.runScheduledJob(fresh, sessionId));
 
         const nextRunAt = this.computeNextOnSuccess(fresh);
         await this.store.markRun(scope, fresh.scheduleId, nextRunAt);

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -366,20 +366,20 @@ export const main = async (): Promise<void> => {
 
   // LRU eviction: scan hydrated runners every minute, stop ones that
   // have been idle past the TTL with no active channels and no live WS
-  // subscribers. OPENHERMIT_EVICTION_TTL_MS=0 disables eviction.
-  const evictionTTLMs = (() => {
-    const raw = process.env.OPENHERMIT_EVICTION_TTL_MS;
-    if (raw === undefined) return 30 * 60_000;
+  // subscribers. OPENHERMIT_EVICTION_TTL_MINUTES=0 disables eviction.
+  const evictionTTLMinutes = (() => {
+    const raw = process.env.OPENHERMIT_EVICTION_TTL_MINUTES;
+    if (raw === undefined) return 30;
     const parsed = Number.parseInt(raw, 10);
-    return Number.isFinite(parsed) ? parsed : 30 * 60_000;
+    return Number.isFinite(parsed) ? parsed : 30;
   })();
-  if (evictionTTLMs > 0) {
+  if (evictionTTLMinutes > 0) {
     instances.startEviction({
-      idleTTLMs: evictionTTLMs,
+      idleTTLMs: evictionTTLMinutes * 60_000,
       tickIntervalMs: 60_000,
       log: logStartup,
     });
-    logStartup(`LRU eviction enabled (idle TTL ${Math.round(evictionTTLMs / 1000)}s)`);
+    logStartup(`LRU eviction enabled (idle TTL ${evictionTTLMinutes}m)`);
   } else {
     logStartup('LRU eviction disabled');
   }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -364,6 +364,26 @@ export const main = async (): Promise<void> => {
     logStartup('central scheduler skipped (no schedule store)');
   }
 
+  // LRU eviction: scan hydrated runners every minute, stop ones that
+  // have been idle past the TTL with no active channels and no live WS
+  // subscribers. OPENHERMIT_EVICTION_TTL_MS=0 disables eviction.
+  const evictionTTLMs = (() => {
+    const raw = process.env.OPENHERMIT_EVICTION_TTL_MS;
+    if (raw === undefined) return 30 * 60_000;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : 30 * 60_000;
+  })();
+  if (evictionTTLMs > 0) {
+    instances.startEviction({
+      idleTTLMs: evictionTTLMs,
+      tickIntervalMs: 60_000,
+      log: logStartup,
+    });
+    logStartup(`LRU eviction enabled (idle TTL ${Math.round(evictionTTLMs / 1000)}s)`);
+  } else {
+    logStartup('LRU eviction disabled');
+  }
+
   const rawPort = process.env.GATEWAY_PORT ?? process.env.PORT;
   const port = rawPort ? Number.parseInt(rawPort, 10) : 4000;
 
@@ -448,6 +468,7 @@ export const main = async (): Promise<void> => {
     logStartup('shutting down...');
 
     await centralScheduler?.stop();
+    instances.stopEviction();
     await instances.stopAll();
     await agentStore?.close();
     await skillStore?.close();

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -368,6 +368,7 @@ export const attachGatewayWs = (
 
     wss.handleUpgrade(request, socket, head, (ws) => {
       log(`[ws] client connected for agent ${agentId} (${auth!.mode}:${auth!.channelUserId || 'channel'})`);
+      instances.wsConnect(agentId);
 
       const conn: WsConnection = {
         ws,
@@ -381,6 +382,7 @@ export const attachGatewayWs = (
       };
 
       ws.on('message', (data) => {
+        instances.touch(agentId);
         let parsed: unknown;
         try {
           parsed = JSON.parse(String(data));
@@ -403,6 +405,7 @@ export const attachGatewayWs = (
           unsub();
         }
         conn.subscriptions.clear();
+        instances.wsDisconnect(agentId);
       });
 
       ws.on('error', () => {

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -192,10 +192,10 @@ One long-lived feature branch `feat/lazy-hydration` off `main` (after the MCP as
 ### Phase 3 — LRU eviction ✅ shipped
 
 1. `AgentInstanceManager` tracks `lastActivityAt` per agent. `touch()` is called from `_doStart`, `getRunner` (read-touch), `getOrHydrate` cache hits, `dispatchWebhook`, and each WS message.
-2. Eviction ticker scans hydrated runners every 60s; agents idle past `OPENHERMIT_EVICTION_TTL_MS` (default 30 min) are stopped.
+2. Eviction ticker scans hydrated runners every 60s; agents idle past `OPENHERMIT_EVICTION_TTL_MINUTES` (default 30) are stopped.
 3. Skip-guards: agents with active channel handles (telegram/slack/discord polling), live WS connections, or non-zero `busy` counter are kept warm.
 4. Long-running ops wrap themselves in `withBusy(agentId, fn)`; central scheduler does this around `runScheduledJob` so jobs that exceed the TTL aren't evicted mid-run.
-5. `OPENHERMIT_EVICTION_TTL_MS=0` disables eviction.
+5. `OPENHERMIT_EVICTION_TTL_MINUTES=0` disables eviction.
 
 ### Phase 4 — Channel connection pooling
 

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -189,11 +189,13 @@ One long-lived feature branch `feat/lazy-hydration` off `main` (after the MCP as
    accepted for v1; in-process Cron timers can be re-added later if a
    specific schedule needs sub-second precision.
 
-### Phase 3 — LRU eviction
+### Phase 3 — LRU eviction ✅ shipped
 
-1. Track `lastActivityAt` on each runner.
-2. Eviction ticker: every minute, evict runners idle > TTL with no active sessions / WS subscribers / pending tool calls.
-3. Active-aware: never evict a runner that holds a streaming session or open WS subscription.
+1. `AgentInstanceManager` tracks `lastActivityAt` per agent. `touch()` is called from `_doStart`, `getRunner` (read-touch), `getOrHydrate` cache hits, `dispatchWebhook`, and each WS message.
+2. Eviction ticker scans hydrated runners every 60s; agents idle past `OPENHERMIT_EVICTION_TTL_MS` (default 30 min) are stopped.
+3. Skip-guards: agents with active channel handles (telegram/slack/discord polling), live WS connections, or non-zero `busy` counter are kept warm.
+4. Long-running ops wrap themselves in `withBusy(agentId, fn)`; central scheduler does this around `runScheduledJob` so jobs that exceed the TTL aren't evicted mid-run.
+5. `OPENHERMIT_EVICTION_TTL_MS=0` disables eviction.
 
 ### Phase 4 — Channel connection pooling
 


### PR DESCRIPTION
## Summary
Bound resident memory by stopping idle AgentRunners. Default TTL 30 min, configurable via \`OPENHERMIT_EVICTION_TTL_MS\` (\`0\` disables).

- \`AgentInstanceManager\` tracks \`lastActivityAt\` per agent. \`touch()\` is called from \`_doStart\`, \`getRunner\` (read-touch), \`getOrHydrate\` cache hits, \`dispatchWebhook\`, and every WS message.
- \`wsConnect\` / \`wsDisconnect\` maintain a per-agent live-connection counter; the WS handler wires connect/close into them.
- \`withBusy(agentId, fn)\` brackets long-running ops; central scheduler uses it around \`runScheduledJob\` so cron jobs that exceed the TTL aren't evicted mid-run.

Skip-guards (kept warm):
- agents with active channel handles (telegram/slack/discord polling)
- agents with live WS connections
- agents with non-zero busy counter

Schedules don't keep agents warm — central scheduler hydrates on fire, so an evicted scheduled-only agent re-hydrates within one tick.

## Test plan
- [ ] Restart on test.openhermit.ai with \`OPENHERMIT_EVICTION_TTL_MS=120000\` (2 min) for fast feedback. Confirm idle agents log \`evicting idle runner\` after 2 min.
- [ ] Confirm \`one\` (telegram polling) is NEVER evicted.
- [ ] Trigger a schedule on an evicted agent and confirm it re-hydrates and runs.
- [ ] Open WS to an agent, leave idle past TTL, confirm it stays warm.
- [ ] Default (no env): TTL 30 min, eviction enabled at boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LRU-style automatic eviction of idle agent runners with configurable TTL (default ~30m; 0 disables) and start/stop lifecycle.
  * Activity tracking (touches, WebSocket connect/disconnect, and a busy wrapper) to avoid evicting active or in-progress agents.
  * Scheduler now marks agents busy while running scheduled jobs to prevent premature eviction.

* **Bug Fixes**
  * API derives agent status from persistent records and hydrates runtimes on-demand, returning 404 if unavailable.

* **Documentation**
  * Expanded lazy-hydration design notes detailing eviction behavior and guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->