### PR TITLE
feat(gateway): remove autoStartAgents, fully lazy hydration

### DIFF
--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -140,12 +140,11 @@ export const registerAgentsCommand = (program: Command): void => {
       }
     });
 
-  // --- restart (deprecated) ---
+  // --- restart ---
   agents
     .command('restart <agentId>')
-    .description('[deprecated] Evict and re-hydrate the runner')
+    .description('Evict and re-hydrate the runner (use to pick up config/skill/MCP changes)')
     .action(async (agentId: string) => {
-      console.warn(`[deprecated] \`agents restart\` — ${DEPRECATION_NOTE}`);
       try {
         const gateway = createGateway();
         const result = await gateway.manageAgent(agentId, 'restart');

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -106,11 +106,16 @@ export const registerAgentsCommand = (program: Command): void => {
       }
     });
 
-  // --- start ---
+  const DEPRECATION_NOTE =
+    'Runners hydrate on demand and are evicted by LRU; manual start/stop is rarely needed. ' +
+    'Use `hermit agents enable/disable` to control whether an agent accepts traffic.';
+
+  // --- start (deprecated) ---
   agents
     .command('start <agentId>')
-    .description('Hydrate the agent runner into memory (cache management; agents auto-hydrate on demand)')
+    .description('[deprecated] Pre-hydrate the runner into memory')
     .action(async (agentId: string) => {
+      console.warn(`[deprecated] \`agents start\` — ${DEPRECATION_NOTE}`);
       try {
         const gateway = createGateway();
         const result = await gateway.manageAgent(agentId, 'start');
@@ -120,11 +125,12 @@ export const registerAgentsCommand = (program: Command): void => {
       }
     });
 
-  // --- stop ---
+  // --- stop (deprecated) ---
   agents
     .command('stop <agentId>')
-    .description('Evict the runner from memory (cache management; agent stays enabled)')
+    .description('[deprecated] Evict the runner from memory')
     .action(async (agentId: string) => {
+      console.warn(`[deprecated] \`agents stop\` — ${DEPRECATION_NOTE}`);
       try {
         const gateway = createGateway();
         const result = await gateway.manageAgent(agentId, 'stop');
@@ -134,11 +140,12 @@ export const registerAgentsCommand = (program: Command): void => {
       }
     });
 
-  // --- restart ---
+  // --- restart (deprecated) ---
   agents
     .command('restart <agentId>')
-    .description('Evict and re-hydrate the runner (cache management)')
+    .description('[deprecated] Evict and re-hydrate the runner')
     .action(async (agentId: string) => {
+      console.warn(`[deprecated] \`agents restart\` — ${DEPRECATION_NOTE}`);
       try {
         const gateway = createGateway();
         const result = await gateway.manageAgent(agentId, 'restart');

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -7,8 +7,7 @@ Current responsibilities:
 - load `~/.openhermit/gateway/.env` and `~/.openhermit/gateway/gateway.json`
 - connect Drizzle-backed PostgreSQL stores when `DATABASE_URL` is set
 - register built-in skills from `skills/`
-- manage agent records and in-process `AgentRunner` instances
-- auto-start registered agents when `autoStartAgents` is enabled
+- manage agent records and in-process `AgentRunner` instances (lazy hydration on first request)
 - expose agent routes under `/agents/{agentId}/...`
 - expose admin/owner management routes under `/api/...`
 - serve the admin UI at `/admin/` when enabled
@@ -23,8 +22,7 @@ The gateway listens on `GATEWAY_PORT`, then `PORT`, then `4000`, bound to `127.0
 ```json
 {
   "ui": true,
-  "cors": { "origin": "*" },
-  "autoStartAgents": true
+  "cors": { "origin": "*" }
 }
 ```
 

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -215,6 +215,16 @@ export class AgentInstanceManager {
       }
     }
 
+    // 7. Sync platform skills into the runner's exec backends.
+    if (this.skillStore) {
+      try {
+        const enabled = await this.skillStore.listEnabled(agentId);
+        await runner.syncSkills(enabled.map((s) => ({ id: s.id, sourcePath: s.path })));
+      } catch (err) {
+        log(`[${agentId}] skill sync failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
     // 8. Start background timers (stale-session sweep, etc.). Schedule
     //    firing happens at the gateway level (see CentralScheduler).
     runner.startBackgroundTimers();

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1339,7 +1339,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       return {
         agentId: record.agentId,
         ...(record.name ? { name: record.name } : {}),
-        status: record.status === 'active' ? 'running' as const : 'stopped' as const,
+        status: record.status,
         sessions24h: stat.sessions24h,
         errors24h: stat.errors24h,
         ...(stat.lastActivity ? { lastActivity: stat.lastActivity } : {}),

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -11,7 +11,6 @@ export interface SandboxPreset {
 export interface GatewayConfig {
   ui: boolean;
   cors: { origin: string };
-  autoStartAgents: boolean;
   /** Named sandbox presets, keyed by preset name. */
   sandboxPresets: Record<string, SandboxPreset>;
   /**
@@ -33,7 +32,6 @@ const DEFAULT_PRESETS: Record<string, SandboxPreset> = {
 const DEFAULT_CONFIG: GatewayConfig = {
   ui: true,
   cors: { origin: '*' },
-  autoStartAgents: true,
   sandboxPresets: DEFAULT_PRESETS,
   autoProvisionSandbox: 'docker-ubuntu',
 };
@@ -107,9 +105,6 @@ export const parseGatewayConfig = (raw: Record<string, unknown>): GatewayConfig 
     cors: {
       origin: getCorsOrigin(raw) ?? DEFAULT_CONFIG.cors.origin,
     },
-    autoStartAgents: typeof raw.autoStartAgents === 'boolean'
-      ? raw.autoStartAgents
-      : DEFAULT_CONFIG.autoStartAgents,
     sandboxPresets: presets,
     autoProvisionSandbox: autoProvision,
   };

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -37,7 +37,6 @@ import {
 import { AgentInstanceManager } from './agent-instance.js';
 import { ChannelPool } from './channel-pool.js';
 import { CentralScheduler } from './central-scheduler.js';
-import { syncSkillMounts } from './skill-mounts.js';
 import { backfillSandboxes } from './sandbox-backfill.js';
 import { createGatewayApp } from './app.js';
 import { loadGatewayConfig } from './config.js';
@@ -434,54 +433,13 @@ export const main = async (): Promise<void> => {
     logger: logStartup,
   });
 
-  // Start agents from database after server is listening (channels need the gateway URL).
-  if (agentStore && config.autoStartAgents) {
-    const dbAgents = await agentStore.list();
-    // Pre-load all sandbox rows in a single query so we don't N+1 on boot.
-    // Group by agentId; the host-claim invariant below still walks agents
-    // sequentially because it's a serial first-wins decision.
-    const sandboxByAgent = new Map<string, Array<{ type: string }>>();
-    if (sandboxStore) {
-      const allSandboxes = await sandboxStore.listAll();
-      for (const row of allSandboxes) {
-        const arr = sandboxByAgent.get(row.agentId);
-        if (arr) arr.push(row);
-        else sandboxByAgent.set(row.agentId, [row]);
-      }
-    }
-    // Defensive: if DB tampering produced multiple host sandboxes, only the
-    // first agent encountered claims the host backend in this pass. The
-    // create-time check (POST /sandboxes) is the primary guard.
-    let hostClaimed: string | undefined;
-    for (const agent of dbAgents) {
-      try {
-        if (sandboxStore) {
-          const rows = sandboxByAgent.get(agent.agentId) ?? [];
-          const wantsHost = rows.some((r) => r.type === 'host');
-          if (wantsHost && hostClaimed && hostClaimed !== agent.agentId) {
-            logStartup(`skipping agent ${agent.agentId}: host backend already in use by ${hostClaimed}`);
-            continue;
-          }
-          if (wantsHost) hostClaimed = agent.agentId;
-        }
-        await instances.start(agent.agentId, agent.workspaceDir);
-        logStartup(`started agent: ${agent.agentId}`);
-      } catch (error) {
-        logStartup(`failed to start agent ${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
-    // Sync platform skills into each agent's exec backends.
-    if (skillStore) {
-      for (const agent of dbAgents) {
-        const runner = instances.getRunner(agent.agentId);
-        if (runner) {
-          await syncSkillMounts(agent.agentId, runner, skillStore);
-        }
-      }
-    }
-    logStartup(`${dbAgents.length} agent(s) loaded`);
-  } else if (agentStore && !config.autoStartAgents) {
-    logStartup('autoStartAgents disabled — agents will not be started automatically');
+  // Agents hydrate lazily on first request — no boot-time iteration.
+  // Channel pool already loaded all bridges above so inbound traffic
+  // works before any runner exists. The host-backend single-claim
+  // invariant is enforced at sandbox-create time (POST /sandboxes).
+  if (agentStore) {
+    const count = (await agentStore.list()).length;
+    logStartup(`${count} agent(s) registered (lazy hydration)`);
   }
 
   // Re-entrancy guard: SIGINT + SIGTERM can both fire in quick succession

--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -8,7 +8,7 @@ import { ConfigDialog } from './ConfigDialog';
 interface FleetAgent {
   agentId: string;
   name?: string;
-  status: 'running' | 'stopped';
+  status: 'active' | 'disabled';
   sessions24h: number;
   errors24h: number;
   lastActivity?: string;
@@ -140,7 +140,7 @@ export function FleetPanel() {
   };
 
   const totals = useMemo(() => ({
-    running: fleet.filter((a) => a.status === 'running').length,
+    active: fleet.filter((a) => a.status === 'active').length,
     sessions: fleet.reduce((acc, a) => acc + a.sessions24h, 0),
     errors: fleet.reduce((acc, a) => acc + a.errors24h, 0),
   }), [fleet]);
@@ -151,7 +151,7 @@ export function FleetPanel() {
         <h2>
           Agents
           <span className="fleet__sub">
-            &nbsp;· {totals.running}/{fleet.length} running · {totals.sessions} sessions/24h · {totals.errors} errors/24h
+            &nbsp;· {totals.active}/{fleet.length} active · {totals.sessions} sessions/24h · {totals.errors} errors/24h
           </span>
         </h2>
         <div className="panel__header-actions">
@@ -225,7 +225,7 @@ export function FleetPanel() {
                   </div>
                 </td>
                 <td>
-                  <span className={`badge badge--${a.status}`}>{a.status}</span>
+                  <span className={`badge badge--${a.status === 'active' ? 'active' : 'stopped'}`}>{a.status}</span>
                 </td>
                 <td className="fleet-cell-relative">{formatRelative(a.lastActivity)}</td>
                 <td className="fleet-table__num">{a.sessions24h}</td>
@@ -387,13 +387,10 @@ function FleetActionsMenu({
       style={{ position: 'fixed', top, right }}
       onClick={(e) => e.stopPropagation()}
     >
-      {agent.status === 'stopped' ? (
-        <button role="menuitem" onClick={() => onAction(agent.agentId, 'start')}>Start</button>
+      {agent.status === 'disabled' ? (
+        <button role="menuitem" onClick={() => onAction(agent.agentId, 'enable')}>Enable</button>
       ) : (
-        <>
-          <button role="menuitem" onClick={() => onAction(agent.agentId, 'restart')}>Restart</button>
-          <button role="menuitem" onClick={() => onAction(agent.agentId, 'stop')}>Stop</button>
-        </>
+        <button role="menuitem" onClick={() => onAction(agent.agentId, 'disable')}>Disable</button>
       )}
       <div className="fleet-actions__divider" />
       <button role="menuitem" onClick={() => onConfig(agent.agentId)}>Config</button>
@@ -401,7 +398,7 @@ function FleetActionsMenu({
       <button role="menuitem" onClick={() => onMcp(agent.agentId)}>MCP</button>
       <button role="menuitem" onClick={() => onSecrets(agent.agentId)}>Secrets</button>
       <button role="menuitem" onClick={() => onSecurity(agent.agentId)}>Security</button>
-      {agent.status === 'stopped' && (
+      {agent.status === 'disabled' && (
         <>
           <div className="fleet-actions__divider" />
           <button

--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -391,7 +391,7 @@ function FleetActionsMenu({
         <button role="menuitem" onClick={() => onAction(agent.agentId, 'enable')}>Enable</button>
       ) : (
         <>
-          <button role="menuitem" onClick={() => onAction(agent.agentId, 'restart')}>Restart</button>
+          <button role="menuitem" onClick={() => onAction(agent.agentId, 'restart')}>Reload</button>
           <button role="menuitem" onClick={() => onAction(agent.agentId, 'disable')}>Disable</button>
         </>
       )}

--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -390,7 +390,10 @@ function FleetActionsMenu({
       {agent.status === 'disabled' ? (
         <button role="menuitem" onClick={() => onAction(agent.agentId, 'enable')}>Enable</button>
       ) : (
-        <button role="menuitem" onClick={() => onAction(agent.agentId, 'disable')}>Disable</button>
+        <>
+          <button role="menuitem" onClick={() => onAction(agent.agentId, 'restart')}>Restart</button>
+          <button role="menuitem" onClick={() => onAction(agent.agentId, 'disable')}>Disable</button>
+        </>
       )}
       <div className="fleet-actions__divider" />
       <button role="menuitem" onClick={() => onConfig(agent.agentId)}>Config</button>

--- a/apps/gateway/ui/src/components/GatewayConfigPanel.tsx
+++ b/apps/gateway/ui/src/components/GatewayConfigPanel.tsx
@@ -4,7 +4,6 @@ import { api } from '../api';
 interface GatewayConfig {
   ui?: boolean;
   cors?: { origin?: string };
-  autoStartAgents?: boolean;
   sandboxPresets?: Record<string, { type: string; config: Record<string, unknown> }>;
   autoProvisionSandbox?: string | null;
 }
@@ -24,7 +23,6 @@ export function GatewayConfigPanel() {
   const [saving, setSaving] = useState(false);
 
   const [corsOrigin, setCorsOrigin] = useState('');
-  const [autoStartAgents, setAutoStartAgents] = useState(true);
   const [autoProvision, setAutoProvision] = useState('');
   const [presetsText, setPresetsText] = useState('');
   const [presetsError, setPresetsError] = useState('');
@@ -32,7 +30,6 @@ export function GatewayConfigPanel() {
   const applyConfig = useCallback((cfg: GatewayConfig) => {
     setConfig(cfg);
     setCorsOrigin(cfg.cors?.origin ?? '*');
-    setAutoStartAgents(cfg.autoStartAgents ?? true);
     setAutoProvision(cfg.autoProvisionSandbox ?? '');
     setPresetsText(JSON.stringify(cfg.sandboxPresets ?? {}, null, 2));
     setPresetsError('');
@@ -73,7 +70,6 @@ export function GatewayConfigPanel() {
     const next: GatewayConfig = {
       ...(config ?? {}),
       cors: { origin: corsOrigin },
-      autoStartAgents,
       sandboxPresets: presets as GatewayConfig['sandboxPresets'],
       autoProvisionSandbox: autoProvision.trim() === '' ? null : autoProvision.trim(),
     };
@@ -127,15 +123,6 @@ export function GatewayConfigPanel() {
             onChange={(e) => setCorsOrigin(e.target.value)}
             placeholder="*"
           />
-        </label>
-
-        <label className="field" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <input
-            type="checkbox"
-            checked={autoStartAgents}
-            onChange={(e) => setAutoStartAgents(e.target.checked)}
-          />
-          <span>Auto-start agents on boot</span>
         </label>
 
         <label className="field">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,10 +87,9 @@ On startup, the gateway:
 3. opens PostgreSQL stores if `DATABASE_URL` is available
 4. scans and registers built-in skills from `skills/`
 5. starts the Hono server and WebSocket handler
-6. auto-starts registered agents when `autoStartAgents` is true
-7. syncs enabled skills into each started agent's sandbox via `runner.syncSkills`
+6. boots the channel pool — bridges (Telegram/Slack/Discord) attach to gateway HTTP routes; runners hydrate lazily on first inbound traffic
 
-Each started agent initializes workspace/security, creates an `AgentRunner`, registers channel tokens, starts enabled built-in channels, starts the scheduler, and connects enabled MCP servers lazily through the runner.
+Agents hydrate on demand: the first request that targets an agent constructs its `AgentRunner`, syncs enabled skills into the sandbox via `runner.syncSkills`, attaches existing channel outbounds from the pool, starts the per-runner scheduler, and connects enabled MCP servers lazily through the runner. Idle runners are evicted by an LRU after `OPENHERMIT_EVICTION_TTL_MINUTES`; channel bridges in the pool stay alive across eviction.
 
 ## Agent Runtime
 


### PR DESCRIPTION
## Summary
- Phase 5 of the lazy-hydration plan: removes the boot-time agent iteration in `apps/gateway/src/index.ts` and the `autoStartAgents` config field. Agents now hydrate on first request via the existing on-demand paths.
- Skill sync (`runner.syncSkills`) moves into `AgentInstance._doStart` so lazily-hydrated agents still get platform skills mounted into their exec backends — this used to run only as a one-shot in the post-boot loop.
- Drops the defensive host-claim guard from boot; the primary invariant lives at `POST /sandboxes` (create-time check).
- Cleans up the admin UI checkbox, gateway README, and architecture doc.

## Test plan
- [ ] Local: `pnpm -F @openhermit/gateway typecheck`
- [ ] Local: boot gateway, observe `N agent(s) registered (lazy hydration)` log line and absence of any agent boot iteration
- [ ] Test server: send Telegram message → first inbound triggers hydration → reply delivered
- [ ] Test server: confirm builtin channels are reachable on cold start (channel pool boots before any runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now use lazy hydration — initialized on first request for faster gateway startup.

* **Configuration Changes**
  * Removed "Auto-start agents on boot" option and UI control; CORS origin handling consolidated.

* **Agent Initialization**
  * Platform skills are synced into runners at creation; sync failures are logged without aborting startup.

* **CLI**
  * start/stop subcommands marked deprecated and emit a deprecation warning; restart description updated.

* **API & UI**
  * Fleet status uses active/disabled semantics; UI and action menus updated.

* **Documentation**
  * README and architecture docs updated to reflect lazy hydration and new startup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->