### PR TITLE
feat(gateway): support preset name in per-agent sandbox create

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2861,11 +2861,27 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     await requireOwnerOrAdmin(c, agentId);
     const body = await c.req.json<{
       alias?: string;
+      preset?: string;
       type?: string;
       config?: Record<string, unknown>;
     }>();
     const alias = body.alias ?? 'default';
-    const type = body.type;
+    let type: string | undefined;
+    let config: Record<string, unknown> | undefined;
+    if (typeof body.preset === 'string') {
+      const presets = options.sandboxPresets ?? {};
+      const preset = presets[body.preset];
+      if (!preset) {
+        throw new ValidationError(
+          `Unknown sandbox preset "${body.preset}". Known: ${Object.keys(presets).join(', ') || '(none)'}`,
+        );
+      }
+      type = preset.type;
+      config = preset.config;
+    } else {
+      type = body.type;
+      config = body.config;
+    }
     if (type !== 'host' && type !== 'docker' && type !== 'e2b' && type !== 'daytona') {
       throw new ValidationError(`Invalid sandbox type: ${type}`);
     }
@@ -2884,7 +2900,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       agentId,
       alias,
       type,
-      ...(body.config ? { config: body.config } : {}),
+      ...(config ? { config } : {}),
     });
     return c.json(row, 201);
   });


### PR DESCRIPTION
## Summary
- `POST /api/agents/:agentId/sandboxes` now accepts `{"preset": "<name>"}` and resolves against `sandboxPresets`, mirroring the agent-create flow.
- Inline `{"type", "config"}` is still supported when no `preset` is given.

## Why
Attaching a fresh sandbox to an existing agent required duplicating the preset's `type` and `config` inline. With this change, operators can just say `{"preset":"amiko-e2b"}`.

## Test plan
- [ ] `POST /api/agents/:id/sandboxes` with `{"preset":"amiko-e2b"}` creates an e2b sandbox using the preset's config.
- [ ] Unknown preset name returns a 400 ValidationError listing known names.
- [ ] Existing `{"type","config"}` callers still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preset support to sandbox creation. Users can now specify a named preset to automatically apply pre-configured type and configuration parameters, or continue providing type and config directly. Invalid preset names will be rejected with validation errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->