### PR TITLE
feat(channels): persist async approval callbacks via short_id

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1087,10 +1087,10 @@ export class AgentRunner implements SessionRuntime {
     };
   }
 
-  private makeNotifyOwnerApproval(): ((requestId: string, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>) | undefined {
+  private makeNotifyOwnerApproval(): ((requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>) | undefined {
     if (this.channelOutbound.size === 0) return undefined;
 
-    return async (requestId, resourceType, resourceKey, requesterId, requesterSessionId) => {
+    return async (requestId, shortId, resourceType, resourceKey, requesterId, requesterSessionId) => {
       try {
         const config = await this.options.security.readConfig();
         const notif = config.notifications;
@@ -1139,7 +1139,7 @@ export class AgentRunner implements SessionRuntime {
           sessionId: targetSession.sessionId,
           to: outbound.to,
           text,
-          actions: [{ type: 'approval_review', requestId }],
+          actions: [{ type: 'approval_review', requestId, shortId }],
         });
       } catch {
         // Best-effort — don't break the tool call if notification fails.
@@ -1741,7 +1741,7 @@ export class AgentRunner implements SessionRuntime {
                   });
                 }
                 if (notifyOwner) {
-                  notifyOwner(request.id, 'tool', resourceKey, userId, sessionId ?? 'unknown').catch(() => {});
+                  notifyOwner(request.id, request.shortId, 'tool', resourceKey, userId, sessionId ?? 'unknown').catch(() => {});
                 }
                 return {
                   content: [{

--- a/apps/agent/src/tools/shared.ts
+++ b/apps/agent/src/tools/shared.ts
@@ -67,7 +67,7 @@ export interface ToolContext {
   hookBus?: import('../events.js').AgentEventBus;
   /** When set, called after an async ApprovalRequest is created to notify
    *  the owner via their configured notification channel. */
-  notifyOwnerApproval?: (requestId: string, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>;
+  notifyOwnerApproval?: (requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>;
   /** Publish an SSE event to the session's event stream. */
   publishEvent?: (event: Record<string, unknown>) => void;
 }
@@ -185,7 +185,7 @@ export const checkApprovalOrRequest = async (
   }
 
   if (context.notifyOwnerApproval) {
-    context.notifyOwnerApproval(request.id, resourceType, resourceKey, context.currentUserId, context.sessionId ?? 'unknown').catch(() => {});
+    context.notifyOwnerApproval(request.id, request.shortId, resourceType, resourceKey, context.currentUserId, context.sessionId ?? 'unknown').catch(() => {});
   }
 
   throw new ApprovalRequiredError(request.id, resourceType, resourceKey);

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -38,8 +38,6 @@ export class TelegramBridge implements ChannelOutbound {
   private botInfo: TelegramUser | undefined;
   /** Maps short callback IDs to (sessionId, toolCallId) for real-time approval buttons. */
   private readonly pendingApprovals = new Map<string, { sessionId: string; toolCallId: string }>();
-  /** Maps short callback IDs to (requestId, decision) for async approval buttons. */
-  private readonly pendingAsyncApprovals = new Map<string, { requestId: string; decision: 'approved' | 'rejected' }>();
   private approvalSeq = 0;
   /** Per-chat message queue to serialize message handling (avoids duplicate SSE watchers). */
   private readonly chatLocks = new Map<number, Promise<void>>();
@@ -139,13 +137,10 @@ export class TelegramBridge implements ChannelOutbound {
     const buttons: { text: string; callback_data: string }[] = [];
     for (const action of actions) {
       if (action.type === 'approval_review') {
-        const approveId = String(++this.approvalSeq);
-        const rejectId = String(++this.approvalSeq);
-        this.pendingAsyncApprovals.set(approveId, { requestId: action.requestId, decision: 'approved' });
-        this.pendingAsyncApprovals.set(rejectId, { requestId: action.requestId, decision: 'rejected' });
+        const sid = String(action.shortId);
         buttons.push(
-          { text: '✅ Approve', callback_data: `aa:${approveId}` },
-          { text: '❌ Reject', callback_data: `ar:${rejectId}` },
+          { text: '✅ Approve', callback_data: `aa:${sid}` },
+          { text: '❌ Reject', callback_data: `ar:${sid}` },
         );
       }
     }
@@ -549,7 +544,7 @@ export class TelegramBridge implements ChannelOutbound {
     if (prefix === 'a' || prefix === 'r') {
       await this.handleRealtimeApproval(query, id, prefix === 'a');
     } else if (prefix === 'aa' || prefix === 'ar') {
-      await this.handleAsyncApproval(query, id);
+      await this.handleAsyncApproval(query, id, prefix === 'aa');
     }
   }
 
@@ -578,23 +573,20 @@ export class TelegramBridge implements ChannelOutbound {
     this.editApprovalMessage(query, approved);
   }
 
-  private async handleAsyncApproval(query: TelegramCallbackQuery, id: string): Promise<void> {
-    const pending = this.pendingAsyncApprovals.get(id);
-    if (!pending) {
-      await this.telegram.answerCallbackQuery(query.id, { text: 'This approval has expired.', showAlert: true });
+  private async handleAsyncApproval(query: TelegramCallbackQuery, id: string, approved: boolean): Promise<void> {
+    const shortId = Number.parseInt(id, 10);
+    if (!Number.isFinite(shortId)) {
+      await this.telegram.answerCallbackQuery(query.id, { text: 'Invalid approval id.', showAlert: true });
       return;
     }
 
-    this.pendingAsyncApprovals.delete(id);
-    const approved = pending.decision === 'approved';
-
     try {
-      const reviewInput: Parameters<typeof this.client.reviewApprovalRequest>[1] = {
-        decision: pending.decision,
+      const reviewInput: Parameters<typeof this.client.reviewApprovalRequestByShortId>[1] = {
+        decision: approved ? 'approved' : 'rejected',
         resolution: 'once',
       };
       if (query.from?.id) reviewInput.channelUserId = String(query.from.id);
-      await this.client.reviewApprovalRequest(pending.requestId, reviewInput);
+      await this.client.reviewApprovalRequestByShortId(shortId, reviewInput);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.log(`async approval review failed: ${msg}`);

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2491,19 +2491,19 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     return c.json(request);
   });
 
-  app.post('/api/agents/:agentId/approvals/:id/review', async (c) => {
-    const agentId = c.req.param('agentId') ?? '';
-    await requireOwnerOrAdmin(c, agentId);
+  const resolveApprovalReview = async (
+    c: any,
+    agentId: string,
+    request: import('@openhermit/store').ApprovalRequestRecord,
+  ) => {
     const store = requireApprovalStore();
-    const id = c.req.param('id') ?? '';
     const body = await c.req.json() as Record<string, unknown>;
     const decision = body.decision as string;
     if (decision !== 'approved' && decision !== 'rejected') {
       throw new ValidationError('decision must be "approved" or "rejected"');
     }
-    const request = await store.get(id);
-    if (!request || request.agentId !== agentId) {
-      throw new NotFoundError(`Approval request not found: ${id}`);
+    if (request.agentId !== agentId) {
+      throw new NotFoundError(`Approval request not found: ${request.id}`);
     }
     if (request.status !== 'pending') {
       throw new ValidationError(`Request is already ${request.status}`);
@@ -2511,7 +2511,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const resolvedBy = (c as any).get?.('userId') ?? 'owner';
     const resolution = typeof body.resolution === 'string' ? body.resolution as 'once' | 'persistent' : undefined;
     const reason = typeof body.reason === 'string' ? body.reason : undefined;
-    const updated = await store.resolve(id, decision, resolvedBy, resolution, reason);
+    const updated = await store.resolve(request.id, decision, resolvedBy, resolution, reason);
 
     if (decision === 'approved' && resolution === 'persistent' && options.policyStore) {
       await options.policyStore.upsert({
@@ -2524,7 +2524,35 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       });
     }
 
-    return c.json(updated);
+    return updated;
+  };
+
+  app.post('/api/agents/:agentId/approvals/:id/review', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const store = requireApprovalStore();
+    const id = c.req.param('id') ?? '';
+    const request = await store.get(id);
+    if (!request || request.agentId !== agentId) {
+      throw new NotFoundError(`Approval request not found: ${id}`);
+    }
+    return c.json(await resolveApprovalReview(c, agentId, request));
+  });
+
+  app.post('/api/agents/:agentId/approvals/by-short/:shortId/review', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const store = requireApprovalStore();
+    const shortIdParam = c.req.param('shortId') ?? '';
+    const shortId = Number.parseInt(shortIdParam, 10);
+    if (!Number.isFinite(shortId)) {
+      throw new ValidationError(`Invalid short_id: ${shortIdParam}`);
+    }
+    const request = await store.getByShortId(shortId);
+    if (!request || request.agentId !== agentId) {
+      throw new NotFoundError(`Approval request not found: short_id=${shortId}`);
+    }
+    return c.json(await resolveApprovalReview(c, agentId, request));
   });
 
   // --- admin: MCP servers management ---

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -175,6 +175,7 @@ export interface ChannelOutboundResult {
 export interface ChannelMessageAction {
   type: 'approval_review';
   requestId: string;
+  shortId: number;
   label?: string;
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -122,6 +122,15 @@ export class AgentLocalClient {
     return this.postJson(`/approvals/${encodeURIComponent(requestId)}/review`, body, headers);
   }
 
+  async reviewApprovalRequestByShortId(
+    shortId: number,
+    input: { decision: 'approved' | 'rejected'; resolution?: 'once' | 'persistent'; reason?: string; channelUserId?: string },
+  ): Promise<unknown> {
+    const { channelUserId, ...body } = input;
+    const headers = channelUserId ? { 'x-channel-user-id': channelUserId } : undefined;
+    return this.postJson(`/approvals/by-short/${encodeURIComponent(String(shortId))}/review`, body, headers);
+  }
+
   async postMessageSync(
     sessionId: string,
     message: SessionMessage,

--- a/packages/store/drizzle/0017_approval_short_id.sql
+++ b/packages/store/drizzle/0017_approval_short_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "approval_requests" ADD COLUMN "short_id" BIGSERIAL;
+
+CREATE UNIQUE INDEX "idx_approval_requests_short_id" ON "approval_requests" ("short_id");

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778400000000,
       "tag": "0016_agents_status",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1778500000000,
+      "tag": "0017_approval_short_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/approval-request-store.ts
+++ b/packages/store/src/impl/approval-request-store.ts
@@ -53,8 +53,9 @@ export class DbApprovalRequestStore implements ApprovalRequestStore {
       resolvedAt: null,
       ttlMinutes: input.ttlMinutes ?? 60,
     };
-    await this.db.insert(approvalRequests).values(row);
-    return toRecord(row);
+    const [inserted] = await this.db.insert(approvalRequests).values(row).returning();
+    if (!inserted) throw new Error('approval request insert returned no row');
+    return toRecord(inserted);
   }
 
   async get(id: string): Promise<ApprovalRequestRecord | undefined> {
@@ -62,6 +63,15 @@ export class DbApprovalRequestStore implements ApprovalRequestStore {
       .select()
       .from(approvalRequests)
       .where(eq(approvalRequests.id, id))
+      .limit(1);
+    return rows[0] ? toRecord(rows[0]) : undefined;
+  }
+
+  async getByShortId(shortId: number): Promise<ApprovalRequestRecord | undefined> {
+    const rows = await this.db
+      .select()
+      .from(approvalRequests)
+      .where(eq(approvalRequests.shortId, shortId))
       .limit(1);
     return rows[0] ? toRecord(rows[0]) : undefined;
   }
@@ -155,6 +165,7 @@ function isExpired(record: ApprovalRequestRecord): boolean {
 function toRecord(row: typeof approvalRequests.$inferSelect): ApprovalRequestRecord {
   return {
     id: row.id,
+    shortId: Number(row.shortId),
     agentId: row.agentId,
     sessionId: row.sessionId,
     requesterId: row.requesterId,

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -286,6 +286,7 @@ export interface PolicyStore {
 export interface ApprovalRequestStore {
   create(input: ApprovalRequestCreateInput): Promise<ApprovalRequestRecord>;
   get(id: string): Promise<ApprovalRequestRecord | undefined>;
+  getByShortId(shortId: number): Promise<ApprovalRequestRecord | undefined>;
   list(agentId: string, status?: ApprovalStatus): Promise<ApprovalRequestRecord[]>;
   /** Find an approved request matching the given criteria (for retry flow). */
   findApproved(

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -4,8 +4,10 @@ import {
   integer,
   jsonb,
   serial,
+  bigserial,
   boolean,
   index,
+  uniqueIndex,
   primaryKey,
 } from 'drizzle-orm/pg-core';
 
@@ -180,6 +182,7 @@ export const sandboxes = pgTable('sandboxes', {
 
 export const approvalRequests = pgTable('approval_requests', {
   id: text('id').primaryKey(),
+  shortId: bigserial('short_id', { mode: 'number' }).notNull(),
   agentId: text('agent_id').notNull(),
   sessionId: text('session_id').notNull(),
   requesterId: text('requester_id').notNull(),
@@ -196,6 +199,7 @@ export const approvalRequests = pgTable('approval_requests', {
 }, (table) => [
   index('idx_approval_requests_agent').on(table.agentId, table.status),
   index('idx_approval_requests_lookup').on(table.agentId, table.requesterId, table.resourceType, table.resourceKey, table.status),
+  uniqueIndex('idx_approval_requests_short_id').on(table.shortId),
 ]);
 
 export const agentPolicies = pgTable('agent_policies', {

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -72,6 +72,7 @@ export type ApprovalResolution = 'once' | 'persistent';
 
 export interface ApprovalRequestRecord {
   id: string;
+  shortId: number;
   agentId: string;
   sessionId: string;
   requesterId: string;


### PR DESCRIPTION
## Summary
First slice of Phase 4 (channel state externalization). Telegram async-approval inline-button callback_data was keyed by an in-memory counter (`pendingAsyncApprovals` Map). Gateway restart dropped the mapping, breaking already-sent Approve/Reject buttons.

This PR replaces the in-memory mapping with a persisted \`approval_requests.short_id\` (BIGSERIAL, indexed). The mapping now survives restart.

## Changes
- **DB**: migration 0017 adds \`short_id BIGSERIAL\` + unique index to \`approval_requests\`
- **Store**: \`getByShortId\`, \`shortId\` exposed on \`ApprovalRequestRecord\`
- **Gateway**: new route \`POST /api/agents/:agentId/approvals/by-short/:shortId/review\` (refactored shared helper)
- **SDK**: \`reviewApprovalRequestByShortId\`
- **Protocol**: \`ChannelMessageAction.approval_review\` carries \`shortId\`
- **Telegram bridge**: drop \`pendingAsyncApprovals\` Map; callback_data encodes \`shortId\` directly; click handler resolves via SDK

Real-time tool approvals (a:/r: prefix) intentionally stay in-memory — they are synchronous to a tool call that dies with the runner.

## Test plan
- [x] \`npm run build\` clean
- [ ] Migration applies cleanly on test server
- [ ] Manual: trigger an approval-required tool via channel, click Approve/Reject in Telegram, confirm resolution
- [ ] Manual: send approval prompt, restart gateway, click button — should still work (this is the regression we're fixing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Approval requests now include unique short identifiers for easier reference and tracking across notifications and reviews
  * Added support for reviewing approval requests using short ID as an alternative lookup method
  * Enhanced approval workflow to consistently use short IDs in notifications and action callbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->