### PR TITLE
feat(sdk): add listProviders + docs/sdk.md (0.3.2)

### DIFF
--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.1",
+    "@openhermit/sdk": "0.3.2",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.1",
+    "@openhermit/sdk": "0.3.2",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.1",
+    "@openhermit/sdk": "0.3.2",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.1",
+    "@openhermit/sdk": "0.3.2",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,171 @@
+# `@openhermit/sdk`
+
+TypeScript client for the OpenHermit gateway and agent APIs. Targets external
+integrations that need to provision agents, manage their configuration, and
+talk to live sessions over HTTP/WS without re-implementing the wire format.
+
+```bash
+npm install @openhermit/sdk
+```
+
+```ts
+import { GatewayClient } from '@openhermit/sdk';
+
+const gw = new GatewayClient({
+  baseUrl: 'https://test.openhermit.ai',
+  token: process.env.OPENHERMIT_ADMIN_TOKEN,
+});
+
+const agents = await gw.listAgents();
+```
+
+## Auth model
+
+There are two distinct caller identities. Pick the right token for each call:
+
+- **Admin token** — long-lived value from gateway config. Authorises every
+  `/api/admin/...` route plus all per-agent CRUD. Use for back-office /
+  server-to-server provisioning.
+- **User JWT** — issued either via `POST /api/auth/token` (device-key
+  exchange) or `GatewayClient.issueUserToken(...)` (admin-minted on behalf of
+  a user authenticated by your own system). Scoped to that user's agents.
+
+`GatewayClient` accepts either as `token`. `AgentClient` (live session calls)
+expects a user JWT.
+
+## What the SDK supports today
+
+### `GatewayClient` — control plane
+
+**Auth / identity**
+- `GatewayClient.issueUserToken({ baseUrl, adminToken, channel, channelUserId, displayName? })` — admin-only mint of a user JWT for a `(channel, channelUserId)` identity. Use to bridge users authenticated by an external system into OpenHermit without device-key exchange.
+
+**Catalog**
+- `listProviders(): ProviderCatalogEntry[]` — provider/model snapshot from pi-ai.
+
+**Agents**
+- `listAgents()` — admin: every agent in the fleet.
+- `createAgent(request)` / `deleteAgent(agentId)`.
+- `manageAgent(agentId, 'start' | 'stop' | 'restart' | 'enable' | 'disable')`.
+- `agentHealth(agentId)`.
+
+**Per-agent config**
+- `getAgentConfig(agentId)` / `putAgentConfig(agentId, config)`.
+- `getAgentSecurity(agentId)` / `putAgentSecurity(agentId, policy)`.
+
+**Secrets** (per-agent, encrypted server-side)
+- `getAgentSecrets(agentId)` — returns masked previews + `passThrough` flags.
+- `setAgentSecret(agentId, name, value, { passThrough? })`.
+- `deleteAgentSecret(agentId, name)`.
+
+**Channels** (built-in adapters and external webhook channels)
+- `listAgentChannels(agentId)` — all channels with runtime status.
+- `createExternalChannel(agentId, input)` — returns the plaintext token once.
+- `updateAgentChannel(agentId, channelId, input)`.
+- `deleteAgentChannel(agentId, channelId)`.
+
+**Sandboxes** (per-agent exec environments)
+- `listSandboxes(agentId)`.
+- `createSandbox(agentId, input)`.
+- `deleteSandbox(agentId, alias)`.
+
+**Skills** (admin)
+- `listSkills()` / `scanSkills()` / `getSkill(...)`.
+- `registerSkill(input)` / `deleteSkill(skillId)`.
+- `listSkillAssignments()` / `enableSkill(skillId, agentId)` / `disableSkill(skillId, agentId)`.
+
+**MCP servers** (admin)
+- `listMcpServers()` / `registerMcpServer(input)`.
+- `listMcpAssignments()` / `enableMcpServer(mcpServerId, agentId)` / `disableMcpServer(...)`.
+
+**Instructions** (per-agent prompts)
+- `listInstructions(agentId)` / `getInstruction(agentId, key)`.
+- `setInstruction(agentId, key, content)` / `deleteInstruction(agentId, key)`.
+- `fanoutInstruction(input)` — admin: push the same key to many agents.
+
+**Schedules** (per-agent crons)
+- `listSchedules(agentId)` / `createSchedule(agentId, input)`.
+- `updateSchedule(agentId, scheduleId, input)` / `deleteSchedule(agentId, scheduleId)`.
+- `listScheduleRuns(agentId, scheduleId, limit?)`.
+
+**Policies** (per-agent resource access)
+- `listPolicies(agentId, resourceType?)`.
+- `upsertPolicy(agentId, input)` / `deletePolicy(agentId, resourceType, resourceKey)`.
+
+**Approvals** (per-agent tool-call approvals)
+- `listApprovalRequests(agentId, status?)` / `getApprovalRequest(agentId, id)`.
+- `reviewApprovalRequest(agentId, id, { decision, ... })`.
+
+**Gateway-level config** (admin)
+- `getGatewayConfig()` / `putGatewayConfig(config)`.
+- `getAdminStats()`.
+
+### `AgentClient` — runtime session
+
+For talking to a running agent over HTTP/SSE/WS as a user.
+
+- `openSession(spec)` / `listSessions(query?)` / `listSessionMessages(sessionId)`.
+- `postMessage(...)` / `appendMessage(...)` — non-streaming.
+- `postMessageSync(...)` — wait for the assistant turn to complete.
+- `postMessageStream(...)` — async iterable of session events (SSE under the hood).
+- `submitApproval(...)` / `checkpointSession(...)`.
+- `reviewApprovalRequest(...)` / `reviewApprovalRequestByShortId(...)`.
+
+### `AgentRealtimeClient` — WebSocket client (chat-style consumers)
+
+- `sessionOpen` / `sessionMessage` / `sessionApprove` / `sessionCheckpoint`.
+- `sessionList` / `sessionHistory`.
+- `subscribe(sessionId, lastEventId?)` / `unsubscribe(sessionId)`.
+
+## Not yet covered
+
+The gateway exposes more routes than the SDK currently wraps. If you need any
+of these, drop a method in `packages/sdk/src/index.ts` matching the existing
+style. Prioritised by the hole they represent:
+
+**Multi-tenant / membership**
+- `POST /api/users` — create users from outside the device-key flow.
+- `GET /api/agents/:agentId/members` — list users with access to an agent.
+- `POST /api/agents/:agentId/members` — share an agent with a user.
+- `DELETE /api/agents/:agentId/members/:userId` — revoke access.
+- `POST /api/agents/:agentId/users/:userId/promote-to-owner`.
+- `GET /api/agents/:agentId/ownership` / `GET /api/agents/:agentId/info`.
+- `GET /api/users/me/agents` — current-user's accessible agents (currently only `listAgents()` admin variant is wrapped).
+
+**Admin observability**
+- `GET /health`, `GET /metrics`.
+- `GET /api/admin/agents/fleet` (admin fleet dashboard).
+- `GET /api/admin/sandboxes` (cross-agent sandbox view).
+- `GET /api/admin/users` / `GET /api/admin/users/:userId/identities` / `GET /api/admin/users/:userId/agents`.
+- `GET /api/admin/logs` (server log tail).
+- `GET /api/admin/schedules` (cross-agent schedule view).
+- `GET /api/sandbox-presets` (read-only catalog of sandbox templates).
+
+**Sessions / events**
+- `DELETE /api/agents/:agentId/sessions/:sessionId` — delete a session.
+- `GET /api/agents/:agentId/sessions/:sessionId/events` — raw SSE event stream (`AgentClient.postMessageStream` covers the message-driven case but not arbitrary subscription).
+
+**Channels**
+- `POST /api/agents/:agentId/channels/:namespace/webhook` — inbound webhook
+  delivery. External integrations call this directly with the token from
+  `createExternalChannel`; the SDK currently doesn't wrap it because typical
+  consumers are *receiving* webhooks, not posting them programmatically.
+
+**Schedules**
+- `POST /api/agents/:agentId/schedules/:scheduleId/trigger` — manual fire of
+  a cron entry (useful for "test run now" buttons).
+
+**Approvals**
+- `POST /api/agents/:agentId/approvals/by-short/:shortId/review` — review by
+  short-id (the long-id form is wrapped).
+
+## Versioning
+
+Semver-ish. Additive methods are minor/patch bumps; type-breaking changes are
+minor (we're pre-1.0). The ESM build is published from `dist/`; the
+`development` export condition is stripped at pack time via `prepack` so
+in-monorepo dev keeps reading `src/` directly without polluting the published
+tarball.
+
+See [`packages/sdk/src/index.ts`](../packages/sdk/src/index.ts) for the
+authoritative type surface.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -325,6 +325,18 @@ export interface AgentChannel {
   revokedAt: string | null;
 }
 
+/** Provider/model catalog entry returned by GET /api/providers. */
+export interface ProviderModel {
+  id: string;
+  /** True for thinking-only / thinking-capable models in pi-ai. */
+  reasoning: boolean;
+}
+
+export interface ProviderCatalogEntry {
+  provider: string;
+  models: ProviderModel[];
+}
+
 /** Builtin-channel secret-key descriptor surfaced by listAgentChannels. */
 export interface AgentChannelSecretKey {
   key: string;
@@ -444,6 +456,15 @@ export class GatewayClient {
 
   async listAgents(): Promise<AgentInfo[]> {
     return this.getJson(gatewayRoutes.agents);
+  }
+
+  /**
+   * Snapshot of providers and models registered in the gateway's
+   * pi-ai catalog. Used to populate provider/model pickers without
+   * baking the registry into the client.
+   */
+  async listProviders(): Promise<ProviderCatalogEntry[]> {
+    return this.getJson<ProviderCatalogEntry[]>('/api/providers');
   }
 
   async createAgent(request: CreateAgentRequest): Promise<AgentInfo> {


### PR DESCRIPTION
## Summary
- `GatewayClient.listProviders()` returns the gateway's pi-ai provider/model catalog (`ProviderCatalogEntry[]`).
- Adds `docs/sdk.md` documenting the SDK surface (auth model, every wrapped route family) and listing the gateway routes the SDK does not yet wrap, organised by feature area.
- Bumps SDK to **0.3.2** (0.3.1 is already on npm); workspace deps synced.

## Test plan
- [x] `npm run typecheck -w @openhermit/sdk` clean.
- [ ] After publish, smoke from external project: `client.listProviders()` returns array of `{ provider, models }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider catalog listing capability to the SDK for discovering available models.

* **Documentation**
  * Introduced comprehensive SDK documentation covering client types, authentication models, and API capabilities.

* **Chores**
  * Updated SDK version to 0.3.2 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->