### PR TITLE
feat(admin): add passThrough toggle to secrets dialog

### DIFF
--- a/apps/gateway/ui/src/components/SecretsDialog.tsx
+++ b/apps/gateway/ui/src/components/SecretsDialog.tsx
@@ -5,6 +5,8 @@ interface RowState {
   key: string;
   /** Server-supplied masked preview. */
   masked: string;
+  /** Whether this secret is injected into sandbox env at exec time. */
+  passThrough: boolean;
   /** Current edit-in-progress value; empty until the user types. */
   draft: string;
   /** This row is currently mid-PUT/DELETE. */
@@ -16,6 +18,7 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
   const [rows, setRows] = useState<RowState[]>([]);
   const [newKey, setNewKey] = useState('');
   const [newValue, setNewValue] = useState('');
+  const [newPassThrough, setNewPassThrough] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
   const [adding, setAdding] = useState(false);
@@ -30,6 +33,7 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
       Object.keys(map).sort().map((k) => ({
         key: k,
         masked: map[k]?.masked ?? '',
+        passThrough: map[k]?.passThrough ?? false,
         draft: '',
         busy: false,
       })),
@@ -54,12 +58,28 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
     try {
       await api(`/api/agents/${encodeURIComponent(agentId)}/secrets/${encodeURIComponent(key)}`, {
         method: 'PUT',
-        body: { value: row.draft },
+        body: { value: row.draft, passThrough: row.passThrough },
       });
       await loadFromServer();
     } catch (err) {
       setError((err as Error).message);
       updateRow(key, { busy: false });
+    }
+  };
+
+  const togglePassThrough = async (key: string, next: boolean) => {
+    setError('');
+    updateRow(key, { busy: true, passThrough: next });
+    try {
+      await api(`/api/agents/${encodeURIComponent(agentId)}/secrets/${encodeURIComponent(key)}`, {
+        method: 'PUT',
+        body: { passThrough: next },
+      });
+      await loadFromServer();
+    } catch (err) {
+      setError((err as Error).message);
+      // Revert optimistic toggle on failure.
+      updateRow(key, { busy: false, passThrough: !next });
     }
   };
 
@@ -89,10 +109,11 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
     try {
       await api(`/api/agents/${encodeURIComponent(agentId)}/secrets/${encodeURIComponent(k)}`, {
         method: 'PUT',
-        body: { value: newValue },
+        body: { value: newValue, passThrough: newPassThrough },
       });
       setNewKey('');
       setNewValue('');
+      setNewPassThrough(false);
       await loadFromServer();
     } catch (err) {
       setError((err as Error).message);
@@ -123,6 +144,15 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
               disabled={r.busy}
               onChange={(e) => updateRow(r.key, { draft: e.target.value })}
             />
+            <label className="secret-row__passthrough" title="Inject into sandbox env at exec time">
+              <input
+                type="checkbox"
+                checked={r.passThrough}
+                disabled={r.busy}
+                onChange={(e) => void togglePassThrough(r.key, e.target.checked)}
+              />
+              <span>Pass through</span>
+            </label>
             <button
               className="btn btn--sm btn--primary"
               type="button"
@@ -159,6 +189,15 @@ export function SecretsDialog({ agentId, onClose }: { agentId: string; onClose: 
             onChange={(e) => setNewValue(e.target.value)}
             disabled={adding}
           />
+          <label className="secret-row__passthrough" title="Inject into sandbox env at exec time">
+            <input
+              type="checkbox"
+              checked={newPassThrough}
+              disabled={adding}
+              onChange={(e) => setNewPassThrough(e.target.checked)}
+            />
+            <span>Pass through</span>
+          </label>
           <button
             className="btn btn--sm btn--primary"
             type="button"

--- a/apps/gateway/ui/src/styles.css
+++ b/apps/gateway/ui/src/styles.css
@@ -382,6 +382,19 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
 
 .secret-row__value:focus { outline: none; border-color: var(--accent); }
 
+.secret-row__passthrough {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.secret-row__passthrough input[type="checkbox"] { margin: 0; cursor: pointer; }
+
 .secrets-add {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Per-row "Pass through" checkbox on each existing secret in `/admin/fleet → secrets`. Toggling immediately PUTs `{ passThrough }` (optimistic, reverts on error).
- Add-secret row exposes the flag at creation time.
- Saving with a new value now sends `{ value, passThrough }` so the current toggle state isn't lost on edit.

The gateway PUT route already accepts `{ passThrough }` alone for flag-only updates and `{ value, passThrough? }` for value writes — wired up.

## Test plan
- [ ] Toggle passThrough on an existing secret — see flag flip without page reload, persists across reload.
- [ ] Create a new secret with the box checked — reload, flag is on.
- [ ] Edit an existing secret's value — passThrough state preserved after save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Pass through" toggle option for each secret in the Secrets dialog.
  * Toggled settings persist automatically with server synchronization.
  * Updated UI styling for the new passthrough control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->