### PR TITLE
fix(telegram): don't crash gateway on Telegram API timeout

### DIFF
--- a/apps/channels/telegram/src/bot.ts
+++ b/apps/channels/telegram/src/bot.ts
@@ -53,7 +53,12 @@ export class TelegramBot {
       await this.startWebhook();
     } else {
       // Fire-and-forget: polling loop runs in background so start() resolves immediately.
-      void this.startPolling();
+      // Catch any unexpected throw so it never bubbles up as an unhandled rejection
+      // (which would crash the whole gateway).
+      void this.startPolling().catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.log(`polling task crashed: ${message}`);
+      });
     }
   }
 
@@ -76,8 +81,14 @@ export class TelegramBot {
   // --- Polling mode ---
 
   private async startPolling(): Promise<void> {
-    // Ensure no stale webhook.
-    await this.api.deleteWebhook();
+    // Best-effort: failure here (e.g. network timeout to api.telegram.org)
+    // must not crash the gateway. Polling can proceed without it.
+    try {
+      await this.api.deleteWebhook();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`deleteWebhook failed (continuing): ${message}`);
+    }
     this.log('polling mode started');
 
     this.pollAbort = new AbortController();


### PR DESCRIPTION
## Summary
- Wrap the initial \`deleteWebhook()\` in startPolling so a transient ETIMEDOUT to api.telegram.org no longer escapes the polling task.
- Attach a catch on the \`void\`-launched polling promise so any future unexpected throw is logged instead of crashing the gateway process.

## Why
Gateway was crashing on cold-start whenever Railway → Telegram had a brief connect timeout (149.154.166.110:443 ETIMEDOUT). Telegram polling should retry, not nuke the process.

## Test plan
- [ ] Gateway starts when Telegram API is reachable.
- [ ] Simulated network failure during startup logs \`deleteWebhook failed (continuing): …\` and proceeds into the poll loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)