### PR TITLE
feat(events): stamp messageId on outbound turn events

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -997,6 +997,11 @@ export class AgentRunner implements SessionRuntime {
       try {
         await this.refreshAgentConfiguration(session);
         session.latestAssistantText = undefined;
+        if (message.messageId !== undefined) {
+          session.currentTurnMessageId = message.messageId;
+        } else {
+          delete session.currentTurnMessageId;
+        }
         if (this.options.langfuse && session.langfuseTurnContext) {
           startTurnTrace(
             this.options.langfuse,
@@ -1172,6 +1177,7 @@ export class AgentRunner implements SessionRuntime {
         tool: toolName,
         toolCallId,
         ...(args !== undefined ? { args } : {}),
+        ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
       });
 
       await this.queueSideEffect(session, async () => {
@@ -2279,6 +2285,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'thinking_delta',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.delta,
+            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
           });
         }
 
@@ -2287,6 +2294,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'thinking_final',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.content,
+            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
           });
         }
 
@@ -2295,6 +2303,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'text_delta',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.delta,
+            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
           });
         }
 
@@ -2370,6 +2379,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'text_final',
             sessionId: session.spec.sessionId,
             text: thinkingText,
+            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
           });
         }
 
@@ -2429,6 +2439,7 @@ export class AgentRunner implements SessionRuntime {
           isError: event.isError,
           ...(publishText ? { text: publishText } : {}),
           ...(resultDetails !== undefined ? { details: resultDetails } : {}),
+          ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
         });
 
         void this.queueSideEffect(session, async () => {
@@ -2502,6 +2513,7 @@ export class AgentRunner implements SessionRuntime {
               type: 'text_final',
               sessionId: session.spec.sessionId,
               text: finalText,
+              ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
             });
           }
 
@@ -2509,6 +2521,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'agent_end',
             sessionId: session.spec.sessionId,
           });
+          delete session.currentTurnMessageId;
         })();
 
         if (this.options.langfuse && session.langfuseTurnContext) {

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2488,6 +2488,8 @@ export class AgentRunner implements SessionRuntime {
 
         });
 
+        const turnMessageId = session.currentTurnMessageId;
+        delete session.currentTurnMessageId;
         void (async () => {
           // For channel-bound sessions, run the channel.message.out@v1
           // transform so plugins can scrub/rewrite outbound text (e.g.
@@ -2513,7 +2515,7 @@ export class AgentRunner implements SessionRuntime {
               type: 'text_final',
               sessionId: session.spec.sessionId,
               text: finalText,
-              ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+              ...(turnMessageId !== undefined ? { messageId: turnMessageId } : {}),
             });
           }
 
@@ -2521,7 +2523,6 @@ export class AgentRunner implements SessionRuntime {
             type: 'agent_end',
             sessionId: session.spec.sessionId,
           });
-          delete session.currentTurnMessageId;
         })();
 
         if (this.options.langfuse && session.langfuseTurnContext) {

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -15,6 +15,10 @@ export interface RunnerSession extends SessionDescriptor {
   idleSummaryTimer: ReturnType<typeof setTimeout> | undefined;
   latestAssistantText: string | undefined;
   lastUserMessageText?: string;
+  /** messageId of the user message that triggered the in-flight turn. Used
+   *  to stamp every outbound event for that turn so callers can dedup on
+   *  retries. Cleared at agent_end. */
+  currentTurnMessageId?: string;
   approvalGate: ApprovalGate;
   status: SessionStatus;
   messageCount: number;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -122,11 +122,11 @@ export const isCallerIdentity = (value: unknown): value is CallerIdentity =>
   typeof value.channelUserId === 'string';
 
 export type OutboundEvent =
-  | { type: 'thinking_delta'; sessionId: string; text: string }
-  | { type: 'thinking_final'; sessionId: string; text: string }
-  | { type: 'text_delta'; sessionId: string; text: string }
-  | { type: 'text_final'; sessionId: string; text: string }
-  | { type: 'tool_call'; sessionId: string; tool: string; toolCallId: string; args?: unknown }
+  | { type: 'thinking_delta'; sessionId: string; text: string; messageId?: string }
+  | { type: 'thinking_final'; sessionId: string; text: string; messageId?: string }
+  | { type: 'text_delta'; sessionId: string; text: string; messageId?: string }
+  | { type: 'text_final'; sessionId: string; text: string; messageId?: string }
+  | { type: 'tool_call'; sessionId: string; tool: string; toolCallId: string; args?: unknown; messageId?: string }
   | {
       type: 'tool_result';
       sessionId: string;
@@ -135,6 +135,7 @@ export type OutboundEvent =
       isError: boolean;
       text?: string;
       details?: unknown;
+      messageId?: string;
     }
   | {
       type: 'tool_approval_required';


### PR DESCRIPTION
## Summary

- Adds optional `messageId` to `text_delta`, `text_final`, `thinking_delta`, `thinking_final`, `tool_call`, and `tool_result` events.
- Stamps each emitted event with the triggering user message's `messageId` so external callers (e.g. amiko-chat) can dedupe on retries.
- Tracked on `RunnerSession.currentTurnMessageId`; set at start of `postMessage` run, cleared at `agent_end`.

Fulfills item #4 of the amiko integration checklist (`/Users/william/Work/twin/amiko-platform/docs/plans/2026-05-08-hermit-chat-integration-checklist.md`).

## Test plan

- [x] Typecheck (baseline 63 errors, unchanged)
- [ ] Verify `messageId` flows through on a live turn
- [ ] Confirm field is omitted when message has no id (no-op for legacy callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Outbound agent events now include the originating user message ID during a turn and clear it at turn end. This fixes event deduplication on retries and prevents events being misattributed across turns; applies to thinking updates, final text, tool calls and results. Improved consistency for clients and integrations in agent-assisted conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->