### PR TITLE
feat(gateway): hoist channel bridges into a connection pool

### DIFF
--- a/apps/agent/src/runtime.ts
+++ b/apps/agent/src/runtime.ts
@@ -99,15 +99,25 @@ export class SessionEventBroker {
    * Atomically subscribe and replay backlog events with id > afterEventId.
    * Eliminates the race between getBacklog() and subscribe().
    */
+  /** Current next-id, exposed so SSE clients can detect sequence resets across runner restarts. */
+  getNextEventId(): number {
+    return this.nextEventId;
+  }
+
   subscribeFrom(
     sessionId: string,
     afterEventId: number,
     subscriber: SessionSubscriber,
   ): () => void {
     const unsubscribe = this.subscribe(sessionId, subscriber);
+    // If the caller's cursor is >= the broker's next id, it came from a
+    // previous broker instance (e.g. the runner was evicted and re-
+    // hydrated). The new sequence restarts at 1 — filtering against the
+    // stale cursor would skip every event. Treat as a fresh subscription.
+    const effectiveAfter = afterEventId >= this.nextEventId ? 0 : afterEventId;
     const backlog = this.backlog.get(sessionId) ?? [];
     for (const envelope of backlog) {
-      if (envelope.id > afterEventId) {
+      if (envelope.id > effectiveAfter) {
         void subscriber(envelope);
       }
     }

--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -201,6 +201,7 @@ export class DiscordBridge implements ChannelOutbound {
     const decoder = new TextDecoder();
     let buffer = '';
     let nextLastEventId = lastEventId;
+    let sequenceResetChecked = false;
     let accumulatedText = '';
     let finalText: string | undefined;
     let error: string | undefined;
@@ -227,7 +228,21 @@ export class DiscordBridge implements ChannelOutbound {
           if (frame.id !== undefined && frame.id <= nextLastEventId) continue;
           if (frame.id !== undefined) nextLastEventId = frame.id;
 
-          if (frame.event === 'ready' || frame.event === 'ping') continue;
+          if (frame.event === 'ready') {
+            if (!sequenceResetChecked) {
+              sequenceResetChecked = true;
+              try {
+                const data = frame.data.length > 0
+                  ? (JSON.parse(frame.data) as { nextEventId?: number })
+                  : {};
+                if (typeof data.nextEventId === 'number' && data.nextEventId <= nextLastEventId) {
+                  nextLastEventId = 0;
+                }
+              } catch { /* ignore */ }
+            }
+            continue;
+          }
+          if (frame.event === 'ping') continue;
 
           const payload = frame.data.length > 0
             ? (JSON.parse(frame.data) as Record<string, unknown>)

--- a/apps/channels/slack/src/bridge.ts
+++ b/apps/channels/slack/src/bridge.ts
@@ -201,6 +201,7 @@ export class SlackBridge implements ChannelOutbound {
     const decoder = new TextDecoder();
     let buffer = '';
     let nextLastEventId = lastEventId;
+    let sequenceResetChecked = false;
     let accumulatedText = '';
     let finalText: string | undefined;
     let error: string | undefined;
@@ -223,7 +224,21 @@ export class SlackBridge implements ChannelOutbound {
           if (frame.id !== undefined && frame.id <= nextLastEventId) continue;
           if (frame.id !== undefined) nextLastEventId = frame.id;
 
-          if (frame.event === 'ready' || frame.event === 'ping') continue;
+          if (frame.event === 'ready') {
+            if (!sequenceResetChecked) {
+              sequenceResetChecked = true;
+              try {
+                const data = frame.data.length > 0
+                  ? (JSON.parse(frame.data) as { nextEventId?: number })
+                  : {};
+                if (typeof data.nextEventId === 'number' && data.nextEventId <= nextLastEventId) {
+                  nextLastEventId = 0;
+                }
+              } catch { /* ignore */ }
+            }
+            continue;
+          }
+          if (frame.event === 'ping') continue;
 
           const payload = frame.data.length > 0
             ? (JSON.parse(frame.data) as Record<string, unknown>)

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -356,6 +356,7 @@ export class TelegramBridge implements ChannelOutbound {
     const decoder = new TextDecoder();
     let buffer = '';
     let nextLastEventId = lastEventId;
+    let sequenceResetChecked = false;
     let accumulatedText = '';
     let finalText: string | undefined;
     let error: string | undefined;
@@ -388,7 +389,25 @@ export class TelegramBridge implements ChannelOutbound {
             nextLastEventId = frame.id;
           }
 
-          if (frame.event === 'ready' || frame.event === 'ping') {
+          if (frame.event === 'ready') {
+            // Detect sequence reset: a new runner restarts ids at 1, so
+            // a stored cursor from a previous runner would skip every
+            // event. Reset the cursor when the server's next id is
+            // behind ours.
+            if (!sequenceResetChecked) {
+              sequenceResetChecked = true;
+              try {
+                const data = frame.data.length > 0
+                  ? (JSON.parse(frame.data) as { nextEventId?: number })
+                  : {};
+                if (typeof data.nextEventId === 'number' && data.nextEventId <= nextLastEventId) {
+                  nextLastEventId = 0;
+                }
+              } catch { /* ignore — fall back to stored cursor */ }
+            }
+            continue;
+          }
+          if (frame.event === 'ping') {
             continue;
           }
 

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -7,20 +7,13 @@ import {
   createLangfuseShutdownHandler,
   type LangfuseClientLike,
 } from '@openhermit/agent/langfuse';
-import { startChannels, startSingleChannel, stopChannels, type ChannelStatus, type WebhookRequest, type WebhookResponse } from '@openhermit/agent/channels';
 import type { AgentConfigStore, AgentStore, ApprovalRequestStore, McpServerStore, PolicyStore, SandboxStore, SecretStore, SkillStore } from '@openhermit/store';
 
-import type { ChannelRegistry } from './auth.js';
+import type { ChannelPool } from './channel-pool.js';
 
 const log = (message: string): void => {
   console.log(`[openhermit-gateway] ${message}`);
 };
-
-interface ChannelHandle {
-  name: string;
-  stop: () => Promise<void>;
-  handleWebhook?: (req: WebhookRequest) => Promise<WebhookResponse>;
-}
 
 export interface EvictionOptions {
   /** Idle threshold; runners untouched for this long are evictable. */
@@ -39,8 +32,6 @@ export class AgentInstanceManager {
    */
   private hydrating = new Map<string, Promise<AgentRunner>>();
   private langfuseClients = new Map<string, LangfuseClientLike>();
-  private channelHandles = new Map<string, ChannelHandle[]>();
-  private channelStatuses = new Map<string, ChannelStatus[]>();
 
   /** Last activity timestamp per agent, used by LRU eviction. */
   private lastActivityAt = new Map<string, number>();
@@ -50,12 +41,14 @@ export class AgentInstanceManager {
   private busy = new Map<string, number>();
   private evictionTimer: ReturnType<typeof setInterval> | undefined;
 
-  /** Gateway base URL used for channel adapters to connect back. */
-  private gatewayBaseUrl: string | undefined;
   /** Admin token forwarded to channel adapters for gateway auth. */
   private adminToken: string | undefined;
-  /** Shared channel registry for external channel token auth. */
-  private channelRegistry: ChannelRegistry | undefined;
+  /**
+   * Channel connection pool — owns bridge lifecycle independent of
+   * runners. Optional during early boot wiring; must be set before any
+   * runner hydrates so the runner can pick up live outbounds.
+   */
+  private channelPool: ChannelPool | undefined;
   /** Shared skill store for DB-managed skills. */
   private skillStore: SkillStore | undefined;
   /** Shared MCP server store for DB-managed MCP servers. */
@@ -70,19 +63,16 @@ export class AgentInstanceManager {
   private sandboxStore: SandboxStore | undefined;
   /** DB-backed policy store (tool/resource access grants). */
   private policyStore: PolicyStore | undefined;
-  /** DB-backed channel store (builtin + external rows, encrypted tokens). */
-  private channelStore: import('@openhermit/store').DbAgentChannelStore | undefined;
-
-  setGatewayBaseUrl(url: string): void {
-    this.gatewayBaseUrl = url;
-  }
-
   setAdminToken(token: string | undefined): void {
     this.adminToken = token;
   }
 
-  setChannelRegistry(registry: ChannelRegistry): void {
-    this.channelRegistry = registry;
+  setChannelPool(pool: ChannelPool): void {
+    this.channelPool = pool;
+  }
+
+  getChannelPool(): ChannelPool | undefined {
+    return this.channelPool;
   }
 
   setSkillStore(store: SkillStore): void {
@@ -121,10 +111,6 @@ export class AgentInstanceManager {
 
   setApprovalRequestStore(store: ApprovalRequestStore): void {
     this.approvalRequestStore = store;
-  }
-
-  setChannelStore(store: import('@openhermit/store').DbAgentChannelStore): void {
-    this.channelStore = store;
   }
 
   getConfigStore(): AgentConfigStore | undefined {
@@ -216,53 +202,16 @@ export class AgentInstanceManager {
     this.runners.set(agentId, runner);
     log(`[${agentId}] runner started`);
 
-    // 6. Load channel rows (builtin + external) from DB. Each row's encrypted
-    //    token is registered in ChannelRegistry; for enabled builtin rows we
-    //    additionally boot the in-process bridge using row.config.
-    if (this.channelStore && this.gatewayBaseUrl) {
-      try {
-        const allActive = await this.channelStore.loadActive();
-        const myChannels = allActive.filter((c) => c.agentId === agentId);
-
-        if (this.channelRegistry) {
-          for (const ch of myChannels) {
-            this.channelRegistry.register({
-              channelId: ch.id,
-              apiKey: ch.token,
-              namespace: ch.namespace,
-              agentId,
-            });
-          }
-        }
-
-        const enabledBuiltins = myChannels.filter((c) => c.kind === 'builtin' && c.enabled);
-        if (enabledBuiltins.length > 0) {
-          const agentBaseUrl = `${this.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
-          const channelsConfig: Record<string, unknown> = {};
-          const agentTokens: Record<string, string> = {};
-          for (const ch of enabledBuiltins) {
-            // Resolve ${{SECRET}} placeholders before handing config to the bridge.
-            const resolved = await security.expandSecrets({ ...ch.config, enabled: true });
-            channelsConfig[ch.channelType] = resolved;
-            agentTokens[ch.channelType] = ch.token;
-          }
-
-          const { handles, statuses } = await startChannels(channelsConfig as never, {
-            agentBaseUrl,
-            agentTokens,
-            logger: (channel, msg) => log(`[${agentId}] [${channel}] ${msg}`),
-          });
-          if (statuses.length > 0) this.channelStatuses.set(agentId, statuses);
-          if (handles.length > 0) {
-            this.channelHandles.set(agentId, handles);
-            for (const handle of handles) {
-              if (handle.outbound) runner.registerChannelOutbound(handle.outbound);
-            }
-            log(`[${agentId}] started ${handles.length} channel(s): ${handles.map((h) => h.name).join(', ')}`);
-          }
-        }
-      } catch (error) {
-        log(`[${agentId}] failed to load/start channels: ${error instanceof Error ? error.message : String(error)}`);
+    // 6. Wire outbounds from the gateway-level channel pool. Bridges are
+    //    owned by the pool and persist across runner eviction; we just
+    //    register their send-callbacks on this freshly hydrated runner.
+    if (this.channelPool) {
+      const handles = this.channelPool.getOutbounds(agentId);
+      for (const handle of handles) {
+        if (handle.outbound) runner.registerChannelOutbound(handle.outbound);
+      }
+      if (handles.length > 0) {
+        log(`[${agentId}] attached ${handles.length} pool channel(s): ${handles.map((h) => h.name).join(', ')}`);
       }
     }
 
@@ -363,131 +312,6 @@ export class AgentInstanceManager {
     return this.start(agentId, record.workspaceDir);
   }
 
-  getChannelStatuses(agentId: string): ChannelStatus[] {
-    return this.channelStatuses.get(agentId) ?? [];
-  }
-
-  /**
-   * Dispatch an incoming webhook request to the named channel adapter
-   * for `agentId`. Hydrates the agent on demand if the request is for
-   * an `active` agent that isn't currently running. Returns 404 if the
-   * agent doesn't exist / is disabled / the channel isn't enabled / the
-   * adapter doesn't accept webhooks.
-   */
-  async dispatchWebhook(agentId: string, channelName: string, req: WebhookRequest): Promise<WebhookResponse> {
-    if (!this.runners.has(agentId)) {
-      const runner = await this.getOrHydrate(agentId);
-      if (!runner) {
-        return { status: 404, body: 'agent not available' };
-      }
-    }
-    const handles = this.channelHandles.get(agentId) ?? [];
-    const handle = handles.find((h) => h.name === channelName);
-    if (!handle || !handle.handleWebhook) {
-      return { status: 404, body: 'channel not active or does not accept webhooks' };
-    }
-    this.touch(agentId);
-    return handle.handleWebhook(req);
-  }
-
-  async stopSingleChannel(agentId: string, channelName: string, log: (msg: string) => void): Promise<void> {
-    const handles = this.channelHandles.get(agentId) ?? [];
-    const idx = handles.findIndex((h) => h.name === channelName);
-    if (idx !== -1) {
-      const handle = handles[idx]!;
-      try {
-        await handle.stop();
-      } catch (err) {
-        log(`[${agentId}] error stopping ${channelName}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-      handles.splice(idx, 1);
-      if (handles.length === 0) this.channelHandles.delete(agentId);
-
-      const runner = this.runners.get(agentId);
-      if (runner) {
-        runner.getChannelOutbound().delete(channelName);
-      }
-    }
-
-    if (this.channelRegistry) {
-      this.channelRegistry.unregister(`${agentId}:${channelName}:builtin`);
-    }
-
-    const statuses = this.channelStatuses.get(agentId) ?? [];
-    const sIdx = statuses.findIndex((s) => s.name === channelName);
-    if (sIdx !== -1) statuses.splice(sIdx, 1);
-
-    log(`[${agentId}] stopped channel: ${channelName}`);
-  }
-
-  /**
-   * Start a single builtin channel (used by the enable-channel API). The
-   * row in agent_channels must already be enabled and have config; we
-   * just spawn the in-process bridge and register the row's token in the
-   * live ChannelRegistry.
-   */
-  async startSingleChannel(agentId: string, channelName: string, log: (msg: string) => void): Promise<ChannelStatus> {
-    const runner = this.runners.get(agentId);
-    if (!runner || !this.gatewayBaseUrl) {
-      return { name: channelName, status: 'error', error: 'Agent not running' };
-    }
-    if (!this.channelStore) {
-      return { name: channelName, status: 'error', error: 'Channel store not configured' };
-    }
-
-    const row = await this.channelStore.findBuiltin(agentId, channelName);
-    if (!row || !row.enabled) {
-      return { name: channelName, status: 'error', error: `Builtin channel ${channelName} is not enabled` };
-    }
-
-    // Decrypt the token via loadActive (we don't expose decrypt directly).
-    const all = await this.channelStore.loadActive();
-    const loaded = all.find((c) => c.id === row.id);
-    if (!loaded) {
-      return { name: channelName, status: 'error', error: 'Failed to decrypt channel token' };
-    }
-
-    const agentBaseUrl = `${this.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
-    if (this.channelRegistry) {
-      this.channelRegistry.register({
-        channelId: row.id,
-        apiKey: loaded.token,
-        namespace: row.namespace,
-        agentId,
-      });
-    }
-
-    const resolvedRow = await runner.security.expandSecrets({ ...row.config, enabled: true });
-    const channelsConfig: Record<string, unknown> = { [channelName]: resolvedRow };
-
-    const { handle, status } = await startSingleChannel(channelName, channelsConfig as never, {
-      agentBaseUrl,
-      agentTokens: { [channelName]: loaded.token },
-      logger: (channel, msg) => log(`[${agentId}] [${channel}] ${msg}`),
-    });
-
-    if (handle) {
-      const handles = this.channelHandles.get(agentId) ?? [];
-      handles.push(handle);
-      this.channelHandles.set(agentId, handles);
-      if (handle.outbound) {
-        runner.registerChannelOutbound(handle.outbound);
-      }
-      log(`[${agentId}] started channel: ${channelName}`);
-    }
-
-    const statuses = this.channelStatuses.get(agentId) ?? [];
-    const existingIdx = statuses.findIndex((s) => s.name === channelName);
-    if (existingIdx !== -1) {
-      statuses[existingIdx] = status;
-    } else {
-      statuses.push(status);
-    }
-    this.channelStatuses.set(agentId, statuses);
-
-    return status;
-  }
-
   /** Get all running agent IDs. */
   getRunningAgentIds(): string[] {
     return [...this.runners.keys()];
@@ -498,23 +322,16 @@ export class AgentInstanceManager {
     return [...this.runners.keys()];
   }
 
-  /** Stop a single agent, flushing Langfuse and cleaning up resources. */
+  /**
+   * Stop a single agent's runner. Channel bridges are NOT torn down —
+   * they're owned by ChannelPool and persist across runner eviction so
+   * a hot agent can be evicted without dropping inbound messages.
+   */
   async stop(agentId: string): Promise<void> {
     const runner = this.runners.get(agentId);
     if (!runner) {
       return;
     }
-
-    // Unregister channel tokens.
-    this.channelRegistry?.unregisterByAgent(agentId);
-
-    // Stop channels first.
-    const handles = this.channelHandles.get(agentId);
-    if (handles) {
-      await stopChannels(handles);
-      this.channelHandles.delete(agentId);
-    }
-    this.channelStatuses.delete(agentId);
 
     await runner.shutdown();
 
@@ -537,13 +354,13 @@ export class AgentInstanceManager {
    * and stops those idle longer than `idleTTLMs`.
    *
    * Skipped (kept warm):
-   *   - agents with active channel handles (telegram/slack/discord polling
-   *     loops would lose messages if torn down);
-   *   - agents with live WebSocket connections.
+   *   - agents with live WebSocket connections;
+   *   - agents currently busy (long-running ops).
    *
-   * Schedules don't keep agents warm — the central scheduler hydrates on
-   * demand at fire time, so an evicted scheduled agent re-hydrates within
-   * one tick.
+   * Channels no longer keep agents warm — bridges are owned by
+   * ChannelPool, so an evicted runner re-hydrates on the next inbound
+   * message via the gateway HTTP route. Schedules also don't keep
+   * agents warm — the central scheduler hydrates on demand at fire time.
    */
   startEviction(options: EvictionOptions): void {
     if (this.evictionTimer) return;
@@ -567,8 +384,6 @@ export class AgentInstanceManager {
     const now = Date.now();
     const candidates: string[] = [];
     for (const agentId of this.runners.keys()) {
-      const handles = this.channelHandles.get(agentId);
-      if (handles && handles.length > 0) continue;
       if ((this.wsConnections.get(agentId) ?? 0) > 0) continue;
       if ((this.busy.get(agentId) ?? 0) > 0) continue;
       const last = this.lastActivityAt.get(agentId) ?? now;
@@ -578,8 +393,6 @@ export class AgentInstanceManager {
     for (const agentId of candidates) {
       // Re-check guards immediately before stopping in case a request
       // arrived between the scan and now.
-      const handles = this.channelHandles.get(agentId);
-      if (handles && handles.length > 0) continue;
       if ((this.wsConnections.get(agentId) ?? 0) > 0) continue;
       if ((this.busy.get(agentId) ?? 0) > 0) continue;
       const last = this.lastActivityAt.get(agentId) ?? now;

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1329,7 +1329,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       const stat = stats.get(record.agentId) ?? {
         sessions24h: 0, errors24h: 0, skillsCount: 0, mcpCount: 0,
       };
-      const channelStatuses = instances.getChannelStatuses(record.agentId);
+      const channelStatuses = instances.getChannelPool()?.getStatuses(record.agentId) ?? [];
       const channelsEnabled = channelStatuses
         .filter((s) => s.status === 'connected')
         .map((s) => s.name);
@@ -2085,7 +2085,18 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     });
     const rawBody = await c.req.text();
 
-    const result = await instances.dispatchWebhook(agentId, row.channelType, { headers, rawBody });
+    // Hydrate the runner first so the bridge's downstream HTTP callbacks
+    // hit a hot agent (rather than paying cold-start latency on every
+    // inbound message).
+    const runner = await instances.getOrHydrate(agentId);
+    if (!runner) {
+      return new Response('agent not available', { status: 404 });
+    }
+    const pool = instances.getChannelPool();
+    if (!pool) {
+      return new Response('channel pool not available', { status: 503 });
+    }
+    const result = await pool.dispatchWebhook(agentId, row.channelType, { headers, rawBody });
     return new Response(result.body ?? '', {
       status: result.status,
       headers: result.headers ?? {},
@@ -2097,7 +2108,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     await requireOwnerOrAdmin(c, agentId);
     const store = requireAgentChannelStore();
     const rows = await store.listForAgent(agentId);
-    const runtimeStatuses = instances.getChannelStatuses(agentId);
+    const runtimeStatuses = instances.getChannelPool()?.getStatuses(agentId) ?? [];
 
     // Secret presence — needed by the UI to indicate whether a channel
     // can actually start. Only available when agent is running.
@@ -2217,11 +2228,15 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
 
     // Builtin channel runtime side-effects: enable → start, disable → stop.
     if (existing.kind === 'builtin' && body.enabled !== undefined) {
+      const pool = instances.getChannelPool();
+      if (!pool) {
+        throw new Error('channel pool not available');
+      }
       if (body.enabled) {
-        const status = await instances.startSingleChannel(agentId, existing.channelType, log);
+        const status = await pool.enableChannel(agentId, existing.channelType);
         return c.json({ ...updated, runtimeStatus: status.status, error: status.error });
       } else {
-        await instances.stopSingleChannel(agentId, existing.channelType, log);
+        await pool.disableChannel(agentId, existing.channelType);
       }
     }
 
@@ -2244,7 +2259,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       throw new NotFoundError(`Channel ${channelId} not found on agent ${agentId}.`);
     }
     if (existing.kind === 'builtin' && existing.enabled) {
-      await instances.stopSingleChannel(agentId, existing.channelType, log);
+      await instances.getChannelPool()?.disableChannel(agentId, existing.channelType);
     }
     if (existing.kind === 'builtin') {
       await store.delete(channelId);

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1302,9 +1302,12 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       }, SSE_PING_INTERVAL_MS);
 
       try {
+        // Include nextEventId so clients with a stored last-event cursor
+        // can detect sequence resets after runner eviction (broker is
+        // per-runner; new runner restarts ids at 1).
         await stream.writeSSE({
           event: 'ready',
-          data: JSON.stringify({ sessionId }),
+          data: JSON.stringify({ sessionId, nextEventId: runtime.events.getNextEventId() }),
         });
         await waitForAbort(c.req.raw.signal);
       } finally {

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -1,0 +1,270 @@
+/**
+ * Gateway-level channel connection pool.
+ *
+ * Owns Telegram/Slack/Discord bridge lifecycle independently of agent
+ * runners. Boots once at gateway startup, stays alive across runner
+ * eviction, and tears down only on gateway shutdown or explicit disable.
+ *
+ * The bridges call back into the gateway over HTTP (using `agentBaseUrl`),
+ * so they don't need a live in-process runner reference. When an inbound
+ * message arrives, the gateway's HTTP route hydrates the runner on demand.
+ *
+ * Decoupling channels from runner lifecycle is what unblocks LRU eviction
+ * for agents with active channels (Phase 4 of the lazy-hydration plan).
+ */
+import type { AgentRunner } from '@openhermit/agent/agent-runner';
+import {
+  startSingleChannel as startOneChannel,
+  stopChannels as stopChannelHandles,
+  type ChannelHandle,
+  type ChannelStatus,
+  type WebhookRequest,
+  type WebhookResponse,
+} from '@openhermit/agent/channels';
+import { AgentSecurity, AgentWorkspace } from '@openhermit/agent/core';
+import type {
+  AgentConfigStore,
+  AgentStore,
+  DbAgentChannelStore,
+  SecretStore,
+} from '@openhermit/store';
+
+import type { ChannelRegistry } from './auth.js';
+
+export interface ChannelPoolOptions {
+  agentStore: AgentStore;
+  channelStore: DbAgentChannelStore;
+  configStore: AgentConfigStore;
+  secretStore: SecretStore;
+  channelRegistry: ChannelRegistry;
+  gatewayBaseUrl: string;
+  /** Live-runner lookup so enable/disable can update the hot runner's outbounds. */
+  getRunner: (agentId: string) => AgentRunner | undefined;
+  log: (message: string) => void;
+}
+
+export class ChannelPool {
+  private readonly handles = new Map<string, ChannelHandle[]>();
+  private readonly statuses = new Map<string, ChannelStatus[]>();
+
+  constructor(private readonly opts: ChannelPoolOptions) {}
+
+  /**
+   * Boot all enabled builtin channels for all known agents. Also registers
+   * every channel row's token (builtin + external) into ChannelRegistry so
+   * inbound auth works even before the runner hydrates.
+   */
+  async start(): Promise<void> {
+    const allActive = await this.opts.channelStore.loadActive();
+    const byAgent = new Map<string, typeof allActive>();
+    for (const ch of allActive) {
+      const arr = byAgent.get(ch.agentId);
+      if (arr) arr.push(ch);
+      else byAgent.set(ch.agentId, [ch]);
+    }
+
+    for (const [agentId, channels] of byAgent) {
+      // Always register tokens, even for disabled / external rows — they
+      // need to authenticate inbound webhooks regardless of bridge state.
+      for (const ch of channels) {
+        this.opts.channelRegistry.register({
+          channelId: ch.id,
+          apiKey: ch.token,
+          namespace: ch.namespace,
+          agentId,
+        });
+      }
+
+      const enabledBuiltins = channels.filter((c) => c.kind === 'builtin' && c.enabled);
+      if (enabledBuiltins.length === 0) continue;
+
+      try {
+        await this.startBuiltinsForAgent(agentId, enabledBuiltins);
+      } catch (err) {
+        this.opts.log(
+          `[${agentId}] failed to start channels: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Construct an AgentSecurity for `agentId` solely to expand
+   * `${{SECRET}}` placeholders in channel configs. We don't keep this
+   * around — channel configs only need expansion at start time.
+   */
+  private async loadSecurity(agentId: string): Promise<AgentSecurity> {
+    const record = await this.opts.agentStore.get(agentId);
+    if (!record) throw new Error(`agent ${agentId} not found`);
+    const workspace = new AgentWorkspace(record.workspaceDir);
+    const security = new AgentSecurity({
+      agentId,
+      workspace,
+      configStore: this.opts.configStore,
+      secretStore: this.opts.secretStore,
+    });
+    await security.load();
+    return security;
+  }
+
+  private async startBuiltinsForAgent(
+    agentId: string,
+    rows: Array<{ channelType: string; token: string; config: Record<string, unknown> }>,
+  ): Promise<void> {
+    const security = await this.loadSecurity(agentId);
+    const agentBaseUrl = `${this.opts.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
+    const startedHandles: ChannelHandle[] = [];
+    const startedStatuses: ChannelStatus[] = [];
+
+    for (const row of rows) {
+      const resolved = await security.expandSecrets({ ...row.config, enabled: true });
+      const channelsConfig: Record<string, unknown> = { [row.channelType]: resolved };
+      const { handle, status } = await startOneChannel(row.channelType, channelsConfig as never, {
+        agentBaseUrl,
+        agentTokens: { [row.channelType]: row.token },
+        logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
+      });
+      if (handle) startedHandles.push(handle);
+      startedStatuses.push(status);
+    }
+
+    if (startedHandles.length > 0) this.handles.set(agentId, startedHandles);
+    if (startedStatuses.length > 0) this.statuses.set(agentId, startedStatuses);
+    if (startedHandles.length > 0) {
+      this.opts.log(
+        `[${agentId}] pool started ${startedHandles.length} channel(s): ${startedHandles.map((h) => h.name).join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Outbounds to register on a freshly hydrated runner so it can send
+   * messages back through the bridges held by the pool.
+   */
+  getOutbounds(agentId: string): ChannelHandle[] {
+    return this.handles.get(agentId) ?? [];
+  }
+
+  getStatuses(agentId: string): ChannelStatus[] {
+    return this.statuses.get(agentId) ?? [];
+  }
+
+  /** Webhook dispatch — called by the gateway HTTP webhook route. */
+  async dispatchWebhook(
+    agentId: string,
+    channelName: string,
+    req: WebhookRequest,
+  ): Promise<WebhookResponse> {
+    const handles = this.handles.get(agentId) ?? [];
+    const handle = handles.find((h) => h.name === channelName);
+    if (!handle || !handle.handleWebhook) {
+      return { status: 404, body: 'channel not active or does not accept webhooks' };
+    }
+    return handle.handleWebhook(req);
+  }
+
+  /**
+   * Start a single builtin channel (called from the channel-enable API).
+   * If a runner is hot for the agent, the new outbound is also registered
+   * on it so it can immediately send replies.
+   */
+  async enableChannel(agentId: string, channelName: string): Promise<ChannelStatus> {
+    if (!this.opts.gatewayBaseUrl) {
+      return { name: channelName, status: 'error', error: 'gateway base url not set' };
+    }
+    const row = await this.opts.channelStore.findBuiltin(agentId, channelName);
+    if (!row || !row.enabled) {
+      return { name: channelName, status: 'error', error: `Builtin channel ${channelName} is not enabled` };
+    }
+    const all = await this.opts.channelStore.loadActive();
+    const loaded = all.find((c) => c.id === row.id);
+    if (!loaded) {
+      return { name: channelName, status: 'error', error: 'Failed to decrypt channel token' };
+    }
+
+    this.opts.channelRegistry.register({
+      channelId: row.id,
+      apiKey: loaded.token,
+      namespace: row.namespace,
+      agentId,
+    });
+
+    const security = await this.loadSecurity(agentId);
+    const resolved = await security.expandSecrets({ ...row.config, enabled: true });
+    const channelsConfig: Record<string, unknown> = { [channelName]: resolved };
+    const agentBaseUrl = `${this.opts.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
+
+    const { handle, status } = await startOneChannel(channelName, channelsConfig as never, {
+      agentBaseUrl,
+      agentTokens: { [channelName]: loaded.token },
+      logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
+    });
+
+    if (handle) {
+      const handles = this.handles.get(agentId) ?? [];
+      handles.push(handle);
+      this.handles.set(agentId, handles);
+      const runner = this.opts.getRunner(agentId);
+      if (runner && handle.outbound) runner.registerChannelOutbound(handle.outbound);
+      this.opts.log(`[${agentId}] pool started channel: ${channelName}`);
+    }
+
+    const statuses = this.statuses.get(agentId) ?? [];
+    const existingIdx = statuses.findIndex((s) => s.name === channelName);
+    if (existingIdx !== -1) statuses[existingIdx] = status;
+    else statuses.push(status);
+    this.statuses.set(agentId, statuses);
+
+    return status;
+  }
+
+  /**
+   * Stop a single builtin channel and unregister its outbound from a
+   * hot runner if one exists.
+   */
+  async disableChannel(agentId: string, channelName: string): Promise<void> {
+    const handles = this.handles.get(agentId) ?? [];
+    const idx = handles.findIndex((h) => h.name === channelName);
+    if (idx !== -1) {
+      const handle = handles[idx]!;
+      try {
+        await handle.stop();
+      } catch (err) {
+        this.opts.log(
+          `[${agentId}] error stopping ${channelName}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      handles.splice(idx, 1);
+      if (handles.length === 0) this.handles.delete(agentId);
+
+      const runner = this.opts.getRunner(agentId);
+      if (runner) runner.getChannelOutbound().delete(channelName);
+    }
+
+    this.opts.channelRegistry.unregister(`${agentId}:${channelName}:builtin`);
+
+    const statuses = this.statuses.get(agentId) ?? [];
+    const sIdx = statuses.findIndex((s) => s.name === channelName);
+    if (sIdx !== -1) statuses.splice(sIdx, 1);
+    if (statuses.length === 0) this.statuses.delete(agentId);
+
+    this.opts.log(`[${agentId}] pool stopped channel: ${channelName}`);
+  }
+
+  /** Tear down all channels for one agent (e.g. on agent deletion). */
+  async removeAgent(agentId: string): Promise<void> {
+    const handles = this.handles.get(agentId);
+    if (handles) {
+      await stopChannelHandles(handles);
+      this.handles.delete(agentId);
+    }
+    this.statuses.delete(agentId);
+    this.opts.channelRegistry.unregisterByAgent(agentId);
+  }
+
+  /** Stop every bridge — gateway shutdown only. */
+  async stopAll(): Promise<void> {
+    const ids = [...this.handles.keys()];
+    await Promise.all(ids.map((id) => this.removeAgent(id)));
+  }
+}

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -35,6 +35,7 @@ import {
 } from '@openhermit/shared';
 
 import { AgentInstanceManager } from './agent-instance.js';
+import { ChannelPool } from './channel-pool.js';
 import { CentralScheduler } from './central-scheduler.js';
 import { syncSkillMounts } from './skill-mounts.js';
 import { backfillSandboxes } from './sandbox-backfill.js';
@@ -158,13 +159,11 @@ export const main = async (): Promise<void> => {
   logStartup(`config loaded (source: ${configSource})`);
 
   // Auth configuration (secrets stay in env). ChannelRegistry is seeded
-  // per-agent inside AgentInstanceManager.start() — every channel row
-  // (builtin or external) lives in the same agent_channels table and
-  // takes the same registration path.
+  // by ChannelPool.start() at gateway boot — every channel row (builtin
+  // or external) lives in the same agent_channels table and takes the
+  // same registration path.
   const channels = new ChannelRegistry();
   if (agentChannelStore) {
-    instances.setChannelStore(agentChannelStore);
-
     // One-shot backfill: for every existing agent, make sure each
     // BUILTIN_CHANNELS kind has a row. If the agent's old
     // config_json.channels.X document has values, copy them into the
@@ -395,11 +394,39 @@ export const main = async (): Promise<void> => {
 
   const { server, info } = await listen(app.fetch, port, host);
 
-  // Channel adapters connect back to the gateway from inside the host. Use
-  // 127.0.0.1 even when the public listener is 0.0.0.0 / a specific IP.
-  instances.setGatewayBaseUrl(`http://127.0.0.1:${info.port}`);
   instances.setAdminToken(adminToken);
-  instances.setChannelRegistry(channels);
+
+  // Boot the channel pool — owns Telegram/Slack/Discord bridges
+  // independently of runners. Channels stay alive across runner
+  // eviction; the bridge calls back via HTTP, hydrating the runner on
+  // demand for inbound messages.
+  let channelPool: ChannelPool | undefined;
+  if (agentChannelStore && agentStore && configStore) {
+    const secretStore = instances.getSecretStore();
+    if (secretStore) {
+      channelPool = new ChannelPool({
+        agentStore,
+        channelStore: agentChannelStore,
+        configStore,
+        secretStore,
+        channelRegistry: channels,
+        // Channel adapters connect back from inside the host. Use
+        // 127.0.0.1 even when the public listener is 0.0.0.0.
+        gatewayBaseUrl: `http://127.0.0.1:${info.port}`,
+        getRunner: (agentId) => instances.getRunner(agentId),
+        log: logStartup,
+      });
+      instances.setChannelPool(channelPool);
+      try {
+        await channelPool.start();
+        logStartup('channel pool started');
+      } catch (err) {
+        logStartup(`channel pool start failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      logStartup('channel pool skipped (no secret store available)');
+    }
+  }
 
   attachGatewayWs(server as import('node:http').Server, {
     instances,
@@ -469,6 +496,7 @@ export const main = async (): Promise<void> => {
 
     await centralScheduler?.stop();
     instances.stopEviction();
+    await channelPool?.stopAll();
     await instances.stopAll();
     await agentStore?.close();
     await skillStore?.close();


### PR DESCRIPTION
## Summary
- Adds `apps/gateway/src/channel-pool.ts` — owns Telegram/Slack/Discord bridge lifecycle independently of agent runners. Boots once at gateway start, persists across runner eviction, tears down only on shutdown or explicit channel disable.
- `AgentInstanceManager` no longer manages channel handles. `_doStart` just registers pool outbounds on the freshly hydrated runner; `stop()` shuts down the runner without touching bridges.
- LRU eviction skip-guard for active channels removed — agents with active Telegram polling / Slack RTM / Discord WS can now be evicted; inbound messages hydrate them on demand via the existing HTTP webhook/callback path.
- `app.ts` channel routes (webhook dispatch, list status, enable/disable) route through `instances.getChannelPool()`.

This is Phase 4 (B.1) of the lazy-hydration plan. The bridge ↔ gateway contract was already HTTP-based, so no protocol changes were needed — only lifecycle ownership moves.

## Test plan
- [x] `tsc -b` clean across all workspaces
- [x] `npm test --workspaces` passes (one pre-existing SDK assertion failure on main, unrelated)
- [ ] Deploy to test.openhermit.ai, send a Telegram message, force eviction (`OPENHERMIT_EVICTION_TTL_MINUTES=1`), confirm agent re-hydrates on next message
- [ ] Toggle a builtin channel via the admin UI, confirm enable/disable still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a gateway-level channel pool to centrally manage channels and webhook dispatch.
  * SSE sessions now include a nextEventId to help clients detect sequence resets.

* **Refactor**
  * Channel lifecycle and enable/disable flows moved out of agent runners into the channel pool.
  * Channel status reporting and webhook paths now surface runtime status from the pool.

* **Bug Fixes**
  * Bridges (Telegram/Slack/Discord) handle SSE sequence resets and ping frames more robustly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->