### PR TITLE
fix(agent): always register identity link toolset

### DIFF
--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -59,8 +59,6 @@ export const createBuiltInToolsets = (
   }
   if (context.userStore) {
     toolsets.push(createUserToolset(context));
-  }
-  if (context.userStore && context.currentUserId && context.currentChannel && context.currentChannelUserId) {
     toolsets.push(createIdentityToolset(context));
   }
   if (context.sessionStore) {


### PR DESCRIPTION
## Summary
- Remove the `currentChannel` / `currentChannelUserId` gate on `identity_link_request` / `identity_link_confirm` registration.
- These tools must be available to every user; channel context is validated inside the tool at execute time (returns a clear `ValidationError`) instead of making the tool vanish from the model's tool list.

## Why
On amiko sessions where session-level channel resolution didn't populate `resolvedChannel` / `resolvedChannelUserId`, the identity tools disappeared entirely and the agent surfaced a generic "Tool not found" error to the owner trying to run `identity_link_confirm`. Exposing the tool and surfacing a real validation error is strictly better UX.

## Test plan
- [ ] Owner can call `identity_link_confirm` from an amiko session.
- [ ] Missing channel context still yields a clear error message rather than a silent disappearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved condition handling for tool availability to ensure tools are only accessible when required context is present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->