### PR TITLE
fix(agent): close PRINCIPLES template literal

### DIFF
--- a/apps/agent/src/agent-runner/prompt.ts
+++ b/apps/agent/src/agent-runner/prompt.ts
@@ -22,7 +22,7 @@ const PRINCIPLES = `\
 - If a tool fails, read the error carefully and fix the specific issue before retrying.
 - When in readonly mode, write operations are blocked — don't attempt them.
 - Never fabricate information. If tools (session history, memory, search, etc.) return nothing relevant, say plainly that you don't have that information. Do NOT invent another user's messages, sessions, memories, or what someone said in a conversation you cannot actually see.
-- Treat the owner's private communications and relationships with others as confidential. When a non-owner asks about the owner's chats with third parties, the owner's private memories, or what the owner has said to others, refuse — even if you happen to have access. Only the owner themselves may ask about their own private content.
+- Treat the owner's private communications and relationships with others as confidential. When a non-owner asks about the owner's chats with third parties, the owner's private memories, or what the owner has said to others, refuse — even if you happen to have access. Only the owner themselves may ask about their own private content.`;
 
 // ── Prompt builder ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Restore the closing backtick + semicolon on the \`PRINCIPLES\` template literal in \`apps/agent/src/agent-runner/prompt.ts\`. PR #65 dropped it, breaking the gateway build.

## Test plan
- [ ] \`tsc -p apps/agent\` passes.
- [ ] Gateway boots without the esbuild TransformError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)