### PR TITLE
style(web): /manage/secrets row — single line, full width

### DIFF
--- a/apps/web/ui/src/styles.css
+++ b/apps/web/ui/src/styles.css
@@ -1214,7 +1214,7 @@ h2 { font-size: 14px; font-weight: 600; }
   display: flex;
   flex-direction: column;
   gap: 16px;
-  max-width: 640px;
+  width: 100%;
   padding: 16px 20px;
 }
 
@@ -1225,7 +1225,7 @@ h2 { font-size: 14px; font-weight: 600; }
 
 .secrets-row {
   display: grid;
-  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  grid-template-columns: minmax(160px, 220px) 1fr auto auto;
   gap: 8px;
   align-items: center;
   padding: 6px 8px;
@@ -1258,7 +1258,7 @@ h2 { font-size: 14px; font-weight: 600; }
 
 .secrets-panel__add {
   display: grid;
-  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  grid-template-columns: minmax(160px, 220px) 1fr auto auto;
   gap: 8px;
   align-items: center;
   padding: 6px 8px;


### PR DESCRIPTION
## Summary
- Drop the 640px max on `.secrets-panel` so the panel uses the available width.
- Bump the grid to 4 tracks (`key | value | passthrough | actions`) so the row stays on a single line instead of wrapping the buttons below.

Mobile breakpoint at 720px already collapses to one column — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced Secrets panel layout to display at full width and improved grid spacing for better control arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->