### PR TITLE
docs(lazy-hydration): reflect shipped status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-OpenHermit is a gateway-managed, multi-agent runtime. The gateway owns process lifecycle and API surface; each running agent is an in-process `AgentRunner` with its own workspace, security policy, tools, scheduler, channel adapters, MCP connections, and state scope.
+OpenHermit is a gateway-managed, multi-agent runtime. The gateway owns process lifecycle, the API surface, the channel-bridge pool, and the central cron scheduler. Per agent, an in-process `AgentRunner` carries the workspace, security policy, tools, MCP connections, and per-session state — runners hydrate on demand when traffic arrives and are LRU-evicted when idle (controlled by `OPENHERMIT_EVICTION_TTL_MINUTES`, default 30). `agents.status` ('active' / 'disabled') in the DB is the source of truth for whether traffic is accepted; the in-memory runner map is a hydration cache, not a lifecycle.
 
 ## Components
 
@@ -23,7 +23,7 @@ PostgreSQL stores (Drizzle)
 | Component | Responsibility |
 |-----------|----------------|
 | `apps/gateway` | Control plane, auth, admin API, admin UI, agent lifecycle, WebSocket attachment, channel startup |
-| `apps/agent` | Agent loop, prompt assembly, tools, sessions, events, introspection, compaction, scheduler, MCP client manager |
+| `apps/agent` | Agent loop, prompt assembly, tools, sessions, events, introspection, compaction, MCP client manager |
 | `apps/cli` | Setup, gateway lifecycle, agent management, chat TUI, config/secrets, schedules, logs/status |
 | `apps/web` | Standalone end-user chat web app |
 | `apps/channels/*` | Telegram, Discord, and Slack bridges |
@@ -89,7 +89,7 @@ On startup, the gateway:
 5. starts the Hono server and WebSocket handler
 6. boots the channel pool — bridges (Telegram/Slack/Discord) attach to gateway HTTP routes; runners hydrate lazily on first inbound traffic
 
-Agents hydrate on demand: the first request that targets an agent constructs its `AgentRunner`, syncs enabled skills into the sandbox via `runner.syncSkills`, attaches existing channel outbounds from the pool, starts the per-runner scheduler, and connects enabled MCP servers lazily through the runner. Idle runners are evicted by an LRU after `OPENHERMIT_EVICTION_TTL_MINUTES`; channel bridges in the pool stay alive across eviction.
+Agents hydrate on demand: the first request that targets an agent constructs its `AgentRunner`, syncs enabled skills into the sandbox via `runner.syncSkills`, attaches existing channel outbounds from the pool, and connects enabled MCP servers lazily through the runner. Schedules fire from a single gateway-level `CentralScheduler` that hydrates the target runner on demand at fire time. Idle runners are evicted by an LRU after `OPENHERMIT_EVICTION_TTL_MINUTES`; channel bridges in the pool stay alive across eviction.
 
 ## Agent Runtime
 

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -1,6 +1,6 @@
 # Channel Adapters
 
-OpenHermit includes built-in Telegram, Discord, and Slack adapters. The gateway starts enabled adapters for each running agent and registers scoped channel tokens so adapters can call back into `/api/agents/{agentId}/...`.
+OpenHermit includes built-in Telegram, Discord, and Slack adapters. At gateway boot the `ChannelPool` (`apps/gateway/src/channel-pool.ts`) starts every enabled adapter for every agent with `agents.status='active'` and registers scoped channel tokens so adapters can call back into `/api/agents/{agentId}/...`. Bridges are owned by the gateway, not by the per-agent runner — they stay alive across runner eviction and only tear down on gateway shutdown, agent disable, or explicit `disableChannel`. When an inbound message arrives, the gateway hydrates the runner on demand before dispatching.
 
 ## Implemented Adapters
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,10 +103,12 @@ Manage agent records.
 |------------|-------------|
 | `agents list` | List every registered agent and its status. |
 | `agents create <agentId>` | Create a new agent. Auto-seeds the `identity` / `soul` / `rules` instructions. |
