### PR TITLE
feat(gateway,sdk): admin issue-token for trusted issuers

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -475,6 +475,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       if (!body.channelUserId || typeof body.channelUserId !== 'string') {
         throw new ValidationError('channelUserId is required.');
       }
+      if (body.displayName !== undefined && typeof body.displayName !== 'string') {
+        throw new ValidationError('displayName must be a string if provided.');
+      }
 
       let userId = await userStore.resolve(body.channel, body.channelUserId);
       let created = false;

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -444,6 +444,79 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     });
 
     /**
+     * Admin-only token mint for trusted issuers. Lets a third-party platform
+     * that has already authenticated its own user hand them a gateway JWT
+     * without going through device-key. Body:
+     *   { channel, channelUserId, displayName? }
+     * The caller chooses a stable `channel` namespace for their platform
+     * (e.g. "my-platform"); `channelUserId` should be the platform's own
+     * user id. Same `(channel, channelUserId)` always resolves to the same
+     * gateway user, so this composes with channel webhooks using the same
+     * namespace.
+     */
+    app.post('/api/admin/auth/issue-token', async (c) => {
+      requireAdmin(c.req.header('authorization'));
+      if (!userStore) {
+        throw new OpenHermitError('User store is not configured.', 'not_configured', 500);
+      }
+      const body = await c.req.json().catch(() => ({})) as {
+        channel?: string;
+        channelUserId?: string;
+        displayName?: string;
+      };
+      if (!body.channel || typeof body.channel !== 'string') {
+        throw new ValidationError('channel is required.');
+      }
+      if (body.channel === 'admin') {
+        // 'admin' is reserved for the static admin token path; minting a
+        // JWT with this channel would be confusing in audit views.
+        throw new ValidationError('channel "admin" is reserved.');
+      }
+      if (!body.channelUserId || typeof body.channelUserId !== 'string') {
+        throw new ValidationError('channelUserId is required.');
+      }
+
+      let userId = await userStore.resolve(body.channel, body.channelUserId);
+      let created = false;
+      if (!userId) {
+        const id = `usr-${crypto.randomBytes(6).toString('hex')}`;
+        const now = new Date().toISOString();
+        await userStore.upsert({
+          userId: id,
+          ...(body.displayName ? { name: body.displayName } : {}),
+          createdAt: now,
+          updatedAt: now,
+        });
+        await userStore.linkIdentity({
+          userId: id,
+          channel: body.channel,
+          channelUserId: body.channelUserId,
+          createdAt: now,
+        });
+        userId = id;
+        created = true;
+      } else if (body.displayName) {
+        const existing = await userStore.get(userId);
+        if (existing && existing.name !== body.displayName) {
+          await userStore.upsert({ ...existing, name: body.displayName });
+        }
+      }
+
+      const { token, expiresAt } = await signJwt(authOptions.jwt, {
+        channel: body.channel,
+        channelUserId: body.channelUserId,
+      });
+
+      return c.json({
+        token,
+        expiresAt,
+        userId,
+        isNewDevice: created,
+        ...(body.displayName ? { displayName: body.displayName } : {}),
+      });
+    });
+
+    /**
      * Agents the JWT subject is a member of. Powers the web "pick agent"
      * screen so users can jump straight back into agents they've already
      * joined.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -312,6 +312,82 @@ export class GatewayClient {
     this.fetchImpl = options.fetch ?? fetch;
   }
 
+  /**
+   * Mint a user JWT via the admin-only trusted-issuer path. For external
+   * platforms that authenticate their users elsewhere and want to hand
+   * them a gateway token without going through device-key.
+   *
+   * The caller's `adminToken` is the trust boundary — never expose it to
+   * end users. Pick a stable `channel` namespace for your platform (e.g.
+   * "my-platform"); the same `(channel, channelUserId)` always resolves
+   * to the same gateway user.
+   */
+  static async issueUserToken(input: {
+    baseUrl: string;
+    adminToken: string;
+    channel: string;
+    channelUserId: string;
+    displayName?: string;
+    fetch?: FetchLike;
+  }): Promise<{
+    token: string;
+    expiresAt: number;
+    userId: string;
+    isNewDevice: boolean;
+    displayName?: string;
+  }> {
+    const fetchImpl = input.fetch ?? fetch;
+    const url = joinUrl(input.baseUrl, '/api/admin/auth/issue-token');
+    const body: Record<string, unknown> = {
+      channel: input.channel,
+      channelUserId: input.channelUserId,
+    };
+    if (input.displayName !== undefined) body.displayName = input.displayName;
+
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${input.adminToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new OpenHermitError(
+        `Gateway API is unavailable at ${url}: ${message}`,
+        'gateway_api_error',
+        500,
+      );
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      const statusCode: OpenHermitStatusCode =
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 404 ||
+        response.status === 500
+          ? response.status
+          : 500;
+      throw new OpenHermitError(
+        `issueUserToken failed (${response.status}): ${responseText || response.statusText}`,
+        'gateway_api_error',
+        statusCode,
+      );
+    }
+
+    return (await response.json()) as {
+      token: string;
+      expiresAt: number;
+      userId: string;
+      isNewDevice: boolean;
+      displayName?: string;
+    };
+  }
+
   async listAgents(): Promise<AgentInfo[]> {
     return this.getJson(gatewayRoutes.agents);
   }


### PR DESCRIPTION
## Summary
- New endpoint \`POST /api/admin/auth/issue-token\` that mints a user JWT given \`{channel, channelUserId, displayName?}\` and admin auth. For external platforms that authenticate their users elsewhere and want to hand them a gateway JWT without device-key.
- SDK static \`GatewayClient.issueUserToken({baseUrl, adminToken, channel, channelUserId, displayName?})\` — needed before a client instance exists.
- Reserves the \`admin\` channel name to avoid audit confusion with the static admin-token path.
- Composes with channel webhooks: same \`(channel, channelUserId)\` resolves to the same gateway user, so a platform using the same namespace for both webhook + issued JWTs sees one unified user.

## Test plan
- [ ] POST with valid admin auth + new \`(channel, channelUserId)\` → returns JWT, creates user
- [ ] POST again with same identity → returns JWT, no new user
- [ ] Token works as Bearer for \`GET /api/users/me/agents\` etc.
- [ ] Without admin auth → 401
- [ ] Missing \`channel\` / \`channelUserId\` → 400
- [ ] \`channel: "admin"\` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only endpoint to issue gateway tokens for external channels, supporting automated user provisioning, identity linking, optional display name updates, and new-device detection.
  * SDK helper to call the trusted issuer endpoint, returning token, expiry, user ID, new-device flag, and optional display name with normalized error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->