### PR TITLE
fix(store): per-agent skill disable overrides wildcard enable

### DIFF
--- a/packages/store/src/impl/skill-store.ts
+++ b/packages/store/src/impl/skill-store.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { eq, and, inArray, asc } from 'drizzle-orm';
+import { eq, inArray, asc } from 'drizzle-orm';
 import pg from 'pg';
 
 import type { SkillStore } from '../interfaces.js';
@@ -67,14 +67,23 @@ export class DbSkillStore implements SkillStore {
   }
 
   async disable(agentId: string, skillId: string): Promise<void> {
-    await this.db.update(agentSkills).set({ enabled: false })
-      .where(and(eq(agentSkills.agentId, agentId), eq(agentSkills.skillId, skillId)))
-      .catch(() => undefined);
+    const now = new Date().toISOString();
+    await this.db.insert(agentSkills)
+      .values({ agentId, skillId, enabled: false, createdAt: now })
+      .onConflictDoUpdate({
+        target: [agentSkills.agentId, agentSkills.skillId],
+        set: { enabled: false },
+      });
   }
 
   async listEnabled(agentId: string): Promise<SkillRecord[]> {
+    // Pull both the wildcard row and the per-agent row regardless of enabled
+    // state. A per-agent row always overrides the wildcard so that
+    // `disable --agent X` after `enable --all` actually opts X out.
     const rows = await this.db.select({
       skillId: agentSkills.skillId,
+      assignmentAgentId: agentSkills.agentId,
+      enabled: agentSkills.enabled,
       id: skills.id,
       name: skills.name,
       description: skills.description,
@@ -84,18 +93,19 @@ export class DbSkillStore implements SkillStore {
       updatedAt: skills.updatedAt,
     }).from(agentSkills)
       .innerJoin(skills, eq(agentSkills.skillId, skills.id))
-      .where(and(
-        inArray(agentSkills.agentId, [agentId, '*']),
-        eq(agentSkills.enabled, true),
-      ));
+      .where(inArray(agentSkills.agentId, [agentId, '*']));
 
-    const seen = new Set<string>();
-    const result: SkillRecord[] = [];
+    const effective = new Map<string, typeof rows[number]>();
     for (const row of rows) {
-      if (!seen.has(row.skillId)) {
-        seen.add(row.skillId);
-        result.push(this.rowToRecord(row));
+      const prior = effective.get(row.skillId);
+      if (!prior || (prior.assignmentAgentId === '*' && row.assignmentAgentId === agentId)) {
+        effective.set(row.skillId, row);
       }
+    }
+
+    const result: SkillRecord[] = [];
+    for (const row of effective.values()) {
+      if (row.enabled) result.push(this.rowToRecord(row));
     }
     return result.sort((a, b) => a.name.localeCompare(b.name));
   }


### PR DESCRIPTION
## Summary
Fixes two related bugs in `DbSkillStore` that prevented `hermit skills disable --agent X` from overriding a prior `hermit skills enable --all`:

1. **`listEnabled` ignored per-agent overrides.** It filtered `enabled=true` before deduping, so a wildcard (`*`) row with `enabled=true` always won, even if the per-agent row was `enabled=false`.
2. **`disable()` was an update.** With no existing per-agent row, the update affected zero rows — so per-agent disable couldn't even write a row to override the wildcard.

After this PR: `disable` upserts `enabled=false`, and `listEnabled` pulls both wildcard and per-agent rows regardless of state and applies a clear override: per-agent row beats wildcard.

## Test plan
- [ ] `hermit skills enable foo --all` then `hermit skills disable foo --agent a1` → agent `a1` no longer sees `foo`, other agents still do
- [ ] `hermit skills enable foo --agent a1` then `hermit skills disable foo --all` → `a1` keeps `foo`, no one else gets it
- [ ] `hermit skills enable foo --agent a1` then `hermit skills disable foo --agent a1` → `a1` no longer sees `foo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal skill store implementation for more efficient handling of agent-level and wildcard skill assignments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->