### PR TITLE
feat(approval): include tool args in approval events

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1759,11 +1759,12 @@ export class AgentRunner implements SessionRuntime {
                     resourceType: 'tool',
                     resourceKey: t.name,
                     toolCallId,
+                    ...(args !== undefined ? { args } : {}),
                     mode: 'async',
                   });
                 }
                 if (notifyOwner) {
-                  notifyOwner(request.id, request.shortId, 'tool', resourceKey, userId, sessionId ?? 'unknown').catch(() => {});
+                  notifyOwner(request.id, request.shortId, 'tool', resourceKey, userId, sessionId ?? 'unknown', args).catch(() => {});
                 }
                 return {
                   content: [{

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1103,10 +1103,10 @@ export class AgentRunner implements SessionRuntime {
     };
   }
 
-  private makeNotifyOwnerApproval(): ((requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>) | undefined {
+  private makeNotifyOwnerApproval(): ((requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string, args?: unknown) => Promise<void>) | undefined {
     if (this.channelOutbound.size === 0) return undefined;
 
-    return async (requestId, shortId, resourceType, resourceKey, requesterId, requesterSessionId) => {
+    return async (requestId, shortId, resourceType, resourceKey, requesterId, requesterSessionId, args) => {
       try {
         const config = await this.options.security.readConfig();
         const notif = config.notifications;
@@ -1140,6 +1140,7 @@ export class AgentRunner implements SessionRuntime {
           resourceKey,
           requesterId,
           requesterSessionId,
+          ...(args !== undefined ? { args } : {}),
           mode: 'async',
         });
 
@@ -1707,6 +1708,7 @@ export class AgentRunner implements SessionRuntime {
                   resourceType: 'tool',
                   resourceKey: t.name,
                   toolCallId,
+                  ...(args !== undefined ? { args } : {}),
                   mode: 'realtime',
                 });
                 void eventBroker.publish({
@@ -1717,6 +1719,7 @@ export class AgentRunner implements SessionRuntime {
                   resourceKey: t.name,
                   requesterId: userId ?? 'unknown',
                   requesterSessionId: sessionId,
+                  ...(args !== undefined ? { args } : {}),
                   mode: 'realtime',
                 });
               }

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -108,6 +108,7 @@ const checkFilePath = async (
   sandboxAlias: string,
   mode: FileMode,
   path: string,
+  args?: unknown,
 ): Promise<void> => {
   if (!context.policyStore || !context.agentId) return;
 
@@ -134,7 +135,7 @@ const checkFilePath = async (
       sandbox: sandboxAlias,
       mode,
       path,
-    });
+    }, args);
   }
 };
 
@@ -147,7 +148,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'read', args.path);
+    await checkFilePath(context, backend.id, 'read', args.path, args);
     const { data } = await backend.files.read(args.path);
     if (data.byteLength > MAX_READ_BYTES && !args.offset && !args.limit) {
       throw new ValidationError(
@@ -201,7 +202,7 @@ export const createFileWriteTool = (context: ToolContext): PolicyAwareTool<typeo
   parameters: FileWriteParams,
   execute: async (_id, args: FileWriteArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'write', args.path);
+    await checkFilePath(context, backend.id, 'write', args.path, args);
     const mode: FileWriteMode = args.mode ?? 'overwrite';
     const encoding = args.encoding ?? 'utf8';
     const data =
@@ -222,7 +223,7 @@ export const createFileListTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileListParams,
   execute: async (_id, args: FileListArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'read', args.path);
+    await checkFilePath(context, backend.id, 'read', args.path, args);
     const entries = await backend.files.list(args.path);
     return {
       content: asTextContent(formatJson(entries)),
@@ -239,7 +240,7 @@ export const createFileStatTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileStatParams,
   execute: async (_id, args: FileStatArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'read', args.path);
+    await checkFilePath(context, backend.id, 'read', args.path, args);
     const stat = await backend.files.stat(args.path);
     return {
       content: asTextContent(stat ? formatJson(stat) : 'null\n'),
@@ -257,7 +258,7 @@ export const createFileEditTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileEditParams,
   execute: async (_id, args: FileEditArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'write', args.path);
+    await checkFilePath(context, backend.id, 'write', args.path, args);
     const { data } = await backend.files.read(args.path);
     const original = data.toString('utf8');
 
@@ -297,7 +298,7 @@ export const createFileDeleteTool = (context: ToolContext): PolicyAwareTool<type
   parameters: FileDeleteParams,
   execute: async (_id, args: FileDeleteArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'write', args.path);
+    await checkFilePath(context, backend.id, 'write', args.path, args);
     await backend.files.delete(args.path);
     return {
       content: asTextContent(`Deleted ${args.path}.\n`),

--- a/apps/agent/src/tools/sandbox-exec.ts
+++ b/apps/agent/src/tools/sandbox-exec.ts
@@ -69,7 +69,7 @@ export const createSandboxExecTool = (
             sandbox: backend.id,
             command: args.command,
             ...(args.cwd ? { cwd: args.cwd } : {}),
-          });
+          }, args);
         }
       }
     }

