### PR TITLE
release: openhermit v0.6.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump CLI from 0.6.2 → 0.6.3 for npm publish.
- New since 0.6.2: \`--pass-through\` / \`--no-pass-through\` flags on \`openhermit secrets set\` (#34).

## Test plan
- [ ] After merge: \`npm publish --workspace openhermit\` from repo root
- [ ] \`npm view openhermit version\` shows 0.6.3
- [ ] \`npx openhermit@0.6.3 --help\` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version updated to 0.6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->