### PR TITLE
refactor(protocol): drop channel_message_sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.8 — 2026-05-09
+
+### Breaking: drop `channel_message_sent`
+
+Proactive sends from `session_send` were recorded as a synthetic `channel_message_sent` log entry whose `text` field made the row invisible to LLM history replay (which keys off `content`). The wire `OutboundEvent.channel_message_sent` type existed in the protocol but was never published. Both have been removed.
+
+- **Removed** `channel_message_sent` from `OutboundEventBody` (wire). Zero publishers, zero subscribers — pure dead code.
+- **Changed** `session_send` to record deliveries as a normal assistant log entry: `{ role: 'assistant', content: text, metadata: { source: 'session_send', fromSession, channel, to, messageId } }`. The receiver session's LLM history replay now sees proactive sends as ordinary assistant turns.
+- **Added** explicit `metadata?: Record<string, unknown>` slot on `SessionLogEntry`. Existing `[key: string]: unknown` permits it; this just documents the convention so future derivative fields land in `metadata` instead of scattering at the entry root.
+- Migration `0021_drop_channel_message_sent.sql` rewrites existing rows in place: `event_type` becomes `'assistant'`, `text` is folded into `content`, delivery details move under `payload.metadata`.
+
+Released as a patch since the SDK is still in 0.x.
+
+---
+
 ## 0.6.7 — 2026-05-09
 
 ### Breaking: unified approval event naming

--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -308,16 +308,20 @@ export const createSessionSendTool = (context: ToolContext): PolicyAwareTool<typ
       };
     }
 
