### PR TITLE
fix(gateway): rehydrate session on message after restart / idle

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -659,6 +659,29 @@ export class AgentRunner implements SessionRuntime {
     return limit !== undefined ? summaries.slice(0, limit) : summaries;
   }
 
+  /**
+   * Ensure the session is loaded in-memory. If the runner doesn't have it
+   * but the session row is persisted (e.g. after a gateway restart or LRU
+   * eviction), reopen it transparently using the persisted source so
+   * subsequent postMessage / appendMessage calls don't 404. Throws
+   * NotFoundError when no persisted row exists either.
+   */
+  async ensureSessionLoaded(sessionId: string, caller?: Caller): Promise<void> {
+    if (this.sessions.has(sessionId)) return;
+    const persisted = await this.store.sessions.get(this.scope, sessionId);
+    if (!persisted) {
+      throw new NotFoundError(`Session not found: ${sessionId}`);
+    }
+    await this.openSession(
+      {
+        sessionId,
+        source: persisted.source,
+        ...(persisted.metadata ? { metadata: persisted.metadata } : {}),
+      },
+      caller,
+    );
+  }
+
   /** Verify that callerUserId is a participant of the session (or an owner). Throws NotFoundError if not. */
   async verifySessionAccess(sessionId: string, callerUserId: string): Promise<void> {
     const role = await this.store.users.getAgentRole(this.scope, callerUserId);

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1141,6 +1141,14 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const url = new URL(c.req.url);
     const appendMode = url.searchParams.get('append') === 'true' || url.searchParams.get('inject') === 'true';
 
+    // Lazy-rehydrate after a gateway restart / eviction. The session may
+    // still exist in DB but not in the runner's in-memory map; the runner's
+    // post/append paths require an active session and would 404 otherwise.
+    const httpCaller = (auth.mode === 'user' || auth.mode === 'channel') && auth.channelUserId
+      ? { channel: auth.channel, channelUserId: auth.channelUserId }
+      : undefined;
+    await runtime.ensureSessionLoaded(sessionId, httpCaller);
+
     if (appendMode) {
       await runtime.appendMessage(sessionId, payload);
       return c.json({ sessionId, appended: true });

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -167,6 +167,12 @@ const handleRequest = async (
           sendError(ws, id, 'INVALID_PARAMS', 'Invalid message params.');
           return;
         }
+        // Lazy-rehydrate after a gateway restart / eviction so a client that
+        // skipped session.open (e.g. auto-reconnect after idle) doesn't 404.
+        const messageCaller = conn.auth.mode === 'user' && conn.auth.channelUserId
+          ? { channel: conn.auth.channel, channelUserId: conn.auth.channelUserId }
+          : undefined;
+        await runtime.ensureSessionLoaded(sessionId, messageCaller);
         const result = await runtime.postMessage(sessionId, message);
         sendResult(ws, id, result);
         return;


### PR DESCRIPTION
## Summary
Fixes the `[error] Session not found: web:...` that the web UI shows when sending a message after the gateway restarted (or after a long idle that triggered LRU runner eviction).

**Root cause**: a persisted session row stays in the DB, and `requireSessionAccess` passes against the DB. But `postMessage` → `getRequiredSession` only checks the in-memory map, which is empty until something calls `openSession`. The web client's WS auto-reconnect re-subscribes for events but doesn't reissue `session.open`, so the next message 404s.

**Fix**: add `AgentRunner.ensureSessionLoaded(sessionId, caller?)` that calls `openSession` with the persisted source when the session isn't in memory. Call it from both transports before posting/appending:
- WS `session.message` handler
- HTTP `POST /api/agents/:agentId/sessions/:sessionId/messages` (and the `append`/`inject` branch)

## Test plan
- [ ] On test.openhermit.ai: open web UI, restart gateway, type a message, hit send → message goes through (previously 404)
- [ ] Same flow with a stale session ID that was previously deleted → still 404 (correct)
- [ ] Existing in-memory session: no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions are now automatically recovered from storage after gateway restarts or memory evictions, preventing message processing failures.
  * HTTP and WebSocket message handlers now verify session availability before proceeding, ensuring uninterrupted conversation continuation across system events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/74)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->