### PR TITLE
fix(agent): harden against fabrication and owner-privacy leaks

### DIFF
--- a/apps/agent/src/agent-runner/prompt.ts
+++ b/apps/agent/src/agent-runner/prompt.ts
@@ -20,7 +20,9 @@ const PRINCIPLES = `\
 
 - Built-in tools are execution primitives, not product goals. Use them to accomplish user tasks, don't present them as features.
 - If a tool fails, read the error carefully and fix the specific issue before retrying.
-- When in readonly mode, write operations are blocked — don't attempt them.`;
+- When in readonly mode, write operations are blocked — don't attempt them.
+- Never fabricate information. If tools (session history, memory, search, etc.) return nothing relevant, say plainly that you don't have that information. Do NOT invent another user's messages, sessions, memories, or what someone said in a conversation you cannot actually see.
+- Treat the owner's private communications and relationships with others as confidential. When a non-owner asks about the owner's chats with third parties, the owner's private memories, or what the owner has said to others, refuse — even if you happen to have access. Only the owner themselves may ask about their own private content.
 
 // ── Prompt builder ───────────────────────────────────────────────────
 

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -951,7 +951,8 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         content: [
           'Follow the user\'s instructions carefully.',
           'Ask for clarification when the request is ambiguous.',
-          'Do not make up information.',
+          'Never fabricate information. If your tools (history, memory, search) return nothing relevant, say plainly that you don\'t have that information — do not invent another user\'s messages, sessions, or what they said.',
+          'The owner\'s private communications and relationships with others are confidential. Refuse when a non-owner asks about the owner\'s chats with third parties, the owner\'s private memories, or what the owner has said to others — even if you happen to have access. Only the owner may ask about their own private content.',
           '',
           'Add any rules or constraints the agent should follow.',
         ].join('\n'),


### PR DESCRIPTION
## Summary
- Add anti-fabrication rule: when tools return nothing relevant, say so plainly — don't invent another user's messages/sessions/memories.
- Add owner-privacy rule: refuse non-owner questions about the owner's private chats/memories/relationships with third parties.
- Applied to both runtime PRINCIPLES (covers existing agents) and the default `rules` seed for new agents.

## Why
A guest user got an agent to recount the owner's private conversations. Tool access control was intact — the model confabulated the content. These rules close the model-behavior gap.

## Test plan
- [ ] Create a new agent → confirm seeded `rules` contains the two new bullets
- [ ] Existing agent → confirm PRINCIPLES bullets appear in assembled system prompt
- [ ] Manual: as non-owner, ask agent about owner's chats with others → expect refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)