### PR TITLE
feat(message): plumb per-message metadata end-to-end

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -885,6 +885,7 @@ export class AgentRunner implements SessionRuntime {
       ...(session.resolvedUserId ? { senderUserId: session.resolvedUserId } : {}),
       ...(session.resolvedUserRole ? { senderRole: session.resolvedUserRole } : {}),
       ...(message.sender?.channel ? { senderChannel: message.sender.channel } : {}),
+      ...(message.metadata ? { metadata: message.metadata } : {}),
     });
     if (transformed.text !== message.text) {
       message = { ...message, text: transformed.text };

--- a/apps/agent/src/events.ts
+++ b/apps/agent/src/events.ts
@@ -64,6 +64,9 @@ export interface SessionMessageReceivedPayload {
   senderUserId?: string;
   senderRole?: 'owner' | 'user' | 'guest';
   senderChannel?: string;
+  /** Caller-supplied per-message metadata. Plugins may inspect this and
+   *  rewrite `text` accordingly (e.g. prepend a context note for the model). */
+  metadata?: Record<string, unknown>;
 }
 
 export interface PromptAssemblePayload {

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -157,6 +157,7 @@ const handleRequest = async (
           ...(p.messageId !== undefined ? { messageId: p.messageId } : {}),
           ...(p.attachments !== undefined ? { attachments: p.attachments } : {}),
           ...(p.sender !== undefined ? { sender: p.sender } : {}),
+          ...(p.metadata !== undefined ? { metadata: p.metadata } : {}),
         };
         if (!isSessionMessage(message)) {
           sendError(ws, id, 'INVALID_PARAMS', 'Invalid message params.');

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -72,6 +72,9 @@ export interface SessionHistoryMessage {
   introspection?: boolean;
   introspectionPhase?: 'start' | 'end';
   introspectionSummary?: string;
+  /** Per-message metadata supplied by the caller on user turns. Persisted
+   *  alongside the log entry; surfaced for plugins/tools, not the model. */
+  metadata?: Record<string, unknown>;
 }
 
 export type SessionStatus = 'idle' | 'running' | 'awaiting_approval' | 'inactive';
@@ -421,7 +424,13 @@ export const isSessionMessage = (value: unknown): value is SessionMessage => {
       return false;
     }
 
-    return value.attachments.every(isAttachment);
+    if (!value.attachments.every(isAttachment)) {
+      return false;
+    }
+  }
+
+  if (value.metadata !== undefined && !isRecord(value.metadata)) {
+    return false;
   }
 
   return true;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -429,8 +429,10 @@ export const isSessionMessage = (value: unknown): value is SessionMessage => {
     }
   }
 
-  if (value.metadata !== undefined && !isRecord(value.metadata)) {
-    return false;
+  if (value.metadata !== undefined) {
+    if (!isRecord(value.metadata) || Array.isArray(value.metadata)) {
+      return false;
+    }
   }
 
   return true;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1176,6 +1176,7 @@ export class AgentWsClient {
     sessionId: string;
     text: string;
     messageId?: string;
+    metadata?: Record<string, unknown>;
   }): Promise<{ sessionId: string; messageId?: string }> {
     return this.request('session.message', params) as Promise<{ sessionId: string; messageId?: string }>;
   }

--- a/packages/store/src/impl/message-store.ts
+++ b/packages/store/src/impl/message-store.ts
@@ -21,6 +21,9 @@ const mapEventRowToHistoryMessage = (row: {
     const message: SessionHistoryMessage = { ts: row.ts, role: 'user', content: row.content ?? '' };
     if (typeof payload?.messageId === 'string') message.messageId = payload.messageId;
     if (Array.isArray(payload?.attachments)) message.attachments = payload.attachments as SessionAttachment[];
+    if (payload && typeof payload.metadata === 'object' && payload.metadata !== null && !Array.isArray(payload.metadata)) {
+      message.metadata = payload.metadata as Record<string, unknown>;
+    }
     return message;
   }
 


### PR DESCRIPTION
## Summary
`SessionMessage.metadata` already existed in the protocol but was half-wired. Closing the gaps so callers can reliably attach arbitrary metadata to user turns.

- **WS path**: `ws-handler.ts` rebuilt the payload and silently dropped `metadata` — now forwarded.
- **Validator**: `isSessionMessage` accepted any shape — now requires `metadata` to be a plain object when present.
- **History**: `SessionHistoryMessage` gains `metadata?: Record<string, unknown>`; `message-store` rowToHistory surfaces it.
- **Hook payload**: `SessionMessageReceivedPayload` (transform) now carries `metadata`. Plugins can inspect it and rewrite `text` (e.g. prepend a model-visible note) before it reaches the LLM.
- **SDK**: `AgentRealtimeClient.sessionMessage` typed param adds `metadata?`.

No prompt-side renderer in this PR — injection policy is left to plugins via the hook.

## Test plan
- [ ] HTTP `POST .../messages` with `metadata: { foo: 1 }` → metadata round-trips through history.
- [ ] WS `session.message` with metadata → forwarded (previously dropped).
- [ ] Register a `session.message.received@v1` transform that prepends `[meta=…] ` to text → user message reaching the model is rewritten.
- [ ] Send `metadata: "string"` → rejected with INVALID_PARAMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-message metadata that travels with messages across the platform.
  * Plugins and transformation hooks can access and modify message metadata during processing.
  * Clients can include metadata when sending session messages; metadata is stored and surfaced in message history.

* **Bug Fixes / Validation**
  * Enhanced validation to ensure metadata is a proper record and attachments are validated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->