### PR TITLE
fix(agent): recover e2b sandbox after pause / unexpected death

### DIFF
--- a/apps/agent/src/core/backends/e2b.ts
+++ b/apps/agent/src/core/backends/e2b.ts
@@ -37,6 +37,12 @@ interface E2BBackendPersisted {
   template: string;
   cwd: string;
   updatedAt: string;
+  /** Last intent we recorded:
+   *  - 'active' after a successful connect/create
+   *  - 'paused' after our own shutdown()→pause()
+   * Informational; `connect()` itself transparently resumes paused
+   * sandboxes, so this is for observability rather than dispatch. */
+  state?: 'active' | 'paused';
 }
 
 interface E2BPendingSkillSync {
@@ -69,13 +75,63 @@ class E2BExecBackend implements ExecBackend {
     this.username = config.username ?? E2B_DEFAULT_USERNAME;
     this.agentHome = config.agent_home ?? E2B_DEFAULT_AGENT_HOME;
     this.files = new E2BFileBackend();
+    this.files.getSandbox = () => this.sandbox;
     this.files.ensureSandbox = () => this.ensure();
+    this.files.invalidate = () => { this.sandbox = null; };
+
+    // Fire-and-forget: reconcile persisted state with the remote on
+    // startup. Catches the case where the previous process crashed
+    // before recording a deliberate pause (or the sandbox was paused
+    // out-of-band), so our DB stays in sync with e2b.
+    void this.reconcilePersistedState();
+  }
+
+  /**
+   * Best-effort check that runtime_state's `state` matches what e2b
+   * reports for the persisted sandboxId. Runs once at construction.
+   * Skips silently on any error — `ensure()` is the source of truth
+   * for liveness and will overwrite this on first use.
+   */
+  private async reconcilePersistedState(): Promise<void> {
+    try {
+      if (this.sandbox) return;
+      const persisted = await this.loadState();
+      if (!persisted?.sandboxId) return;
+      const apiKey = process.env['E2B_API_KEY'];
+      if (!apiKey) return;
+      const { Sandbox, SandboxNotFoundError } = await import('e2b');
+      let remoteState: 'active' | 'paused';
+      try {
+        const info = await Sandbox.getInfo(persisted.sandboxId, { apiKey });
+        remoteState = info.state === 'paused' ? 'paused' : 'active';
+      } catch (err) {
+        if (err instanceof SandboxNotFoundError) {
+          // Remote is gone entirely. Leave sandboxId in place — ensure()
+          // will hit the same 404 and fall through to create, which is
+          // the right behaviour. No state to record here.
+          return;
+        }
+        throw err;
+      }
+      // Re-check we haven't raced with ensure() taking ownership.
+      if (this.sandbox) return;
+      const fresh = await this.loadState();
+      if (!fresh || fresh.sandboxId !== persisted.sandboxId) return;
+      if (fresh.state === remoteState) return;
+      await this.saveState({
+        ...fresh,
+        state: remoteState,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch {
+      // Fire-and-forget: never let reconcile errors bubble up.
+    }
   }
 
   async ensure(): Promise<void> {
     if (this.sandbox) return;
 
-    const { Sandbox } = await import('e2b');
+    const { Sandbox, SandboxNotFoundError } = await import('e2b');
     const apiKey = process.env['E2B_API_KEY'];
     if (!apiKey) {
       throw new ValidationError(
@@ -86,19 +142,28 @@ class E2BExecBackend implements ExecBackend {
     const persisted = await this.loadState();
     if (persisted?.sandboxId) {
       try {
+        // `connect()` POSTs to /sandboxes/{id}/connect, which transparently
+        // resumes paused sandboxes. So `persisted.state === 'paused'` and
+        // `'active'` take the same code path — the state field is recorded
+        // for observability, not branching.
         this.sandbox = await Sandbox.connect(persisted.sandboxId, {
           apiKey,
           timeoutMs: this.sandboxTimeoutMs,
         });
-        this.files.sandbox = this.sandbox;
+        await this.saveState({
+          ...persisted,
+          updatedAt: new Date().toISOString(),
+          state: 'active',
+        });
         await this.context.markActive?.({
           externalId: this.sandbox.sandboxId,
           lastSeenAt: new Date().toISOString(),
         });
         await this.replayPendingSkillSync();
         return;
-      } catch {
-        // Sandbox gone — create a new one.
+      } catch (err) {
+        if (!(err instanceof SandboxNotFoundError)) throw err;
+        // 404 on connect = paused snapshot also expired. Fall through.
       }
     }
 
@@ -107,7 +172,6 @@ class E2BExecBackend implements ExecBackend {
       timeoutMs: this.sandboxTimeoutMs,
       metadata: { agentId: this.context.agentId },
     });
-    this.files.sandbox = this.sandbox;
 
     await this.sandbox.commands.run(`mkdir -p ${this.agentHome}`);
 
@@ -116,6 +180,7 @@ class E2BExecBackend implements ExecBackend {
       template: this.template,
       cwd: this.agentHome,
       updatedAt: new Date().toISOString(),
+      state: 'active',
     });
     await this.context.markActive?.({
       externalId: this.sandbox.sandboxId,
@@ -153,6 +218,13 @@ class E2BExecBackend implements ExecBackend {
           exitCode: e.exitCode,
           durationMs: Date.now() - startedAt,
         };
+      }
+      const { SandboxNotFoundError } = await import('e2b');
+      if (error instanceof SandboxNotFoundError) {
+        // Cached handle points at a dead/paused-and-evicted sandbox.
+        // Drop it so the next call re-enters ensure() → connect (auto-
+        // resume) or create. The current call still surfaces the error.
+        this.sandbox = null;
       }
       return {
         stdout: '',
@@ -217,13 +289,24 @@ class E2BExecBackend implements ExecBackend {
 
   async shutdown(): Promise<void> {
     if (!this.sandbox) return;
+    let paused = false;
     try {
       await this.sandbox.pause();
+      paused = true;
     } catch {
       // Already paused or gone.
     }
     this.sandbox = null;
-    this.files.sandbox = null;
+    if (paused) {
+      const persisted = await this.loadState();
+      if (persisted?.sandboxId) {
+        await this.saveState({
+          ...persisted,
+          updatedAt: new Date().toISOString(),
+          state: 'paused',
+        });
+      }
+    }
   }
 
   private async loadState(): Promise<E2BBackendPersisted | null> {

--- a/apps/agent/src/core/backends/file-backend.ts
+++ b/apps/agent/src/core/backends/file-backend.ts
@@ -256,71 +256,99 @@ export class HostFileBackend implements FileBackend {
  * The sandbox handle is lazily provided after `ensure()`.
  */
 export class E2BFileBackend implements FileBackend {
-  sandbox: import('e2b').Sandbox | null = null;
+  /** Single source of truth for the live sandbox handle lives on the
+   * E2BExecBackend; we read it through this getter so invalidation in
+   * either place is visible to both without a sync step. */
+  getSandbox: (() => import('e2b').Sandbox | null) | null = null;
   ensureSandbox: (() => Promise<void>) | null = null;
+  /** Called when an operation surfaces a `SandboxNotFoundError`, so the
+   * exec backend can drop its cached handle and let the next call
+   * re-`ensure()` (which triggers connect → auto-resume, or create). */
+  invalidate: (() => void) | null = null;
 
   private get sb(): import('e2b').Sandbox {
-    if (!this.sandbox) throw new ValidationError('E2B sandbox is not connected. Call ensure() first.');
-    return this.sandbox;
+    const sb = this.getSandbox?.() ?? null;
+    if (!sb) throw new ValidationError('E2B sandbox is not connected. Call ensure() first.');
+    return sb;
   }
 
   private async ready(): Promise<void> {
-    if (!this.sandbox && this.ensureSandbox) await this.ensureSandbox();
+    if (!this.getSandbox?.() && this.ensureSandbox) await this.ensureSandbox();
+  }
+
+  private async withInvalidate<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      const { SandboxNotFoundError } = await import('e2b');
+      if (err instanceof SandboxNotFoundError) this.invalidate?.();
+      throw err;
+    }
   }
 
   async read(filePath: string): Promise<FileReadResult> {
     requireAbsolutePath(filePath);
     await this.ready();
-    const bytes = await this.sb.files.read(filePath, { format: 'bytes' });
-    return { data: Buffer.from(bytes) };
+    return this.withInvalidate(async () => {
+      const bytes = await this.sb.files.read(filePath, { format: 'bytes' });
+      return { data: Buffer.from(bytes) };
+    });
   }
 
   async write(filePath: string, data: Buffer, mode: FileWriteMode): Promise<void> {
     requireAbsolutePath(filePath);
     await this.ready();
-    if (mode === 'create') {
-      const exists = await this.sb.files.exists(filePath);
-      if (exists) throw new ValidationError(`File already exists (mode=create): ${filePath}`);
-    }
-    if (mode === 'append') {
-      let existing = Buffer.alloc(0);
-      try {
-        const bytes = await this.sb.files.read(filePath, { format: 'bytes' });
-        existing = Buffer.from(bytes);
-      } catch {
-        // File doesn't exist — append acts like create.
+    return this.withInvalidate(async () => {
+      if (mode === 'create') {
+        const exists = await this.sb.files.exists(filePath);
+        if (exists) throw new ValidationError(`File already exists (mode=create): ${filePath}`);
       }
-      const buf = Buffer.concat([existing, data]);
-      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
-      await this.sb.files.write(filePath, ab);
-    } else {
-      const ab = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
-      await this.sb.files.write(filePath, ab);
-    }
+      if (mode === 'append') {
+        let existing = Buffer.alloc(0);
+        try {
+          const bytes = await this.sb.files.read(filePath, { format: 'bytes' });
+          existing = Buffer.from(bytes);
+        } catch {
+          // File doesn't exist — append acts like create.
+        }
+        const buf = Buffer.concat([existing, data]);
+        const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+        await this.sb.files.write(filePath, ab);
+      } else {
+        const ab = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+        await this.sb.files.write(filePath, ab);
+      }
+    });
   }
 
   async list(dirPath: string): Promise<DirEntry[]> {
     requireAbsolutePath(dirPath);
     await this.ready();
-    const entries = await this.sb.files.list(dirPath);
-    return entries.map((e) => ({
-      name: e.name,
-      type: e.type === 'dir' ? 'directory' as const : e.type === 'file' ? 'file' as const : 'other' as const,
-      ...(e.type === 'file' ? { size: e.size } : {}),
-    }));
+    return this.withInvalidate(async () => {
+      const entries = await this.sb.files.list(dirPath);
+      return entries.map((e) => ({
+        name: e.name,
+        type: e.type === 'dir' ? 'directory' as const : e.type === 'file' ? 'file' as const : 'other' as const,
+        ...(e.type === 'file' ? { size: e.size } : {}),
+      }));
+    });
   }
 
   async stat(filePath: string): Promise<FileStat | null> {
     requireAbsolutePath(filePath);
     await this.ready();
     try {
-      const info = await this.sb.files.getInfo(filePath);
-      return {
-        type: info.type === 'dir' ? 'directory' : info.type === 'file' ? 'file' : 'other',
-        size: info.size,
-        mtime: info.modifiedTime ? info.modifiedTime.toISOString() : new Date().toISOString(),
-      };
-    } catch {
+      return await this.withInvalidate(async () => {
+        const info = await this.sb.files.getInfo(filePath);
+        return {
+          type: info.type === 'dir' ? 'directory' : info.type === 'file' ? 'file' : 'other',
+          size: info.size,
+          mtime: info.modifiedTime ? info.modifiedTime.toISOString() : new Date().toISOString(),
+        };
+      });
+    } catch (err) {
+      const { SandboxNotFoundError } = await import('e2b');
+      if (err instanceof SandboxNotFoundError) throw err;
       return null;
     }
   }
@@ -328,7 +356,9 @@ export class E2BFileBackend implements FileBackend {
   async delete(filePath: string): Promise<void> {
     requireAbsolutePath(filePath);
     await this.ready();
-    await this.sb.files.remove(filePath);
+    return this.withInvalidate(async () => {
+      await this.sb.files.remove(filePath);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Tool calls against a cached `Sandbox` handle whose remote was paused (by our own `shutdown()`) or evicted would keep failing for the rest of the session. `ensure()` short-circuited on the cached handle, so `connect()` — which auto-resumes paused sandboxes — was never re-attempted.
- `E2BFileBackend` and `E2BExecBackend` now share a single sandbox reference via a `getSandbox` getter, and either side drops it on `SandboxNotFoundError` (via an `invalidate` callback). Next tool call re-enters `ensure()` → `connect()` → auto-resume, preserving sandbox state.
- Persisted `runtime_state.e2b` gains an `active | paused` field, written on connect/create success and on a successful `shutdown()` pause, for observability.
- Fire-and-forget `Sandbox.getInfo()` at construction reconciles the persisted state with e2b's view, in case the previous process crashed before recording a deliberate pause.

## Test plan
- [ ] In a session backed by e2b, idle past the gateway eviction TTL (triggers `shutdown()` → `pause()`), then send a new message — first tool call recovers without losing files/processes inside the sandbox.
- [ ] If the paused snapshot has been GC'd by e2b, the same flow falls through to `create()` (fresh sandbox, expected data loss).
- [ ] Mid-session sandbox death: a `SandboxNotFoundError` on one tool call invalidates the cache; the next call ensures and succeeds.
- [ ] `runtime_state.e2b.state` reflects `paused` after our `shutdown()` and `active` after `connect()`/`create()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sandbox state persistence with pause/resume capability
  * Automatic reconnection when sandbox connections are lost
  
* **Bug Fixes**
  * Improved error recovery for disconnected sandboxes
  * Enhanced state reconciliation on agent startup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->