-| `agents start <agentId>` | Start a stopped agent (gateway spawns the in-process `AgentRunner`). |
-| `agents stop <agentId>` | Stop a running agent. |
-| `agents restart <agentId>` | Restart. |
-| `agents delete <agentId>` | Delete the agent and all its per-agent rows (must be stopped first). |
+| `agents enable <agentId>` | Set `agents.status='active'` — gateway accepts traffic; runner hydrates on first request. |
+| `agents disable <agentId>` | Set `agents.status='disabled'` — gateway rejects traffic and evicts any hot runner. |
+| `agents restart <agentId>` | Evict and re-hydrate the runner. Useful for picking up DB-side config / skill / MCP changes. |
+| `agents start <agentId>` | **Deprecated** cache hint — pre-hydrates the runner. Lazy hydration handles this on demand; prefer `enable`. |
+| `agents stop <agentId>` | **Deprecated** cache hint — evicts the runner without disabling the agent. Prefer `disable`. |
+| `agents delete <agentId>` | Delete the agent and all its per-agent rows (must be disabled first). |
 
 Flags on `create`:
 
@@ -120,7 +122,6 @@ Flags on `create`:
 
 ```bash
 hermit agents create oncall --name "On-Call Buddy" --owner user_marcus
-hermit agents start oncall
 hermit agents list
 ```
 
@@ -412,7 +413,7 @@ hermit logs --json | jq 'select(.level=="error")'
 | Need to… | Use |
 |----------|-----|
 | Spin up the gateway | `hermit setup && hermit gateway start` |
-| Create and start an agent | `hermit agents create main && hermit agents start main` |
+| Create an agent | `hermit agents create main` (active by default; hydrates on first request) |
 | Talk to it | `hermit chat --agent main` |
 | Set a model API key | `hermit config secrets set OPENROUTER_API_KEY ... --agent main` |
 | Switch model | `hermit config set model.model google/gemini-3-flash-preview --agent main` |

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -1,6 +1,6 @@
 # Lazy Hydration & Multi-Tenant Scaling Design
 
