### PR TITLE
chore: bump sdk to 0.3.3, cli to 0.6.4

### DIFF
--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.2",
+    "@openhermit/sdk": "0.3.3",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.2",
+    "@openhermit/sdk": "0.3.3",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.2",
+    "@openhermit/sdk": "0.3.3",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.2",
+    "@openhermit/sdk": "0.3.3",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.2.0",
+        "@openhermit/sdk": "0.3.3",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -61,7 +61,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.2.0",
+        "@openhermit/sdk": "0.3.3",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -71,7 +71,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.2.0",
+        "@openhermit/sdk": "0.3.3",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.2",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +112,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.2.0",
+        "@openhermit/sdk": "0.3.3",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +10973,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch bumps to publish recent additive changes.

- \`@openhermit/sdk\`: 0.3.2 → 0.3.3
- \`openhermit\` (CLI): 0.6.3 → 0.6.4
- Channels (private workspaces) updated to consume sdk@0.3.3.

Includes work merged on main:
- #47 messageId on outbound turn events
- #48 args on approval events
- #49 group sender-name prefix on resumed history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK to version 0.3.3 across Discord, Slack, and Telegram channel integrations
  * CLI updated to version 0.6.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->