### PR TITLE
feat(protocol)!: correlationId + per-event eventId (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.7.0 — 2026-05-09
+
+### Breaking: outbound event identifiers (#51)
+
+The `messageId` field on outbound events `text_delta`, `text_final`, `thinking_delta`, `thinking_final`, `tool_call`, and `tool_result` was misnamed: every event in a turn carried the same value (the inbound user-message id), so consumers persisting events by `messageId` hit unique-key collisions.
+
+- **Renamed** `messageId` → `correlationId` on those six events. Same semantics: the inbound user-message id that triggered the turn.
+- **Added** `eventId: string` to every outbound event. Per-event unique (UUID) — minted by the runtime. Use this for persistence dedup.
+- SDK consumers reading the event stream must update field references (`event.messageId` → `event.correlationId`, plus optionally use `event.eventId`).
+
+`SessionMessage.messageId` (inbound), `ChannelOutboundResult.messageId`, and `channel_message_sent.messageId` are unchanged — those are unrelated identifiers.
+
+---
+
 ## 0.6.2 — 2026-05-07
 
 ### Lazy hydration of agents (#23, #24, #25, #26, #30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0 — 2026-05-09
+## 0.6.5 — 2026-05-09
 
 ### Breaking: outbound event identifiers (#51)
 
@@ -9,6 +9,8 @@ The `messageId` field on outbound events `text_delta`, `text_final`, `thinking_d
 - **Renamed** `messageId` → `correlationId` on those six events. Same semantics: the inbound user-message id that triggered the turn.
 - **Added** `eventId: string` to every outbound event. Per-event unique (UUID) — minted by the runtime. Use this for persistence dedup.
 - SDK consumers reading the event stream must update field references (`event.messageId` → `event.correlationId`, plus optionally use `event.eventId`).
+
+Released as a patch since the SDK is still in 0.x and the misnamed field shipped only one patch ago in 0.3.3.
 
 `SessionMessage.messageId` (inbound), `ChannelOutboundResult.messageId`, and `channel_message_sent.messageId` are unchanged — those are unrelated identifiers.
 

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -998,9 +998,9 @@ export class AgentRunner implements SessionRuntime {
         await this.refreshAgentConfiguration(session);
         session.latestAssistantText = undefined;
         if (message.messageId !== undefined) {
-          session.currentTurnMessageId = message.messageId;
+          session.currentTurnCorrelationId = message.messageId;
         } else {
-          delete session.currentTurnMessageId;
+          delete session.currentTurnCorrelationId;
         }
         if (this.options.langfuse && session.langfuseTurnContext) {
           startTurnTrace(
@@ -1178,7 +1178,7 @@ export class AgentRunner implements SessionRuntime {
         tool: toolName,
         toolCallId,
         ...(args !== undefined ? { args } : {}),
-        ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+        ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
       });
 
       await this.queueSideEffect(session, async () => {
@@ -2296,7 +2296,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'thinking_delta',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.delta,
-            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+            ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
           });
         }
 
@@ -2305,7 +2305,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'thinking_final',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.content,
-            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+            ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
           });
         }
 
@@ -2314,7 +2314,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'text_delta',
             sessionId: session.spec.sessionId,
             text: event.assistantMessageEvent.delta,
-            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+            ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
           });
         }
 
@@ -2390,7 +2390,7 @@ export class AgentRunner implements SessionRuntime {
             type: 'text_final',
             sessionId: session.spec.sessionId,
             text: thinkingText,
-            ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+            ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
           });
         }
 
@@ -2450,7 +2450,7 @@ export class AgentRunner implements SessionRuntime {
           isError: event.isError,
           ...(publishText ? { text: publishText } : {}),
           ...(resultDetails !== undefined ? { details: resultDetails } : {}),
-          ...(session.currentTurnMessageId ? { messageId: session.currentTurnMessageId } : {}),
+          ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
         });
 
         void this.queueSideEffect(session, async () => {
@@ -2499,8 +2499,8 @@ export class AgentRunner implements SessionRuntime {
 
         });
 
-        const turnMessageId = session.currentTurnMessageId;
-        delete session.currentTurnMessageId;
+        const turnCorrelationId = session.currentTurnCorrelationId;
+        delete session.currentTurnCorrelationId;
         void (async () => {
           // For channel-bound sessions, run the channel.message.out@v1
           // transform so plugins can scrub/rewrite outbound text (e.g.
@@ -2526,7 +2526,7 @@ export class AgentRunner implements SessionRuntime {
               type: 'text_final',
               sessionId: session.spec.sessionId,
               text: finalText,
-              ...(turnMessageId !== undefined ? { messageId: turnMessageId } : {}),
+              ...(turnCorrelationId !== undefined ? { correlationId: turnCorrelationId } : {}),
             });
           }
 

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -15,10 +15,11 @@ export interface RunnerSession extends SessionDescriptor {
   idleSummaryTimer: ReturnType<typeof setTimeout> | undefined;
   latestAssistantText: string | undefined;
   lastUserMessageText?: string;
-  /** messageId of the user message that triggered the in-flight turn. Used
-   *  to stamp every outbound event for that turn so callers can dedup on
-   *  retries. Cleared at agent_end. */
-  currentTurnMessageId?: string;
+  /** Inbound messageId of the user message that triggered the in-flight
+   *  turn. Stamped onto every outbound event for that turn as
+   *  `correlationId`, so callers can group events back to the originating
+   *  user message. Cleared at agent_end. */
+  currentTurnCorrelationId?: string;
   approvalGate: ApprovalGate;
   status: SessionStatus;
   messageCount: number;

--- a/apps/agent/src/runtime.ts
+++ b/apps/agent/src/runtime.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'node:crypto';
 import {
   type OutboundEvent,
+  type OutboundEventBody,
   type SessionHistoryMessage,
   type SessionListQuery,
   type SessionMessage,
@@ -124,18 +126,19 @@ export class SessionEventBroker {
     return unsubscribe;
   }
 
-  async publish(event: OutboundEvent): Promise<void> {
+  async publish(event: OutboundEventBody): Promise<void> {
+    const fullEvent: OutboundEvent = { ...event, eventId: randomUUID() };
     const envelope: SessionEventEnvelope = {
       id: this.nextEventId,
-      event,
+      event: fullEvent,
     };
     this.nextEventId += 1;
 
-    const sessionBacklog = this.backlog.get(event.sessionId) ?? [];
+    const sessionBacklog = this.backlog.get(fullEvent.sessionId) ?? [];
     sessionBacklog.push(envelope);
-    this.backlog.set(event.sessionId, sessionBacklog.slice(-100));
+    this.backlog.set(fullEvent.sessionId, sessionBacklog.slice(-100));
 
-    const sessionSubscribers = this.subscribers.get(event.sessionId);
+    const sessionSubscribers = this.subscribers.get(fullEvent.sessionId);
 
     if (!sessionSubscribers) {
       return;

--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.3.4",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.3",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.3.4",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.3",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.3.4",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.3",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.7.0",
+  "version": "0.6.5",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.3.4",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.3",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.3",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -61,7 +61,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.3",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -71,7 +71,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.3",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +112,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.3.3",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +10973,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.3.4",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -61,7 +61,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.3.4",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -71,7 +71,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.3.4",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.7.0",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +112,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.3.4",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +10973,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.4.0",
+      "version": "0.3.4",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -121,12 +121,21 @@ export const isCallerIdentity = (value: unknown): value is CallerIdentity =>
   typeof value.channel === 'string' &&
   typeof value.channelUserId === 'string';
 
-export type OutboundEvent =
-  | { type: 'thinking_delta'; sessionId: string; text: string; messageId?: string }
-  | { type: 'thinking_final'; sessionId: string; text: string; messageId?: string }
-  | { type: 'text_delta'; sessionId: string; text: string; messageId?: string }
-  | { type: 'text_final'; sessionId: string; text: string; messageId?: string }
-  | { type: 'tool_call'; sessionId: string; tool: string; toolCallId: string; args?: unknown; messageId?: string }
+/**
+ * Body of an outbound event without the per-event identifier. Producers emit
+ * this shape; the runtime mints `eventId` before delivering to consumers.
+ *
+ * `correlationId` (where present) is the inbound user-message id that
+ * triggered the turn. It is NOT a per-event id — multiple events in the same
+ * turn share the same `correlationId`. Consumers persisting events by id
+ * MUST use `eventId` (added by the runtime), not `correlationId`.
+ */
+export type OutboundEventBody =
+  | { type: 'thinking_delta'; sessionId: string; text: string; correlationId?: string }
+  | { type: 'thinking_final'; sessionId: string; text: string; correlationId?: string }
+  | { type: 'text_delta'; sessionId: string; text: string; correlationId?: string }
+  | { type: 'text_final'; sessionId: string; text: string; correlationId?: string }
+  | { type: 'tool_call'; sessionId: string; tool: string; toolCallId: string; args?: unknown; correlationId?: string }
   | {
       type: 'tool_result';
       sessionId: string;
@@ -135,7 +144,7 @@ export type OutboundEvent =
       isError: boolean;
       text?: string;
       details?: unknown;
-      messageId?: string;
+      correlationId?: string;
     }
   | {
       type: 'tool_approval_required';
@@ -176,6 +185,8 @@ export type OutboundEvent =
   | { type: 'user_message'; sessionId: string; text: string; name?: string }
   | { type: 'agent_end'; sessionId: string }
   | { type: 'error'; sessionId: string; message: string };
+
+export type OutboundEvent = OutboundEventBody & { eventId: string };
 
 // ── Channel Outbound ──────────────────────────────────────────────────
 
@@ -444,13 +455,13 @@ export const isSessionMessage = (value: unknown): value is SessionMessage => {
 export const createTextFinalEvent = (
   sessionId: string,
   text: string,
-): OutboundEvent => ({
+): OutboundEventBody => ({
   type: 'text_final',
   sessionId,
   text,
 });
 
-export const createAgentEndEvent = (sessionId: string): OutboundEvent => ({
+export const createAgentEndEvent = (sessionId: string): OutboundEventBody => ({
   type: 'agent_end',
   sessionId,
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.4.0",
+  "version": "0.3.4",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #51.

- Rename `messageId` → `correlationId` on outbound events `text_delta`, `text_final`, `thinking_delta`, `thinking_final`, `tool_call`, `tool_result`. Same semantics: the inbound user-message id that triggered the turn.
- Add `eventId: string` (required) to every outbound event. Per-event UUID minted by the runtime. Use this for persistence dedup.
- Rename internal `RunnerSession.currentTurnMessageId` → `currentTurnCorrelationId`.

`SessionMessage.messageId` (inbound), `ChannelOutboundResult.messageId`, and `channel_message_sent.messageId` are unchanged — those are unrelated identifiers (consumer's inbound id and channel-side message ids).

## Versioning

Patch bump (0.x SDK, misnamed field shipped only one patch ago in 0.3.3):

- `@openhermit/sdk` 0.3.3 → **0.3.4**
- `openhermit` (CLI) 0.6.4 → **0.6.5**

## Migration for SDK consumers

\`\`\`diff
-event.messageId
+event.correlationId   // same semantics (turn-grouping)
+event.eventId          // new: per-event unique id
\`\`\`

## Test plan

- [x] protocol/sdk/cli/agent/gateway/channels typecheck (src) — clean
- [ ] Manual: stream a turn, confirm every event has unique \`eventId\` and shared \`correlationId\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Outbound events now carry correlationId instead of messageId.
  * Outbound events include a new per-event eventId for deduplication/persistence.
  * Inbound identifier fields remain unchanged; update any outbound handling accordingly.
  * SDK/package versions bumped (SDK → 0.3.4; CLI package → 0.6.5).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->