-    // Record the delivery as a session log entry.
+    // Record the delivery as a normal assistant message in the target session.
+    // Delivery details (source channel, recipient, originating session) live in
+    // metadata so they don't pollute the conversation body.
     await context.messageStore.appendLogEntry(context.storeScope, sessionId, {
       ts: new Date().toISOString(),
       role: 'assistant',
-      type: 'channel_message_sent',
-      channel: outbound.adapter.channel,
-      to: outbound.to,
-      text,
-      messageId: result.messageId,
-      fromSession: context.sessionId,
+      content: text,
+      metadata: {
+        source: 'session_send',
+        ...(context.sessionId ? { fromSession: context.sessionId } : {}),
+        channel: outbound.adapter.channel,
+        to: outbound.to,
+        ...(result.messageId ? { messageId: result.messageId } : {}),
+      },
     });
 
     return {

--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.6",
+    "@openhermit/sdk": "0.3.7",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.6",
+    "@openhermit/sdk": "0.3.7",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.6",
+    "@openhermit/sdk": "0.3.7",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -97,9 +97,9 @@ export class TelegramBridge implements ChannelOutbound {
   /**
    * Send a message to a Telegram chat via the Bot API.
    * Implements `ChannelOutbound.send()`. The caller is responsible for
-   * recording the `channel_message_sent` session event (the tool does this
-   * via the store; the bridge reply path already has the assistant message
-   * recorded by the agent runtime).
+   * recording the assistant log entry in the target session (the tool does
+   * this via the store; the bridge reply path already has the assistant
+   * message recorded by the agent runtime).
    */
   async send(params: { sessionId: string; to: string; text: string; actions?: ChannelMessageAction[] }): Promise<ChannelOutboundResult> {
     const chatId = Number(params.to);

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.6",
+    "@openhermit/sdk": "0.3.7",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -44,7 +44,7 @@ The runtime applies channel-agnostic group behavior:
 
 ## Outbound Messages
 
-Adapters register `ChannelOutbound` implementations. The `session_send` tool can send proactive messages through them, and the runtime records `channel_message_sent`.
+Adapters register `ChannelOutbound` implementations. The `session_send` tool can send proactive messages through them; the delivery is recorded in the target session as a normal assistant log entry whose `metadata.source = 'session_send'` carries the channel/to/messageId/fromSession details.
 
 ## Configuration
 

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -44,7 +44,7 @@ The runtime applies channel-agnostic group behavior:
 
 ## Outbound Messages
 
-Adapters register `ChannelOutbound` implementations. The `session_send` tool can send proactive messages through them; the delivery is recorded in the target session as a normal assistant log entry whose `metadata.source = 'session_send'` carries the channel/to/messageId/fromSession details.
+Adapters register `ChannelOutbound` implementations. The `session_send` tool can send proactive messages through them; the delivery is recorded in the target session as a normal assistant log entry, with `channel`, `to`, `messageId`, and `fromSession` as sibling keys under `metadata` and a `metadata.source = 'session_send'` marker.
 
 ## Configuration
 

--- a/docs/transport-protocol.md
+++ b/docs/transport-protocol.md
@@ -150,7 +150,6 @@ Current event types:
 - `approval_requested` — new request opened (`mode: 'realtime' | 'async'`)
 - `approval_pending` — async-only notification routed to the owner's session
 - `approval_resolved` — request closed (`decision`, optional `resolution`)
-- `channel_message_sent`
 - `user_message`
 - `agent_start`
 - `agent_end`

--- a/docs/user-model.md
+++ b/docs/user-model.md
@@ -148,7 +148,7 @@ Session tools:
 - `session_summary`
 - `session_send`
 
-`session_send` sends proactive messages through registered channel outbound adapters. The delivery is recorded in the target session as a normal assistant log entry, with delivery details (source channel, recipient, messageId, originating session) folded into `metadata.source = 'session_send'`.
+`session_send` sends proactive messages through registered channel outbound adapters. The delivery is recorded in the target session as a normal assistant log entry; delivery details (`channel`, `to`, `messageId`, `fromSession`) are sibling keys under `metadata`, alongside the marker `metadata.source = 'session_send'`.
 
 ## Merge Semantics
 

--- a/docs/user-model.md
+++ b/docs/user-model.md
@@ -148,7 +148,7 @@ Session tools:
 - `session_summary`
 - `session_send`
 
-`session_send` sends proactive messages through registered channel outbound adapters and records `channel_message_sent` events.
+`session_send` sends proactive messages through registered channel outbound adapters. The delivery is recorded in the target session as a normal assistant log entry, with delivery details (source channel, recipient, messageId, originating session) folded into `metadata.source = 'session_send'`.
 
 ## Merge Semantics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.6",
+        "@openhermit/sdk": "0.3.7",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -61,7 +61,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.6",
+        "@openhermit/sdk": "0.3.7",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -71,7 +71,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.6",
+        "@openhermit/sdk": "0.3.7",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +112,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.3.6",
+        "@openhermit/sdk": "0.3.7",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +10973,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -179,14 +179,6 @@ export type OutboundEventBody =
       reviewerId?: string;
       mode: 'realtime' | 'async';
     }
-  | {
-      type: 'channel_message_sent';
-      sessionId: string;
-      channel: string;
-      to: string;
-      text: string;
-      messageId?: string;
-    }
   | { type: 'user_message'; sessionId: string; text: string; name?: string }
   | { type: 'agent_start'; sessionId: string; correlationId?: string }
   | { type: 'agent_end'; sessionId: string }
@@ -211,8 +203,9 @@ export interface ChannelMessageAction {
 
 /**
  * Interface for channel adapters that support outbound (proactive) messaging.
- * Implementations send the message via the channel API and record it as a
- * `channel_message_sent` event in the target session.
+ * Implementations send the message via the channel API. The caller (e.g. the
+ * `session_send` tool) is responsible for recording the delivery as an
+ * assistant log entry in the target session.
  */
 export interface ChannelOutbound {
   readonly channel: string;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/store/drizzle/0021_drop_channel_message_sent.sql
+++ b/packages/store/drizzle/0021_drop_channel_message_sent.sql
@@ -1,0 +1,20 @@
+-- Convert legacy `channel_message_sent` rows into normal assistant messages
+-- with delivery details folded into payload.metadata. This unifies the
+-- conversation-log shape so the LLM history replay path treats proactive
+-- sends just like ordinary assistant turns.
+
+UPDATE session_events
+SET event_type = 'assistant',
+    content = payload->>'text',
+    payload = (payload - 'type' - 'text' - 'fromSession' - 'channel' - 'to' - 'messageId')
+              || jsonb_build_object(
+                'content', payload->>'text',
+                'metadata', jsonb_strip_nulls(jsonb_build_object(
+                  'source', 'session_send',
+                  'fromSession', payload->>'fromSession',
+                  'channel', payload->>'channel',
+                  'to', payload->>'to',
+                  'messageId', payload->>'messageId'
+                ))
+              )
+WHERE event_type = 'channel_message_sent';

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778800000000,
       "tag": "0020_approval_event_rename",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778900000000,
+      "tag": "0021_drop_channel_message_sent",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -135,6 +135,12 @@ export interface SessionLogEntry {
   ts: string;
   role: 'system' | 'user' | 'assistant' | 'tool_call' | 'tool_result' | 'error';
   type?: string;
+  /**
+   * Free-form metadata bag for derivative info that isn't part of the message
+   * body itself (delivery source, action affordances, etc.). Prefer placing
+   * non-core fields here over scattering them on the entry root.
+   */
+  metadata?: Record<string, unknown>;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

- Drop `channel_message_sent` from `OutboundEventBody` — zero publishers, zero subscribers, pure dead type
- `session_send` now records deliveries as a normal assistant log entry with delivery details under `metadata.source = 'session_send'`
- Formalize `metadata?: Record<string, unknown>` on `SessionLogEntry` (existing `[key: string]: unknown` already permitted it; this documents the convention)
- Migration `0021_drop_channel_message_sent.sql` rewrites existing rows: `event_type` → `'assistant'`, `text` → `content`, delivery fields fold into `payload.metadata`

## Why

Today's `channel_message_sent` rows are written with `text` (not `content`), so `deriveContent` returns `null` and `listHistoryMessages` filters them out — proactive sends are invisible to LLM history replay on the receiver session. Switching to `role: 'assistant', content: text` fixes that: a session_send'd message is now part of the receiver's conversation history, exactly like a normal assistant turn.

The wire `channel_message_sent` event type was carried in protocol but never published anywhere, so dropping it has no real consumers to break.

This also unifies the message shape (`role + content + metadata`) ahead of the upcoming async-approval-on-web work, where owner notifications need to render as `message + actions` in the web UI.

## Versions

- `openhermit` 0.6.7 → 0.6.8
- `@openhermit/sdk` 0.3.6 → 0.3.7
- channel adapters' SDK pin updated

## Test plan

- [ ] Run migration `0021` against staging DB; verify existing `channel_message_sent` rows convert to `event_type = 'assistant'` with `content` populated
- [ ] `session_send` from one session writes a row visible in receiver's `/history`
- [ ] Receiver's next agent turn sees the proactive message in LLM context
- [ ] Telegram bridge unaffected (channel adapter API surface unchanged)
- [ ] No breakage of existing realtime/async approval flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the outbound channel message event
  * Proactive sends now persist as normal assistant session log entries with delivery metadata
  * Added an optional per-entry metadata field to session logs

* **Documentation**
  * Updated outbound messaging, transport protocol, and user model docs to reflect the new delivery/logging behavior

* **Chores**
  * Bumped SDK to 0.3.7 and CLI to 0.6.8
  * Added a database migration to convert existing message events

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->