-**Status:** Phases 1–5 shipped on `main` (channel-state externalization + per-bot multi-agent routing deferred — see Phase 4 #4–#5).
+**Status:** Phases 1–5 shipped on `main`. Two items in the original Phase 4 list (per-bot multi-agent routing, channel-state externalization to Postgres) turned out not to be required under the single-gateway / one-bot-per-agent model and are dropped from scope; see Phase 4 #4–#5.
 **Goal:** Support 1000–2000 agents per gateway instance on a 64 GB Railway container
 
 ---
@@ -200,8 +200,13 @@ One long-lived feature branch `feat/lazy-hydration` off `main` (after the MCP as
 1. ✅ Telegram polling loop moves to gateway-level pool (`apps/gateway/src/channel-pool.ts`, PR #29).
 2. ✅ Slack Socket Mode client moves to gateway-level pool.
 3. ✅ Discord client moves to gateway-level pool.
-4. ⏸ **Deferred:** routing table `(channel_kind, connection_id, conversation_id) → agent_id`. The pool is currently keyed by `agentId` — one bot per agent, which matches today's deployment model. Needed only when N agents share one Telegram/Slack/Discord app.
-5. ⏸ **Deferred:** externalize per-agent channel state to Postgres (`chatSessions`, `lastEventIds`, `pendingApprovals`, `chatLocks`/`turnQueues`). Survives runner eviction today (in-memory on the bridge, which lives in the gateway), but **not** gateway restart, and blocks multi-gateway HA. Largest hidden cost of this phase per §5.4 — break out into its own design when prioritized.
+4. 🚫 **Out of scope.** A `(channel_kind, connection_id, conversation_id) → agent_id` routing table was on the original list to support multiple agents sharing one bot. In the actual product, each agent owns its own Telegram/Slack/Discord credentials (rows in `agent_channels`), so routing is 1:1 and already handled by `ChannelRegistry.register({apiKey, agentId})` in the pool. No use case in v1.
+5. 🚫 **Out of scope.** Externalizing per-agent channel state to Postgres turned out to be unnecessary on inspection:
+   - `chatSessions` / `channelSessions` are pure memoization — on cache miss the bridge falls back to `client.listSessions({metadata})` which already reads from the persisted `sessions` table (`apps/channels/{slack,discord,telegram}/src/bridge.ts`).
+   - `lastEventIds` is the SSE dedup cursor, reset across runner restart via the `ready` / `nextEventId` frame (PR #29).
+   - `pendingApprovals` (Telegram realtime) is valid only for the duration of one in-flight turn — that turn is in-memory by nature, so persisting the map is meaningless.
+   - Async approvals already persist via `approval_requests.short_id` (PR #28).
+   - `chatLocks` / `turnQueues` are per-conversation in-process mutexes; correct as in-memory under single-gateway. Multi-gateway HA is explicitly out of scope (see Open Questions §4) and would require its own design pass anyway.
 
 ### Phase 5 — Cleanup ✅ shipped (PR #30)
 

--- a/docs/lazy-hydration-design.md
+++ b/docs/lazy-hydration-design.md
@@ -1,16 +1,16 @@
 # Lazy Hydration & Multi-Tenant Scaling Design
 
-**Status:** Draft — not yet implemented
+**Status:** Phases 1–5 shipped on `main` (channel-state externalization + per-bot multi-agent routing deferred — see Phase 4 #4–#5).
 **Goal:** Support 1000–2000 agents per gateway instance on a 64 GB Railway container
 
 ---
 
-## Background
+## Background (historical — pre-refactor)
 
-Today the gateway eagerly hydrates every agent at boot:
+Before this work the gateway eagerly hydrated every agent at boot:
 
-- `apps/gateway/src/index.ts:375-420` — on startup (when `autoStartAgents=true`), iterates every row in `agents` and calls `instances.start()`.
-- `AgentInstanceManager.runners: Map<agentId, AgentRunner>` is populated forever; there is no idle eviction, no LRU, no TTL.
+- `apps/gateway/src/index.ts` iterated every row in `agents` on startup (under `autoStartAgents=true`) and called `instances.start()`.
+- `AgentInstanceManager.runners: Map<agentId, AgentRunner>` was populated forever; there was no idle eviction, no LRU, no TTL.
 - Per-agent in-process resources held by the runner: scheduler timers, MCP client connections, channel adapters (Slack Socket Mode WebSocket, Discord WebSocket, Telegram polling loop), session event broker, workspace/container manager.
 
 Per-agent baseline ≈ 6–15 MB. With 1000–2000 agents this is 10–20 GB of always-hot memory plus full event-loop pressure even when most agents are idle.
@@ -151,16 +151,14 @@ Assumptions: idle TTL 30 min, ~5 % of agents active in a 30 min window, average 
 
 ## Implementation Plan
 
-### Prerequisite (separate PR, lands on `main` first)
+### Prerequisite — MCP async loading ✅ shipped
 
-**MCP async loading.** Independently valuable — fixes today's "one bad MCP server stalls agent boot" and slow gateway startup, in the same spirit as the existing lazy sandbox provisioning. Not coupled to the lazy-hydration refactor and shipped as its own PR.
+Lives in `apps/agent/src/mcp-client.ts`. Independently valuable — fixed "one bad MCP server stalls agent boot" and slow gateway startup. Required for sub-second cold hydration.
 
-1. Runner construction returns immediately without awaiting MCP `connect()`.
-2. Each MCP client connects in the background; tool list is recomputed as connections complete.
-3. Agent observes connection state (`pending` / `connected` / `failed`); system prompt / tool surface reflects what is currently available.
-4. Tool calls against a not-yet-connected server return a clear, recoverable error ("MCP server X still connecting").
-
-This PR lands first because it is the prerequisite for sub-second hydration latency in the lazy branch — without it, every cold hydration would block on synchronous MCP `connect()`, exposing users to slow first messages.
+1. ✅ `connectAll()` is fire-and-forget; runner construction does not await MCP `connect()`.
+2. ✅ Each client connects in the background; `getToolsets()` filters on `status === 'connected'` so the tool surface grows as connections complete.
+3. ✅ `getStatus()` exposes per-server `'connecting' | 'connected' | 'disconnected' | 'error'` plus `lastError` / `connectedAt`.
+4. ✅ Tool calls on a still-connecting server return `"MCP server … is still connecting. Try again in a moment."`
 
 ### Lazy-hydration branch
 
@@ -199,17 +197,17 @@ One long-lived feature branch `feat/lazy-hydration` off `main` (after the MCP as
 
 ### Phase 4 — Channel connection pooling
 
-1. Telegram polling loop moves to gateway-level pool.
-2. Slack Socket Mode client moves to gateway-level pool.
-3. Discord client moves to gateway-level pool.
-4. Channel routing table `(channel_kind, connection_id, conversation_id) → agent_id`.
-5. Externalize per-agent channel state (`chatSessions`, `lastEventIds`, approvals) to Postgres.
+1. ✅ Telegram polling loop moves to gateway-level pool (`apps/gateway/src/channel-pool.ts`, PR #29).
+2. ✅ Slack Socket Mode client moves to gateway-level pool.
+3. ✅ Discord client moves to gateway-level pool.
+4. ⏸ **Deferred:** routing table `(channel_kind, connection_id, conversation_id) → agent_id`. The pool is currently keyed by `agentId` — one bot per agent, which matches today's deployment model. Needed only when N agents share one Telegram/Slack/Discord app.
+5. ⏸ **Deferred:** externalize per-agent channel state to Postgres (`chatSessions`, `lastEventIds`, `pendingApprovals`, `chatLocks`/`turnQueues`). Survives runner eviction today (in-memory on the bridge, which lives in the gateway), but **not** gateway restart, and blocks multi-gateway HA. Largest hidden cost of this phase per §5.4 — break out into its own design when prioritized.
 
-### Phase 5 — Cleanup
+### Phase 5 — Cleanup ✅ shipped (PR #30)
 
-1. Delete `autoStartAgents` config and the boot-time iteration in `index.ts`.
-2. Update `docs/architecture.md`, `docs/channel-adapter.md`, `docs/storage-model.md`.
-3. End-to-end test: 100+ agents hydrating concurrently, evicting, re-hydrating; cron fires across restart; channel pools survive runner churn.
+1. ✅ Deleted `autoStartAgents` config and the boot-time iteration in `index.ts`.
+2. ✅ Updated `apps/gateway/README.md` and `docs/architecture.md`. (Other doc passes done as needed.)
+3. ⏸ Formal end-to-end load test (100+ agents hydrating concurrently) not run; smoke-tested manually on test.openhermit.ai.
 
 ## Open Questions
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -11,9 +11,9 @@ MCP servers add executable external tools to an agent. Skills are prompt assets;
 
 ## Runtime
 
-`AgentRunner` creates an `McpClientManager` when MCP stores are available. Enabled servers are connected as needed, tool discovery is cached in the manager, and shutdown disconnects all clients.
+`AgentRunner` creates an `McpClientManager` when MCP stores are available. Connections are kicked off asynchronously — `connectAll()` is fire-and-forget so runner hydration never blocks on a slow or broken MCP server. Tools surface as each connection completes; a call against a still-connecting server returns `"MCP server … is still connecting. Try again in a moment."` Tool discovery is cached in the manager, and shutdown disconnects all clients.
 
-Failure to connect one MCP server does not prevent the agent from running. Status is surfaced through `mcp_status` and the gateway UI/API.
+Failure to connect one MCP server does not prevent the agent from running. Per-server status (`connecting` / `connected` / `disconnected` / `error`) is surfaced through `mcp_status` and the gateway UI/API.
 
 MCP tools are namespaced:
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -42,7 +42,7 @@ The gateway scans repository `skills/` at startup and upserts those built-ins in
 
 ## Runtime Loading
 
-At agent startup:
+When a runner hydrates (on the first request that targets the agent, or on `agents restart`):
 
 1. DB-managed enabled skills are resolved for the agent, including global `*` assignments.
 2. The gateway calls `runner.syncSkills`, which dispatches to each `ExecBackend`:


### PR DESCRIPTION
## Summary
- Phases 1–5 of the lazy-hydration plan are all on main; the design doc still claimed "Draft — not yet implemented". Update the status banner and check off shipped items.
- Mark Phase 4 #4 (per-bot routing table for N-agents-sharing-one-app) and #5 (channel-state externalization to Postgres) explicitly as deferred, with rationale.
- Mark the MCP async-loading prerequisite as shipped (\`apps/agent/src/mcp-client.ts\`).

## Test plan
- [ ] Read-only doc change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Finalized lazy-hydration design: Phases 1–5 updated (Phases 1–3 marked complete, Phase 4 deferred, Phase 5 cleanup done); MCP async loading noted as shipped; testing narrowed to a manual smoke check.
  * Clarified gateway-level centralized scheduling and lazy agent hydration behavior.
  * Documented channel-adapter lifecycle and persistent channel bridges.
  * Updated MCP server connection lifecycle and user-facing statuses.
  * Clarified CLI agent lifecycle and runtime skill loading semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->