### PR TITLE
chore(sdk): make @openhermit/sdk publishable to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -131,6 +131,7 @@
         "@openhermit/protocol": "0.2.0",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
+        "croner": "^10.0.1",
         "hono": "^4.7.2",
         "jose": "^6.2.2",
         "react": "^19.1.0",
@@ -8810,7 +8811,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8863,7 +8863,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10975,9 +10974,14 @@
     "packages/sdk": {
       "name": "@openhermit/sdk",
       "version": "0.2.0",
-      "dependencies": {
+      "license": "MIT",
+      "devDependencies": {
         "@openhermit/protocol": "0.2.0",
-        "@openhermit/shared": "0.2.0"
+        "@openhermit/shared": "0.2.0",
+        "tsup": "^8.5.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/shared": {

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenHermit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,77 @@
+# @openhermit/sdk
+
+TypeScript SDK for the [OpenHermit](https://github.com/HCF-S/openhermit) gateway and agent APIs.
+
+## Install
+
+```bash
+npm install @openhermit/sdk
+```
+
+Requires Node 20+ (or any modern runtime with `fetch` and `WebSocket`).
+
+## Usage
+
+### Talking to the gateway
+
+```ts
+import { GatewayClient } from '@openhermit/sdk';
+
+const client = new GatewayClient({
+  baseUrl: 'https://gateway.example.com',
+  token: '<user-jwt>',
+});
+
+const agents = await client.listAgents();
+const agent = await client.createAgent({ /* ... */ });
+await client.setAgentSecret(agent.agentId, 'OPENAI_API_KEY', 'sk-...', { passThrough: true });
+```
+
+### Issuing user tokens for an external platform
+
+If you authenticate users in your own platform and want to hand them an
+OpenHermit JWT without going through device-key:
+
+```ts
+import { GatewayClient } from '@openhermit/sdk';
+
+const { token } = await GatewayClient.issueUserToken({
+  baseUrl: 'https://gateway.example.com',
+  adminToken: process.env.OPENHERMIT_ADMIN_TOKEN!, // server-side only
+  channel: 'my-platform',                          // your stable namespace
+  channelUserId: user.id,                          // your platform's user id
+  displayName: user.name,
+});
+
+// Pass `token` to the user; same `(channel, channelUserId)` always
+// resolves to the same gateway user.
+```
+
+### Talking to a specific agent
+
+```ts
+const agent = client.agent('agt-...');
+const { sessionId } = await agent.openSession({ /* ... */ });
+
+for await (const event of agent.postMessageStream(sessionId, { text: 'hi' })) {
+  console.log(event);
+}
+```
+
+### WebSocket
+
+```ts
+import { AgentWsClient } from '@openhermit/sdk';
+
+const ws = new AgentWsClient({
+  url: client.agent('agt-...').buildWsUrl(),
+  token: '<user-jwt>',
+});
+await ws.connect();
+ws.on('event', (e) => console.log(e));
+await ws.sessionOpen({ sessionId, source: { kind: 'web', interactive: true } });
+```
+
+## License
+
+MIT

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,22 +1,55 @@
 {
   "name": "@openhermit/sdk",
-  "private": true,
   "version": "0.2.0",
+  "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
+  "license": "MIT",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },
-  "scripts": {
-    "build": "tsc -b",
-    "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
-    "test": "npm run build && node --import tsx --test test/*.test.ts"
+  "files": [
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HCF-S/openhermit.git",
+    "directory": "packages/sdk"
   },
-  "dependencies": {
+  "homepage": "https://github.com/HCF-S/openhermit/tree/main/packages/sdk",
+  "bugs": "https://github.com/HCF-S/openhermit/issues",
+  "keywords": [
+    "openhermit",
+    "agent",
+    "ai",
+    "claude",
+    "sdk",
+    "gateway"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
+    "test": "npm run build && node --import tsx --test test/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
     "@openhermit/protocol": "0.2.0",
-    "@openhermit/shared": "0.2.0"
+    "@openhermit/shared": "0.2.0",
+    "tsup": "^8.5.1"
   }
 }

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "outDir": "dist",
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../protocol/src",
+    "../shared/src"
+  ]
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup';
+
+// Bundle the workspace-only dependencies into the published artifact so
+// consumers don't need (and can't reach) @openhermit/protocol or
+// @openhermit/shared on npm.
+const internalPackages = [
+  '@openhermit/protocol',
+  '@openhermit/shared',
+];
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  platform: 'neutral',
+  outDir: 'dist',
+  clean: true,
+  tsconfig: 'tsconfig.build.json',
+  dts: { resolve: true },
+  sourcemap: true,
+  noExternal: internalPackages,
+  esbuildOptions(options) {
+    options.conditions = ['development'];
+  },
+});


### PR DESCRIPTION
## Summary
- Bundle \`@openhermit/protocol\` and \`@openhermit/shared\` into the published artifact via tsup so consumers get a single self-contained package on npm.
- Drop \`private: true\`, move workspace-only deps to \`devDependencies\` (still linked via npm workspaces inside this repo).
- Add standard publish metadata: repository, license, description, keywords, files, prepublishOnly script, README, LICENSE.
- New \`tsconfig.build.json\` exists so tsup's dts emit can include the workspace srcs.

After merge, publishing is one command:
\`\`\`
npm publish --workspace @openhermit/sdk
\`\`\`

\`--dry-run\` shows a 27 kB tarball with \`dist/index.{js,js.map,d.ts}\`, README, LICENSE.

## Test plan
- [x] \`npx tsc -b\` — full repo typecheck clean
- [x] \`npm run build --workspace @openhermit/sdk\` — emits ESM + dts
- [x] \`grep '@openhermit' dist/index.{js,d.ts}\` — no internal package imports leaked
- [x] \`npm publish --workspace @openhermit/sdk --dry-run\` — tarball clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documenting the TypeScript SDK with installation instructions, runtime requirements (Node 20+), and usage examples covering agent management, user token issuance, and WebSocket connections

* **Chores**
  * Configured package metadata, build system, and distribution artifacts for SDK publication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->