### PR TITLE
feat(cli): default skills register name/description from SKILL.md frontmatter

### DIFF
--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -1,3 +1,7 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { parseFrontmatter } from '@openhermit/agent/skills';
 import type { Command } from 'commander';
 
 import { createGateway, handleError, printTable } from './shared.js';
@@ -150,16 +154,41 @@ export const registerSkillsCommand = (program: Command): void => {
   skills
     .command('register <skillId>')
     .description('Register a skill in the global registry')
-    .requiredOption('--name <name>', 'Display name')
-    .requiredOption('--description <text>', 'Skill description')
     .requiredOption('--path <path>', 'Filesystem path to skill directory')
-    .action(async (skillId: string, opts: { name: string; description: string; path: string }) => {
+    .option('--name <name>', 'Display name (default: from SKILL.md frontmatter)')
+    .option('--description <text>', 'Skill description (default: from SKILL.md frontmatter)')
+    .action(async (skillId: string, opts: { name?: string; description?: string; path: string }) => {
       try {
+        let name = opts.name;
+        let description = opts.description;
+
+        if (!name || !description) {
+          const skillMdPath = path.join(opts.path, 'SKILL.md');
+          let fm: Record<string, string> = {};
+          try {
+            fm = parseFrontmatter(await readFile(skillMdPath, 'utf8'));
+          } catch {
+            console.error(
+              `Could not read ${skillMdPath}. Pass --name and --description explicitly, or ensure SKILL.md exists.`,
+            );
+            process.exit(1);
+          }
+          name ??= fm.name;
+          description ??= fm.description;
+        }
+
+        if (!name || !description) {
+          console.error(
+            'Missing name or description. Provide them via flags or SKILL.md frontmatter.',
+          );
+          process.exit(1);
+        }
+
         const gateway = createGateway();
         await gateway.registerSkill({
           id: skillId,
-          name: opts.name,
-          description: opts.description,
+          name,
+          description,
           path: opts.path,
         });
         console.log(`Registered skill ${skillId}.`);


### PR DESCRIPTION
## Summary
- `hermit skills register` no longer requires `--name` / `--description` flags
- When omitted, both default to the values in the target directory's `SKILL.md` frontmatter (matches what `skills scan` already does)
- Explicit flags still override; only `--path` stays required
- Errors clearly if SKILL.md is missing or both flag + frontmatter values are absent

## Test plan
- [ ] `hermit skills register foo --path skills/openhermit-guide` — uses frontmatter
- [ ] `hermit skills register foo --path skills/openhermit-guide --name "Custom"` — name overridden, description from frontmatter
- [ ] `hermit skills register foo --path /nonexistent` — clean error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The `skills register` command's `--name` and `--description` flags are now optional instead of required.
  * When flag values are missing, the command automatically attempts to read skill metadata from configuration files.
  * Improved error handling with informative messages when required information cannot be located.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->