### PR TITLE
feat(session): add per-session custom_instruction

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -469,11 +469,18 @@ export class AgentRunner implements SessionRuntime {
       ...(persisted?.metadata ?? {}),
       ...(spec.metadata ?? {}),
     };
+    // customInstruction is set ONCE at session creation. On reopen we
+    // restore the persisted value so callers can't mutate it later.
+    const effectiveCustomInstruction =
+      persisted?.customInstruction ?? spec.customInstruction;
     const effectiveSpec: SessionSpec = {
       ...spec,
       source: persisted?.source ?? spec.source,
       ...(Object.keys(mergedMetadata).length > 0
         ? { metadata: mergedMetadata }
+        : {}),
+      ...(effectiveCustomInstruction
+        ? { customInstruction: effectiveCustomInstruction }
         : {}),
     };
     const createdAt = persisted?.createdAt ?? now;
@@ -1502,6 +1509,7 @@ export class AgentRunner implements SessionRuntime {
       ...(channelUserId ? { channelUserId } : {}),
       ...(spec.source.type ? { sessionType: spec.source.type } : {}),
       sourceKind: spec.source.kind,
+      ...(spec.customInstruction ? { customInstruction: spec.customInstruction } : {}),
     });
   }
 
@@ -1522,6 +1530,7 @@ export class AgentRunner implements SessionRuntime {
     channelUserId?: string;
     sessionType?: import('@openhermit/protocol').SessionType;
     sourceKind?: string;
+    customInstruction?: string;
   }): Promise<Agent> {
     const webProvider = this.resolveWebProvider(input.config);
 
@@ -1786,6 +1795,7 @@ export class AgentRunner implements SessionRuntime {
         agentId: this.scope.agentId,
         sessionId: input.contextSessionId,
       },
+      input.customInstruction,
     );
     const systemPrompt = input.extraSystemPrompt
       ? `${baseSystemPrompt}\n\n${input.extraSystemPrompt}`.trim()
@@ -1845,6 +1855,7 @@ export class AgentRunner implements SessionRuntime {
       ...(session.resolvedChannelUserId ? { channelUserId: session.resolvedChannelUserId } : {}),
       ...(session.spec.source.type ? { sessionType: session.spec.source.type } : {}),
       sourceKind: session.spec.source.kind,
+      ...(session.spec.customInstruction ? { customInstruction: session.spec.customInstruction } : {}),
     });
     session.agent.state.model = resolveModel(config);
     session.agent.state.systemPrompt = refreshedAgent.state.systemPrompt;

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -469,10 +469,12 @@ export class AgentRunner implements SessionRuntime {
       ...(persisted?.metadata ?? {}),
       ...(spec.metadata ?? {}),
     };
-    // customInstruction is set ONCE at session creation. On reopen we
-    // restore the persisted value so callers can't mutate it later.
-    const effectiveCustomInstruction =
-      persisted?.customInstruction ?? spec.customInstruction;
+    // customInstruction is set ONCE at session creation. On reopen the
+    // persisted row is authoritative — even if it stored no instruction,
+    // we must not let a later spec inject one (immutability).
+    const effectiveCustomInstruction = persisted
+      ? persisted.customInstruction
+      : spec.customInstruction;
     const effectiveSpec: SessionSpec = {
       ...spec,
       source: persisted?.source ?? spec.source,

--- a/apps/agent/src/agent-runner/prompt.ts
+++ b/apps/agent/src/agent-runner/prompt.ts
@@ -52,6 +52,7 @@ export const buildSystemPrompt = async (
   currentUser?: CurrentUserContext,
   skills?: SkillIndexEntry[],
   hook?: PromptAssembleHookContext,
+  customInstruction?: string,
 ): Promise<string> => {
   const keyedSections: { key: string; content: string }[] = [];
 
@@ -69,6 +70,14 @@ export const buildSystemPrompt = async (
     instructionText = '(no instructions configured)';
   }
   keyedSections.push({ key: 'instructions', content: `## Instructions\n\n${instructionText}` });
+
+  // 2b. SESSION INSTRUCTION (per-session addendum, set once at create)
+  if (customInstruction && customInstruction.trim()) {
+    keyedSections.push({
+      key: 'session-instruction',
+      content: `## Session Instruction\n\n${customInstruction.trim()}`,
+    });
+  }
 
   // 3. PRINCIPLES
   keyedSections.push({ key: 'principles', content: PRINCIPLES });

--- a/apps/agent/src/agent-runner/session-index.ts
+++ b/apps/agent/src/agent-runner/session-index.ts
@@ -23,6 +23,9 @@ export const createPersistedSessionIndexEntry = (
     : {}),
   ...(session.spec.metadata ? { metadata: session.spec.metadata } : {}),
   ...(session.userIds.length > 0 ? { userIds: session.userIds } : {}),
+  ...(session.spec.customInstruction
+    ? { customInstruction: session.spec.customInstruction }
+    : {}),
 });
 
 /**

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -105,6 +105,11 @@ expects a user JWT.
 For talking to a running agent over HTTP/SSE/WS as a user.
 
 - `openSession(spec)` / `listSessions(query?)` / `listSessionMessages(sessionId)`.
+  - `spec.customInstruction?: string` — optional per-session prompt addendum.
+    Stored once on the session row at create time and appended to the system
+    prompt as a dedicated section after agent-level instructions. Immutable
+    for the lifetime of the session (subsequent `openSession` calls for the
+    same `sessionId` ignore the field).
 - `postMessage(...)` / `appendMessage(...)` — non-streaming.
 - `postMessageSync(...)` — wait for the assistant turn to complete.
 - `postMessageStream(...)` — async iterable of session events (SSE under the hood).

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -24,6 +24,13 @@ export interface SessionSpec {
   sessionId: string;
   source: SessionSource;
   metadata?: Record<string, MetadataValue>;
+  /**
+   * Optional per-session prompt addendum stored on the session row at
+   * create time. When non-empty, the runner appends it to the system
+   * prompt as a dedicated section after agent-level instructions.
+   * Immutable for the life of the session.
+   */
+  customInstruction?: string;
 }
 
 export interface SessionAttachment {
@@ -380,6 +387,10 @@ export const isSessionSpec = (value: unknown): value is SessionSpec => {
         return false;
       }
     }
