### PR TITLE
fix(mcp): owner-only MCP defaults; pause sandboxes after 5 min idle

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -329,7 +329,7 @@ export class AgentRunner implements SessionRuntime {
       return;
     }
 
-    const timeoutMs = (lifecycle?.idle_timeout_minutes ?? 30) * 60_000;
+    const timeoutMs = (lifecycle?.idle_timeout_minutes ?? 5) * 60_000;
 
     this.workspaceIdleTimer = setTimeout(() => {
       this.workspaceIdleTimer = undefined;

--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -173,7 +173,7 @@ export const buildDefaultAgentConfig = (workspaceRoot: string): AgentRuntimeConf
     lifecycle: {
       start: 'ondemand',
       stop: 'idle',
-      idle_timeout_minutes: 30,
+      idle_timeout_minutes: 5,
     },
   },
   web: { provider: 'defuddle' },

--- a/apps/agent/src/mcp-client.ts
+++ b/apps/agent/src/mcp-client.ts
@@ -2,9 +2,8 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { Type } from '@mariozechner/pi-ai';
-import type { AgentTool } from '@mariozechner/pi-agent-core';
 import type { McpServerRecord } from '@openhermit/store';
-import { asTextContent, type Toolset } from './tools/shared.js';
+import { asTextContent, type PolicyAwareTool, type Toolset } from './tools/shared.js';
 
 export type McpConnectionStatusValue = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -128,7 +127,7 @@ export class McpClientManager {
     for (const state of this.connections.values()) {
       if (state.status !== 'connected' || state.tools.length === 0) continue;
 
-      const tools: AgentTool<any>[] = state.tools.map((mcpTool) =>
+      const tools: PolicyAwareTool[] = state.tools.map((mcpTool) =>
         this.adaptTool(state, mcpTool),
       );
 
@@ -156,10 +155,13 @@ export class McpClientManager {
     return this.connections.has(serverId);
   }
 
-  private adaptTool(state: McpConnectionState, mcpTool: McpToolInfo): AgentTool<any> {
+  private adaptTool(state: McpConnectionState, mcpTool: McpToolInfo): PolicyAwareTool {
     const toolName = `mcp__${state.serverId}__${mcpTool.name}`;
 
     return {
+      // MCP tools default to owner-only. Owner must explicitly grant
+      // wider access via tool/mcp policy rows (per-tool or per-server).
+      policy: { defaultGrants: [{ type: 'role', value: 'owner' }] },
       name: toolName,
       label: `[${state.serverName}] ${mcpTool.name}`,
       description: mcpTool.description ?? `MCP tool from ${state.serverName}`,

--- a/apps/agent/src/tools/mcp.ts
+++ b/apps/agent/src/tools/mcp.ts
@@ -15,7 +15,7 @@ const McpDisableParams = Type.Object({
 export const createMcpStatusTool = (
   mcpClientManager: McpClientManager,
 ): PolicyAwareTool<any> => ({
-  policy: { defaultGrants: [{ type: 'any' }] },
+  policy: { defaultGrants: [{ type: 'role', value: 'owner' }, { type: 'role', value: 'user' }] },
   name: 'mcp_status',
   label: 'MCP Status',
   description: 'View the connection status of all MCP servers, including available tools and errors.',

--- a/docs/sandbox-model.md
+++ b/docs/sandbox-model.md
@@ -151,7 +151,7 @@ The agent config's `exec.lifecycle` block controls when a backend is brought up 
     "lifecycle": {
       "start": "ondemand",
       "stop": "idle",
-      "idle_timeout_minutes": 30
+      "idle_timeout_minutes": 5
     }
   }
 }

--- a/skills/openhermit-usage/SKILL.md
+++ b/skills/openhermit-usage/SKILL.md
@@ -93,7 +93,7 @@ Exec:
     "lifecycle": {
       "start": "ondemand",
       "stop": "idle",
-      "idle_timeout_minutes": 30
+      "idle_timeout_minutes": 5
     }
   }
 }


### PR DESCRIPTION
## Summary
- MCP tools: declare `owner` defaultGrants on every adapted MCP tool so guests on public agents can no longer invoke arbitrary MCP tools (4fd52a6).
- `mcp_status` built-in tool: switch from OPEN to owner+user defaultGrants — was the one MCP-related tool still falling through to `{ type: 'any' }` (b58d545).
- Sandbox lifecycle: drop default `exec.lifecycle.idle_timeout_minutes` from 30 → 5 (bfb5597). E2B sandboxes have a 1h absolute lifetime on each create/connect; pausing earlier means the platform doesn't kill them out from under us (rootfs lost, installed deps gone). 5 min idle → `sandbox.pause()` → next session resumes the same sandbox with a fresh 1h timer.

Investigated against a real Telegram session (`telegram:2026-05-11-38b943d8`) where Sophie's sandbox was killed by E2B at the 1h mark mid-conversation, dropping `noni` build artifacts and `apt install`ed packages.

## Test plan
- [ ] Deploy, verify a fresh agent's config defaults reflect 5-minute idle timeout
- [ ] Confirm guest role on a public agent no longer sees MCP tools in tool list
- [ ] Trigger a sandbox idle longer than 5 minutes and verify the sandbox row flips to paused (not killed) and resumes on next message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP tools now enforce stricter default access policies, restricting usage to authorized roles.
* **Chores**
  * Default workspace idle shutdown timeout reduced from 30 to 5 minutes.
* **Documentation**
  * Lifecycle examples updated to reflect the 5-minute idle timeout.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->