### PR TITLE
feat(file_read): bypass policy + truncation for skill paths

### DIFF
--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { Type, type Static } from '@mariozechner/pi-ai';
 import { ValidationError } from '@openhermit/shared';
 
@@ -105,9 +107,12 @@ const MAX_READ_BYTES = 5 * 1024 * 1024;
  * to contain `.openhermit/skills/` (e.g. a user-supplied workspace tree)
  * doesn't silently inherit the bypass.
  */
-const isSkillPath = (backend: ExecBackend, path: string): boolean => {
+const isSkillPath = (backend: ExecBackend, rawPath: string): boolean => {
+  if (!path.posix.isAbsolute(rawPath)) return false;
+  const normalized = path.posix.normalize(rawPath);
+  if (normalized.split('/').includes('..')) return false;
   const skillsRoot = `${backend.agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
-  return path.startsWith(skillsRoot);
+  return normalized.startsWith(skillsRoot);
 };
 
 const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
@@ -160,7 +165,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   name: 'file_read',
   label: 'Read File',
   description:
-    'Read a file from a sandbox by absolute path. Use offset (1-based line number) and limit (line count) to read a range of lines from large files. Returns text by default; use encoding=base64 for binary files. Hard cap of 5 MiB.',
+    'Read a file from a sandbox by absolute path. Use offset (1-based line number) and limit (line count) to read a range of lines from large files. Returns text by default; use encoding=base64 for binary files. Hard cap of 5 MiB (skill files under <agentHome>/.openhermit/skills/ are exempt and bypass file policies).',
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -165,7 +165,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   name: 'file_read',
   label: 'Read File',
   description:
-    'Read a file from a sandbox by absolute path. Use offset (1-based line number) and limit (line count) to read a range of lines from large files. Returns text by default; use encoding=base64 for binary files. Hard cap of 5 MiB (skill files under <agentHome>/.openhermit/skills/ are exempt and bypass file policies).',
+    'Read a file from a sandbox by absolute path. Use offset (1-based line number) and limit (line count) to read a range of lines from large files. Returns text by default; use encoding=base64 for binary files. Hard cap of 5 MiB.',
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -100,11 +100,15 @@ const MAX_READ_BYTES = 5 * 1024 * 1024;
  * commonly forbid reads under `~/.openhermit/`, so without an exception the
  * agent gets blocked and can't follow its own SKILL.md instructions.
  *
- * Treat any path containing the `/.openhermit/skills/` segment as a skill
- * read: bypass the file-policy check and the size/result truncation caps.
+ * Anchor the check to the backend's agentHome rather than matching the
+ * substring anywhere in the path — that way an unrelated path that happens
+ * to contain `.openhermit/skills/` (e.g. a user-supplied workspace tree)
+ * doesn't silently inherit the bypass.
  */
-const isSkillPath = (path: string): boolean =>
-  path.includes('/.openhermit/skills/');
+const isSkillPath = (backend: ExecBackend, path: string): boolean => {
+  const skillsRoot = `${backend.agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
+  return path.startsWith(skillsRoot);
+};
 
 const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
   if (!context.execBackendManager) {
@@ -160,7 +164,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    const skillRead = isSkillPath(args.path);
+    const skillRead = isSkillPath(backend, args.path);
     if (!skillRead) {
       await checkFilePath(context, backend.id, 'read', args.path, args);
     }

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -94,6 +94,18 @@ type FileDeleteArgs = Static<typeof FileDeleteParams>;
 /** 5 MiB. Beyond this, results blow the model context budget. */
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 
+/**
+ * Skill files live under `<agentHome>/.openhermit/skills/` and are required
+ * reading for the agent to actually use a skill. Path-based file policies
+ * commonly forbid reads under `~/.openhermit/`, so without an exception the
+ * agent gets blocked and can't follow its own SKILL.md instructions.
+ *
+ * Treat any path containing the `/.openhermit/skills/` segment as a skill
+ * read: bypass the file-policy check and the size/result truncation caps.
+ */
+const isSkillPath = (path: string): boolean =>
+  path.includes('/.openhermit/skills/');
+
 const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
   if (!context.execBackendManager) {
     throw new ValidationError('File tools are unavailable: no execution backend configured for this agent.');
@@ -148,9 +160,12 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    await checkFilePath(context, backend.id, 'read', args.path, args);
+    const skillRead = isSkillPath(args.path);
+    if (!skillRead) {
+      await checkFilePath(context, backend.id, 'read', args.path, args);
+    }
     const { data } = await backend.files.read(args.path);
-    if (data.byteLength > MAX_READ_BYTES && !args.offset && !args.limit) {
+    if (!skillRead && data.byteLength > MAX_READ_BYTES && !args.offset && !args.limit) {
       throw new ValidationError(
         `File is ${data.byteLength.toLocaleString()} bytes; exceeds the ${MAX_READ_BYTES.toLocaleString()} byte cap. Use offset/limit to read a range, or exec for very large files.`,
       );
@@ -160,7 +175,9 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
     if (encoding === 'base64') {
       const content = data.toString('base64');
       return {
-        content: asTextContent(content),
+        content: skillRead
+          ? [{ type: 'text' as const, text: content }]
+          : asTextContent(content),
         details: { path: args.path, sandbox: backend.id, size: data.byteLength, encoding },
       };
     }
@@ -180,7 +197,9 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
       .join('\n');
 
     return {
-      content: asTextContent(numbered),
+      content: skillRead
+        ? [{ type: 'text' as const, text: numbered }]
+        : asTextContent(numbered),
       details: {
         path: args.path,
         sandbox: backend.id,

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -200,15 +200,16 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
     const endIdx = args.limit != null ? Math.min(startIdx + args.limit, totalLines) : totalLines;
     const selectedLines = allLines.slice(startIdx, endIdx);
 
-    // Number each line so the agent can reference positions.
-    const numbered = selectedLines
-      .map((line, i) => `${startIdx + i + 1}\t${line}`)
-      .join('\n');
+    // Number each line so the agent can reference positions. Skill files are
+    // returned verbatim — line numbers would just be noise in SKILL.md.
+    const rendered = skillRead
+      ? selectedLines.join('\n')
+      : selectedLines.map((line, i) => `${startIdx + i + 1}\t${line}`).join('\n');
 
     return {
       content: skillRead
-        ? [{ type: 'text' as const, text: numbered }]
-        : asTextContent(numbered),
+        ? [{ type: 'text' as const, text: rendered }]
+        : asTextContent(rendered),
       details: {
         path: args.path,
         sandbox: backend.id,


### PR DESCRIPTION
## Summary
- \`file_read\` on paths containing \`/.openhermit/skills/\` now skips the file-policy check and size/result truncation caps.
- Reason: file policies frequently forbid \`~/.openhermit\` reads, which silently breaks every installed skill (the agent literally can't open its own SKILL.md). And SKILL.md content lives in the agent's working set — truncating it mid-instruction makes skills unreliable.

## Test plan
- [ ] Add a deny-all file policy under \`~/.openhermit\`; agent can still file_read \`<home>/.openhermit/skills/<id>/SKILL.md\`
- [ ] Read a >5 MiB file under skills/ → returns full content (no cap error)
- [ ] Read a >256 KB file under skills/ → returned text is not truncated with the \`[truncated: …]\` marker
- [ ] Reads outside skills/ still hit policy + caps as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local skill files can be read without file-policy enforcement and without the previous 5 MiB size cap for normal reads.
  * Skill file reads return content as explicit text-item structures for both encoded and text reads.
  * For line-range reads, skill files return verbatim lines (no line-number prefixes); non-skill reads keep numbered lines.
  * No public API declarations changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/57)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->