### PR TITLE
fix(sdk): drop development export condition (0.3.1)

### DIFF
--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.0",
+    "@openhermit/sdk": "0.3.1",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.0",
+    "@openhermit/sdk": "0.3.1",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.0",
+    "@openhermit/sdk": "0.3.1",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.0",
+    "@openhermit/sdk": "0.3.1",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -44,7 +45,9 @@
     "build": "tsup",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
     "test": "npm run build && node --import tsx --test test/*.test.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepack": "node scripts/strip-dev-condition.mjs",
+    "postpack": "node scripts/restore-package-json.mjs"
   },
   "devDependencies": {
     "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",
@@ -8,7 +8,6 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/sdk/scripts/restore-package-json.mjs
+++ b/packages/sdk/scripts/restore-package-json.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// postpack: restore package.json from the backup written by prepack.
+import { existsSync, renameSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+if (existsSync(backupPath)) {
+  renameSync(backupPath, pkgPath);
+  console.log('[sdk] restored package.json after publish');
+}

--- a/packages/sdk/scripts/strip-dev-condition.mjs
+++ b/packages/sdk/scripts/strip-dev-condition.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// prepack: back up package.json and remove the `development` export
+// condition so the published tarball only exposes built artifacts.
+// Restored by scripts/restore-package-json.mjs in postpack.
+import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+copyFileSync(pkgPath, backupPath);
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const dot = pkg.exports?.['.'];
+if (dot && typeof dot === 'object' && 'development' in dot) {
+  delete dot.development;
+}
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log('[sdk] stripped development export condition for publish');


### PR DESCRIPTION
## Summary
- 0.3.0 broke Next.js / Turbopack consumers: the `development` export condition pointed at `./src/index.ts`, but `src/` is not in the published tarball, so resolvers honoring that condition (Next dev mode does) hit a non-existent path.
- Drops the `development` condition from `packages/sdk/package.json#exports` so the package only exposes the built artifact.
- Bumps SDK to `0.3.1` and syncs workspace consumers.

## Verification
- `npm pack --dry-run` shows tarball contents: `dist/index.js`, `dist/index.js.map`, `dist/index.d.ts`, `LICENSE`, `README.md`, `package.json`. No `src/`.
- Published `package.json#exports` no longer references `src`.

## Tradeoff
In-monorepo workspaces previously got TS source via the `development` condition; they'll now resolve to compiled `dist/` and need SDK built first (`tsc -b` already covers this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SDK and channel packages (Discord, Slack, Telegram, CLI) to v0.3.1.
  * Improved SDK packaging/publish process to ensure released packages contain only built artifacts and restore package metadata after publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->