### PR TITLE
feat(protocol): add agent_start outbound event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.6 — 2026-05-09
+
+### Outbound `agent_start` event
+
+Added `agent_start` to `OutboundEvent` so SDK consumers see an explicit turn-start signal that mirrors the `agent_start` log entry already written to the message store. Carries `correlationId` (the inbound user-message id, same as the rest of the turn's events). Additive — non-breaking.
+
+---
+
 ## 0.6.5 — 2026-05-09
 
 ### Breaking: outbound event identifiers (#51)

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2280,6 +2280,11 @@ export class AgentRunner implements SessionRuntime {
     switch (event.type) {
       case 'agent_start': {
         const ts = new Date().toISOString();
+        void this.events.publish({
+          type: 'agent_start',
+          sessionId: session.spec.sessionId,
+          ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
+        });
         void this.queueSideEffect(session, async () => {
           await this.store.messages.appendLogEntry(this.scope,session.spec.sessionId, {
             ts,

--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.4",
+    "@openhermit/sdk": "0.3.5",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.4",
+    "@openhermit/sdk": "0.3.5",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.4",
+    "@openhermit/sdk": "0.3.5",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.4",
+    "@openhermit/sdk": "0.3.5",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.4",
+        "@openhermit/sdk": "0.3.5",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -61,7 +61,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.4",
+        "@openhermit/sdk": "0.3.5",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -71,7 +71,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.4",
+        "@openhermit/sdk": "0.3.5",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +112,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.3.4",
+        "@openhermit/sdk": "0.3.5",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +10973,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -183,6 +183,7 @@ export type OutboundEventBody =
       messageId?: string;
     }
   | { type: 'user_message'; sessionId: string; text: string; name?: string }
+  | { type: 'agent_start'; sessionId: string; correlationId?: string }
   | { type: 'agent_end'; sessionId: string }
   | { type: 'error'; sessionId: string; message: string };
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Added \`agent_start\` to the outbound event stream. The pi-agent-core internal \`agent_start\` was already being written to the message store as a log entry, but never published as an \`OutboundEvent\` — so SDK consumers had no explicit turn-start signal and the wire stream was out of sync with what the DB persisted.

- New event: \`{ type: 'agent_start', sessionId, correlationId? }\`
- Carries \`correlationId\` (same as the rest of the turn's events)
- Additive — non-breaking

## Versioning

- \`@openhermit/sdk\` 0.3.4 → **0.3.5**
- \`openhermit\` (CLI) 0.6.5 → **0.6.6**

## Test plan

- [x] protocol/agent typecheck (src) — clean
- [ ] Manual: stream a turn, confirm the first event is \`agent_start\` and last is \`agent_end\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent start events now include session and correlation ID tracking for improved event observability across the system.

* **Updates**
  * CLI updated to v0.6.6
  * SDK updated to v0.3.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->