--- a/apps/agent/src/tools/shared.ts
+++ b/apps/agent/src/tools/shared.ts
@@ -67,7 +67,7 @@ export interface ToolContext {
   hookBus?: import('../events.js').AgentEventBus;
   /** When set, called after an async ApprovalRequest is created to notify
    *  the owner via their configured notification channel. */
-  notifyOwnerApproval?: (requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string) => Promise<void>;
+  notifyOwnerApproval?: (requestId: string, shortId: number, resourceType: string, resourceKey: string, requesterId: string, requesterSessionId: string, args?: unknown) => Promise<void>;
   /** Publish an SSE event to the session's event stream. */
   publishEvent?: (event: Record<string, unknown>) => void;
 }
@@ -118,6 +118,7 @@ export const checkApprovalOrRequest = async (
   resourceType: string,
   resourceKey: string,
   scope?: Record<string, unknown>,
+  args?: unknown,
 ): Promise<void> => {
   if (!context.approvalRequestStore || !context.storeScope || !context.currentUserId) {
     throw new ValidationError(
@@ -180,12 +181,13 @@ export const checkApprovalOrRequest = async (
       requestId: request.id,
       resourceType,
       resourceKey,
+      ...(args !== undefined ? { args } : {}),
       mode: 'async',
     });
   }
 
   if (context.notifyOwnerApproval) {
-    context.notifyOwnerApproval(request.id, request.shortId, resourceType, resourceKey, context.currentUserId, context.sessionId ?? 'unknown').catch(() => {});
+    context.notifyOwnerApproval(request.id, request.shortId, resourceType, resourceKey, context.currentUserId, context.sessionId ?? 'unknown', args).catch(() => {});
   }
 
   throw new ApprovalRequiredError(request.id, resourceType, resourceKey);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -151,6 +151,7 @@ export type OutboundEvent =
       resourceType: string;
       resourceKey: string;
       toolCallId?: string;
+      args?: unknown;
       mode: 'realtime' | 'async';
     }
   | {
@@ -161,6 +162,7 @@ export type OutboundEvent =
       resourceKey: string;
       requesterId: string;
       requesterSessionId: string;
+      args?: unknown;
       mode: 'realtime' | 'async';
     }
   | {


### PR DESCRIPTION
## Summary

- Adds optional \`args?: unknown\` to \`approval_requested\` and \`approval_pending\` events.
- Threads the originating tool call args through \`checkApprovalOrRequest\` + \`notifyOwnerApproval\` and all callers (sandbox-exec, file ops).
- Lets external persisters (e.g. amiko-chat's ApprovalRequest table) render approval UI from a single event — \`resourceType\`/\`resourceKey\` identifies the resource, but the actual payload (Bash command string, file write content, MCP params) lives in args.

Fulfills item #7 of the amiko integration checklist.

## Notes

- \`scope\` (the policy-match predicate, e.g. \`{sandbox, command}\`) is **not** the same as \`args\` — for tool calls like \`file_write\`, scope only carries \`{sandbox, mode, path}\` while args carries the actual content. This PR plumbs args, leaves scope alone.
- Realtime + async (cross-session owner notify) emit sites both stamped.

## Test plan

- [x] Typecheck (baseline 63 errors, unchanged)
- [ ] Trigger a require_approval policy on a Bash command, confirm event carries \`args.command\`
- [ ] Same for file_write, confirm \`args.content\` is in the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval notifications and pending/requested approval events now include tool-call arguments when present, giving owners richer context for review and decision-making.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->