+  }
+
+  if (value.customInstruction !== undefined && typeof value.customInstruction !== 'string') {
+    return false;
   }
 
   return true;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1167,6 +1167,7 @@ export class AgentWsClient {
     sessionId: string;
     source: { kind: string; interactive: boolean; platform?: string; type?: string };
     metadata?: Record<string, unknown>;
+    customInstruction?: string;
   }): Promise<{ sessionId: string }> {
     return this.request('session.open', params as Record<string, unknown>) as Promise<{ sessionId: string }>;
   }

--- a/packages/store/drizzle/0019_session_custom_instruction.sql
+++ b/packages/store/drizzle/0019_session_custom_instruction.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN "custom_instruction" text;

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778600000000,
       "tag": "0018_secret_pass_through",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778700000000,
+      "tag": "0019_session_custom_instruction",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/session-store.ts
+++ b/packages/store/src/impl/session-store.ts
@@ -46,6 +46,7 @@ export class DbSessionStore implements SessionStore {
       interactive: entry.source.interactive ? 1 : 0,
       createdAt: entry.createdAt,
       type: entry.type ?? entry.source.type ?? 'direct',
+      customInstruction: entry.customInstruction ?? null,
     };
     // Runtime-mutable fields — re-written every persistSessionIndex.
     const runtime = {
@@ -126,6 +127,10 @@ export class DbSessionStore implements SessionStore {
 
     const userIds = (row.userIds ?? []) as string[];
     if (userIds.length > 0) entry.userIds = userIds;
+
+    if (row.customInstruction !== null && row.customInstruction !== undefined) {
+      entry.customInstruction = row.customInstruction;
+    }
 
     return entry;
   }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -56,6 +56,8 @@ export const sessions = pgTable('sessions', {
   status: text('status').default('idle').notNull(),
   type: text('type').default('direct').notNull(),
   userIds: jsonb('user_ids').$type<string[]>().default([]).notNull(),
+  /** Caller-supplied per-session prompt addendum, set once at create. */
+  customInstruction: text('custom_instruction'),
 }, (table) => [
   primaryKey({ columns: [table.agentId, table.sessionId] }),
   index('idx_sessions_agent').on(table.agentId, table.lastActivityAt),

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -127,6 +127,8 @@ export interface PersistedSessionIndexEntry {
   metadata?: Record<string, MetadataValue>;
   type?: SessionType;
   userIds?: string[];
+  /** Per-session prompt addendum, set once at create. */
+  customInstruction?: string;
 }
 
 export interface SessionLogEntry {


### PR DESCRIPTION
## Summary
- New optional `SessionSpec.customInstruction` (DB column `sessions.custom_instruction`).
- Stored once at session creation; appended to the system prompt as a dedicated `## Session Instruction` section right after agent-level instructions.
- Immutable for the session's lifetime: on reopen, the persisted value wins over any new spec value (mirrors the existing source/createdAt immutability pattern).

## Changes
- `packages/store`: schema column + migration `0019_session_custom_instruction` + journal + `DbSessionStore` upsert/rowToEntry.
- `packages/protocol`: field on `SessionSpec` + validator (`isSessionSpec`).
- `apps/agent`: thread through `openSession` (immutable on reopen), `createConfiguredAgent`, `refreshAgentConfiguration`, and `buildSystemPrompt`.
- `packages/sdk`: typed param on `AgentRealtimeClient.sessionOpen` (HTTP `AgentLocalClient.openSession` already takes `SessionSpec`, so the new field flows automatically).
- `docs/sdk.md`: documented under `AgentClient.openSession`.

## Test plan
- [ ] Open a session with `customInstruction` → verify the string lands in `sessions.custom_instruction` and appears in the system prompt under `## Session Instruction`.
- [ ] Reopen the same `sessionId` with a different `customInstruction` → persisted value is preserved.
- [ ] Open a session without the field → no `## Session Instruction` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-level custom instructions: add an optional customInstruction to sessions. It's appended to the system prompt, stored at session creation, preserved on reopen, and immutable for the session's lifetime.
* **Documentation**
  * SDK docs updated to document the new optional customInstruction field and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->