### PR TITLE
feat(mcp): expand ${{SECRET}} placeholders in MCP server headers

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -236,12 +236,31 @@ export class AgentRunner implements SessionRuntime {
       await this.mcpClientManager.disconnectAll();
       this.mcpClientManager = undefined;
     }
-    const mcpServers = await this.options.mcpServerStore.listEnabled(this.scope.agentId);
+    const mcpServers = await this.loadEnabledMcpServers();
     if (mcpServers.length > 0) {
       this.mcpClientManager = new McpClientManager();
       this.mcpClientManager.connectAll(mcpServers);
     }
     this.logRuntime(`mcp: reloading (${mcpServers.length} server(s) enabled, connecting in background)`);
+  }
+
+  /**
+   * Load enabled MCP servers for this agent and resolve `${{SECRET}}`
+   * placeholders in their headers against the agent's secret store. Lets
+   * operators store an MCP server config like
+   * `Authorization: Bearer ${{MY_API_TOKEN}}` and have each agent supply
+   * its own token at connect time.
+   */
+  private async loadEnabledMcpServers() {
+    if (!this.options.mcpServerStore) return [];
+    const servers = await this.options.mcpServerStore.listEnabled(this.scope.agentId);
+    return Promise.all(
+      servers.map(async (server) =>
+        server.headers
+          ? { ...server, headers: await this.options.security.expandSecrets(server.headers) }
+          : server,
+      ),
+    );
   }
 
   /** Register a channel outbound adapter (called after channel startup). */
@@ -1746,7 +1765,7 @@ export class AgentRunner implements SessionRuntime {
       if (this.options.mcpServerStore) {
         if (!this.mcpClientManager) {
           this.mcpClientManager = new McpClientManager();
-          const mcpServers = await this.options.mcpServerStore.listEnabled(this.scope.agentId);
+          const mcpServers = await this.loadEnabledMcpServers();
           if (mcpServers.length > 0) {
             // Fire-and-forget: connections proceed in the background. The
             // current turn will only see tools from servers that have


### PR DESCRIPTION
## Summary
- MCP server `headers` JSON now supports `\${{SECRET_NAME}}` placeholders, resolved per-agent at connect time using the same `AgentSecurity.expandSecrets` mechanism agent runtime config uses.
- Lets one shared MCP server row work across agents — each agent supplies its own token via its own secrets (e.g. `Authorization: Bearer \${{MY_API_TOKEN}}`).

## Test plan
- [ ] Register an MCP server with `{"Authorization": "Bearer \${{TEST_MCP_TOKEN}}"}` headers.
- [ ] Set `TEST_MCP_TOKEN` in agent A's secrets, leave agent B's unset.
- [ ] Confirm A connects with the resolved token; B's request goes out with the literal `\${{TEST_MCP_TOKEN}}` (unknown placeholder is left as-is, matching existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server headers now support `${{SECRET}}` placeholders that are dynamically expanded using secrets from the agent's secret store during server initialization and reloads, enabling secure credential management for integrations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->