### PR TITLE
fix(agent): unrelated file/exec policy rules no longer deny other paths

### DIFF
--- a/apps/agent/src/core/policy.ts
+++ b/apps/agent/src/core/policy.ts
@@ -172,9 +172,10 @@ const parseFileScope = (row: PolicyRow): FileScope | undefined => {
 };
 
 /**
- * Resolve file path-level matches. Returns undefined if no file rows exist
- * (caller should fall back to tool-level policy). Returns PolicyMatch[] with
- * all matching rows for the path (across effects).
+ * Resolve file path-level matches. Returns `undefined` when no file row
+ * applies to this (sandbox, mode, path) — caller falls back to tool-level
+ * policy. An unrelated file rule (e.g. one targeting `/root/notes.md`)
+ * must not silently deny reads/writes on other paths.
  */
 export const resolveFilePathMatches = (
   fileRows: PolicyRow[],
@@ -200,7 +201,7 @@ export const resolveFilePathMatches = (
     }
   }
 
-  if (bestByEffect.size === 0) return [];
+  if (bestByEffect.size === 0) return undefined;
   return [...bestByEffect.values()].map(({ row }) => ({
     effect: (row.effect ?? 'allow') as PolicyEffect,
     grants: row.grants as Grant[],
@@ -242,9 +243,9 @@ const normalizeCommand = (cmd: string): string =>
   cmd.trim().replace(/\s+/g, ' ');
 
 /**
- * Resolve exec command-level matches. Returns undefined if no exec rows
- * exist (caller should fall back to tool-level policy). Returns PolicyMatch[]
- * with all matching rows for the command (across effects).
+ * Resolve exec command-level matches. Returns `undefined` when no exec row
+ * applies to this (sandbox, command, cwd) — caller falls back to tool-level
+ * policy. An unrelated command rule must not silently deny other commands.
  */
 export const resolveExecMatches = (
   execRows: PolicyRow[],
@@ -283,7 +284,7 @@ export const resolveExecMatches = (
     }
   }
 
-  if (bestByEffect.size === 0) return [];
+  if (bestByEffect.size === 0) return undefined;
   return [...bestByEffect.values()].map(({ row }) => ({
     effect: (row.effect ?? 'allow') as PolicyEffect,
     grants: row.grants as Grant[],

--- a/apps/agent/test/policy.test.ts
+++ b/apps/agent/test/policy.test.ts
@@ -364,6 +364,17 @@ test('resolveFilePathMatches: deny effect on file path', () => {
   assert.equal(evaluateAccess({ agentId: 'a', role: 'owner' }, matches, 'deny'), 'allow');
 });
 
+test('resolveFilePathMatches: unrelated file rule falls through to tool-level', () => {
+  // A rule scoped to /root/notes.md must not block reads on /root or /etc.
+  const rows: PolicyRow[] = [{
+    agentId: 'a', resourceType: 'file', resourceKey: '*:*:/root/notes.md',
+    effect: 'require_approval', grants: [{ type: 'any' }],
+    scope: { sandbox: '*', mode: '*', path: '/root/notes.md' },
+  }];
+  assert.equal(resolveFilePathMatches(rows, 'primary', 'read', '/root'), undefined);
+  assert.equal(resolveFilePathMatches(rows, 'primary', 'read', '/etc/passwd'), undefined);
+});
+
 // ── resolveExecGrants ─────────────────────────────────────────────────
 
 test('resolveExecGrants: returns undefined when no exec rows', () => {
@@ -550,6 +561,17 @@ test('resolveExecMatches: deny effect on exec command', () => {
   const matches = resolveExecMatches(rows, 'primary', 'ls')!;
   assert.equal(evaluateAccess({ agentId: 'a', role: 'guest' }, matches, 'deny'), 'deny');
   assert.equal(evaluateAccess({ agentId: 'a', role: 'owner' }, matches, 'deny'), 'allow');
+});
+
+test('resolveExecMatches: unrelated exec rule falls through to tool-level', () => {
+  // A rule scoped to `rm -rf /` must not block `ls` or `git status`.
+  const rows: PolicyRow[] = [{
+    agentId: 'a', resourceType: 'exec', resourceKey: 'primary:rm -rf /',
+    effect: 'deny', grants: [{ type: 'any' }],
+    scope: { sandbox: 'primary', command: 'rm -rf /' },
+  }];
+  assert.equal(resolveExecMatches(rows, 'primary', 'ls'), undefined);
+  assert.equal(resolveExecMatches(rows, 'primary', 'git status'), undefined);
 });
 
 // ── parseMcpServerId ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`resolveFilePathMatches` / `resolveExecMatches` returned `[]` when an agent had policy rows but none matched the requested path/command. Callers treat `undefined` as "fall through to tool-level allow", but `[]` flowed into `evaluateAccess(..., 'deny')` which returns the default `deny` for an empty match set.

Net effect: a single `require_approval` rule scoped to `/root/notes.md` denied every other file read/write on that agent, even for owner. Exec had the same trap.

Both functions now return `undefined` when nothing matches, so a narrow rule doesn't silently turn into a deny-all.

## Test plan

- [x] New unit tests: unrelated file/exec rules return `undefined` (fall through)
- [x] Existing `resolveFilePathMatches`/`resolveExecMatches` deny/allow tests still pass
- [x] `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy resolution to correctly handle scoped rules, ensuring file path and execution rules no longer block unrelated access attempts.

* **Tests**
  * Added test cases validating that scoped policy rules for specific files or commands do not interfere with unrelated operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->