### PR TITLE
feat(openrouter): identify requests as OpenHermit via attribution headers

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -55,6 +55,7 @@ import {
   type LangfuseTurnContext,
   startTurnTrace,
 } from './langfuse.js';
+import { withOpenRouterAttribution } from './agent-runner/openrouter-attribution.js';
 import { type Caller, type SessionDescriptor, SessionEventBroker, type SessionRuntime } from './runtime.js';
 export type { SessionEventEnvelope } from './runtime.js';
 import {
@@ -2007,7 +2008,7 @@ export class AgentRunner implements SessionRuntime {
       : baseSystemPrompt;
     const streamFn = createLangfuseTracedStreamFn(
       this.options.langfuse,
-      this.options.streamFn,
+      withOpenRouterAttribution(this.options.streamFn),
       input.langfuseTurnContext ?? { currentTrace: undefined },
     );
 

--- a/apps/agent/src/agent-runner/openrouter-attribution.ts
+++ b/apps/agent/src/agent-runner/openrouter-attribution.ts
@@ -1,0 +1,32 @@
+import type { StreamFn } from '@mariozechner/pi-agent-core';
+import { streamSimple } from '@mariozechner/pi-ai';
+
+const OPENROUTER_REFERER = 'https://openhermit.ai';
+const OPENROUTER_TITLE = 'OpenHermit';
+
+/**
+ * Wrap a stream function so that requests routed through OpenRouter carry
+ * the app-attribution headers OpenRouter uses for its dashboard / app
+ * leaderboard. See https://openrouter.ai/docs/api/reference/overview#headers
+ *
+ * No-op for non-OpenRouter providers. User-supplied headers in
+ * `options.headers` override the defaults so callers can customize when
+ * embedding OpenHermit elsewhere.
+ */
+export const withOpenRouterAttribution = (baseStreamFn: StreamFn | undefined): StreamFn => {
+  const next = baseStreamFn ?? streamSimple;
+  return async (model, context, options) => {
+    if (model.provider !== 'openrouter') {
+      return next(model, context, options);
+    }
+    const merged = {
+      ...(options ?? {}),
+      headers: {
+        'HTTP-Referer': OPENROUTER_REFERER,
+        'X-OpenRouter-Title': OPENROUTER_TITLE,
+        ...(options?.headers ?? {}),
+      },
+    };
+    return next(model, context, merged);
+  };
+};

--- a/apps/agent/test/openrouter-attribution.test.ts
+++ b/apps/agent/test/openrouter-attribution.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { StreamFn } from '@mariozechner/pi-agent-core';
+
+import { withOpenRouterAttribution } from '../src/agent-runner/openrouter-attribution.js';
+
+type StreamArgs = Parameters<StreamFn>;
+
+const makeSpy = () => {
+  const calls: StreamArgs[] = [];
+  const fn: StreamFn = (async (...args: StreamArgs) => {
+    calls.push(args);
+    return { result: async () => ({} as never) } as never;
+  }) as StreamFn;
+  return { fn, calls };
+};
+
+const model = (provider: string) => ({ provider }) as Parameters<StreamFn>[0];
+const context = {} as Parameters<StreamFn>[1];
+
+test('non-openrouter providers pass through untouched', async () => {
+  const spy = makeSpy();
+  const wrapped = withOpenRouterAttribution(spy.fn);
+
+  await wrapped(model('anthropic'), context, { temperature: 0.5 });
+
+  assert.equal(spy.calls.length, 1);
+  assert.deepEqual(spy.calls[0]?.[2], { temperature: 0.5 });
+});
+
+test('openrouter requests get default attribution headers', async () => {
+  const spy = makeSpy();
+  const wrapped = withOpenRouterAttribution(spy.fn);
+
+  await wrapped(model('openrouter'), context, undefined);
+
+  const forwarded = spy.calls[0]?.[2];
+  assert.deepEqual(forwarded?.headers, {
+    'HTTP-Referer': 'https://openhermit.ai',
+    'X-OpenRouter-Title': 'OpenHermit',
+  });
+});
+
+test('caller-supplied headers override the defaults', async () => {
+  const spy = makeSpy();
+  const wrapped = withOpenRouterAttribution(spy.fn);
+
+  await wrapped(model('openrouter'), context, {
+    headers: { 'X-OpenRouter-Title': 'CustomEmbed', 'X-Trace-Id': 'abc' },
+  });
+
+  const forwarded = spy.calls[0]?.[2];
+  assert.deepEqual(forwarded?.headers, {
+    'HTTP-Referer': 'https://openhermit.ai',
+    'X-OpenRouter-Title': 'CustomEmbed',
+    'X-Trace-Id': 'abc',
+  });
+});


### PR DESCRIPTION
## Summary
- Wraps the agent's `streamFn` with `withOpenRouterAttribution`, which injects `HTTP-Referer: https://openhermit.ai` and `X-OpenRouter-Title: OpenHermit` for `provider=openrouter` requests.
- No-op for all other providers. User-supplied `options.headers` still override the defaults.
- Source: https://openrouter.ai/docs/api/reference/overview#headers

## Test plan
- [ ] Run an agent against an OpenRouter model; confirm requests appear under OpenHermit on OpenRouter's app dashboard.
- [ ] Confirm requests against non-OpenRouter providers (anthropic / openai) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced attribution for OpenRouter model requests by adding default HTTP headers for clearer source/title annotation while preserving caller-supplied headers and leaving other providers unaffected.
* **Tests**
  * Added tests validating header behavior for OpenRouter and non-OpenRouter requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/59)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->