### PR TITLE
fix(admin): render masked secret preview, not [object Object]

### DIFF
--- a/apps/gateway/ui/src/components/SecretsDialog.tsx
+++ b/apps/gateway/ui/src/components/SecretsDialog.tsx
@@ -23,11 +23,13 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
   useEffect(() => { dialogRef.current?.showModal(); }, []);
 
   const loadFromServer = async () => {
-    const map = await api<Record<string, string>>(`/api/agents/${encodeURIComponent(agentId)}/secrets`);
+    const map = await api<Record<string, { masked: string; passThrough: boolean }>>(
+      `/api/agents/${encodeURIComponent(agentId)}/secrets`,
+    );
     setRows(
       Object.keys(map).sort().map((k) => ({
         key: k,
-        masked: map[k] ?? '',
+        masked: map[k]?.masked ?? '',
         draft: '',
         busy: false,
       })),


### PR DESCRIPTION
## Summary
- `/admin/fleet` agent → secrets dialog showed `[object Object]` as the placeholder for each existing secret.
- Cause: `GET /api/agents/:id/secrets` returns `Record<string, { masked, passThrough }>`, but `SecretsDialog` typed it as `Record<string, string>` and assigned `map[k]` directly to `masked`, which stringified the wrapper object.
- Fix: extract `.masked` and update the type.

## Test plan
- [ ] Open a fleet agent with an existing secret, click secrets — placeholder shows the masked value (e.g. `***xyz`), not `[object Object]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)