### PR TITLE
chore: bump sdk to 0.3.8, cli to 0.6.9

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.7",
+    "@openhermit/sdk": "0.3.8",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,15 @@
         "discord.js": "^14.16.3"
       }
     },
+    "apps/channels/discord/node_modules/@openhermit/sdk": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/channels/slack": {
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
@@ -65,6 +74,15 @@
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
+      }
+    },
+    "apps/channels/slack/node_modules/@openhermit/sdk": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "apps/channels/telegram": {
@@ -77,9 +95,18 @@
         "remend": "^1.3.0"
       }
     },
+    "apps/channels/telegram/node_modules/@openhermit/sdk": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -112,7 +139,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.3.7",
+        "@openhermit/sdk": "0.3.8",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -10973,7 +11000,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- \`@openhermit/sdk\`: 0.3.7 → 0.3.8
- \`openhermit\` (CLI): 0.6.8 → 0.6.9

## Includes
- fix(telegram): gateway no longer crashes on Telegram API timeout (#69)
- fix(agent): close PRINCIPLES template literal (#68)
- feat(gateway): support preset name in per-agent sandbox create (#67)
- fix(agent): always register identity link toolset (#66)
- fix(agent): harden against fabrication and owner-privacy leaks (#65)

## Publish plan (manual, after merge)
\`\`\`
git checkout main && git pull
cd packages/sdk && npm publish
cd ../../apps/cli && npm publish
git tag v0.6.9 && git push --tags
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)