### PR TITLE
fix(group): prefix sender name on resumed user messages

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1895,6 +1895,9 @@ export class AgentRunner implements SessionRuntime {
     const { compactionSummary, entries } =
       await this.store.messages.listSessionEntriesSinceLastCompaction(this.scope, sessionId);
 
+    const session = this.sessions.get(sessionId);
+    const isGroup = session?.spec.source.type === 'group';
+
     const messages: AgentMessage[] = [];
 
     // If there was a previous compaction, inject its summary as a context block.
@@ -1918,7 +1921,11 @@ export class AgentRunner implements SessionRuntime {
 
       if (entry.role === 'user' && typeof entry.content === 'string') {
         lastAssistant = null;
-        messages.push({ role: 'user', content: entry.content, timestamp: ts });
+        const userName = typeof entry.userName === 'string' ? entry.userName : undefined;
+        const content = isGroup && userName
+          ? `[${userName}] ${entry.content}`
+          : entry.content;
+        messages.push({ role: 'user', content, timestamp: ts });
         continue;
       }
 


### PR DESCRIPTION
## Summary

- \`postMessage\` already prefixes \`[name] text\` when handing the current group turn to pi-agent-core, but the resumption-time hydration (\`buildResumptionMessages\`) was loading raw \`entry.content\` — so after any session restart / process reconnect, the model lost speaker context for prior group messages.
- This PR mirrors the same logic at hydration: when the session is a group and the stored entry has \`userName\`, prefix \`[userName] \` on rebuild.
- Storage stays raw; the prefix is purely a prompt-assembly concern.

Also covers the \`appendMessage\` (silent inject) path, since those entries flow through the same hydration on resume.

## Test plan

- [x] Typecheck (baseline 63 errors, unchanged)
- [ ] Run a group session with two users speaking; restart agent; confirm next turn's prompt context shows \`[Alice] ...\` / \`[Bob] ...\` prefixes on prior user messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* When resuming group chat sessions, user messages now display usernames with message content (e.g., "[userName] message") for clearer attribution in group conversations. Individual session resumption remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->