### PR TITLE
fix(agent): assign guest membership for cross-agent known senders

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1523,9 +1523,23 @@ export class AgentRunner implements SessionRuntime {
     );
     if (existingUserId) {
       const user = await this.store.users.get(existingUserId);
-      const role = await this.store.users.getAgentRole(this.scope, existingUserId) ?? 'guest';
       if (user) {
-        return { userId: user.userId, role, ...(user.name ? { userName: user.name } : {}) };
+        const explicitRole = await this.store.users.getAgentRole(this.scope, existingUserId);
+        if (explicitRole) {
+          return { userId: user.userId, role: explicitRole, ...(user.name ? { userName: user.name } : {}) };
+        }
+        // Globally-known user with no role on THIS agent. Mirror
+        // resolveSessionUser: public agents auto-claim a guest
+        // membership; protected/private agents deny.
+        const accessLevel = this.options.security.getAccessLevel();
+        if (accessLevel !== 'public') {
+          this.logRuntime(
+            `denied known user ${existingUserId} on ${accessLevel} agent ${this.scope.agentId} — no membership row`,
+          );
+          return {};
+        }
+        await this.store.users.assignAgent(this.scope, existingUserId, 'guest', now);
+        return { userId: user.userId, role: 'guest', ...(user.name ? { userName: user.name } : {}) };
       }
     }
 


### PR DESCRIPTION
## Summary
`resolveMessageSender` resolved globally-known users without ever calling `assignAgent`, so a sender visiting a public agent from another agent (e.g. an amiko bridge sender who is the owner of a different agent) would land in `session_events` but never appear in the destination agent's `user_agents` member list.

This mirrors the behavior already implemented in `resolveSessionUser` (agent-runner.ts:1433-1444):
- Globally-known user with no role on this agent + `access=public` → auto-claim `guest` membership.
- Same situation on `protected` / `private` → deny (return no userId) so the message is dropped at the runtime boundary instead of silently admitted.
- Globally-known user with an explicit role → return that role (was previously coerced to `guest` via `?? 'guest'`, masking role rows).

## Repro (live)
On the production gateway, session `amiko:cmp0tgk53000004lb3fxn128n` on agent `Zero` (public): `session_events.user_id = usr-4ff040f9e222` (Mr Twelve, owner of a different agent) but no row in `user_agents` for that agent. After this fix, the next message would auto-claim a guest row.

## Test plan
- [ ] User A (owner of agent A) sends a message to public agent B via a shared channel → user A appears as `guest` in agent B's `user_agents`
- [ ] User A sends a message to `protected` agent B → message dropped, no `user_agents` row written
- [ ] User who already has an explicit role on agent B keeps that role (not silently coerced to guest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access control for users without assigned roles on agents based on agent privacy settings. Private agents now deny access to unassigned users for enhanced security. Public agents continue granting guest-level access. This improves alignment between user roles and agent visibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->