### PR TITLE
feat(sdk): appendMessage supports assistant-role + occurredAt + idempotency

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1103,41 +1103,89 @@ export class AgentRunner implements SessionRuntime {
   async appendMessage(
     sessionId: string,
     message: SessionMessage,
-  ): Promise<void> {
+  ): Promise<{ appended: boolean; deduped?: true }> {
     const session = this.getRequiredSession(sessionId);
     session.updatedAt = new Date().toISOString();
 
-    let messageUserId = session.resolvedUserId;
-    if (message.sender) {
-      const now = new Date().toISOString();
-      const resolved = await this.resolveMessageSender(message.sender, now);
-      if (resolved.userId) {
-        messageUserId = resolved.userId;
-        session.userIds = addUserIdToList(session.userIds, resolved.userId);
+    // Idempotency: if a prior append already recorded this messageId in
+    // this session, return early. Lets host apps retry on flaky networks
+    // without doubling history entries.
+    if (message.messageId) {
+      const existing = await this.store.messages.findEntryIdByMessageId(
+        this.scope, session.spec.sessionId, message.messageId,
+      );
+      if (existing !== null) {
+        return { appended: false, deduped: true };
       }
     }
 
-    const receivedAt = new Date().toISOString();
+    const role: 'user' | 'assistant' = message.appendAs === 'assistant' ? 'assistant' : 'user';
+    const ts = message.occurredAt ?? new Date().toISOString();
     const displayName = message.sender?.displayName;
-    await this.queueSideEffect(session, async () => {
-      await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
-        ts: receivedAt,
-        role: 'user',
-        messageId: message.messageId,
-        content: message.text,
-        ...(message.attachments ? { attachments: message.attachments } : {}),
-        ...(messageUserId ? { userId: messageUserId } : {}),
-        ...(displayName ? { userName: displayName } : {}),
-        ...(message.metadata ? { metadata: message.metadata } : {}),
-      });
-    });
 
-    void this.events.publish({
-      type: 'user_message',
-      sessionId,
-      text: message.text,
-      ...(displayName ? { name: displayName } : {}),
-    });
+    if (role === 'user') {
+      // User-role backfill: resolve the sender as an authoring user the
+      // same way postMessage does, so userId/userName get stamped on the
+      // entry and `users` table is kept in sync.
+      let messageUserId = session.resolvedUserId;
+      if (message.sender) {
+        const now = new Date().toISOString();
+        const resolved = await this.resolveMessageSender(message.sender, now);
+        if (resolved.userId) {
+          messageUserId = resolved.userId;
+          session.userIds = addUserIdToList(session.userIds, resolved.userId);
+        }
+      }
+
+      await this.queueSideEffect(session, async () => {
+        await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
+          ts,
+          role: 'user',
+          messageId: message.messageId,
+          content: message.text,
+          ...(message.attachments ? { attachments: message.attachments } : {}),
+          ...(messageUserId ? { userId: messageUserId } : {}),
+          ...(displayName ? { userName: displayName } : {}),
+          ...(message.metadata ? { metadata: message.metadata } : {}),
+        });
+      });
+
+      void this.events.publish({
+        type: 'user_message',
+        sessionId,
+        text: message.text,
+        ...(displayName ? { name: displayName } : {}),
+      });
+    } else {
+      // Assistant-role backfill: the agent did not generate this turn —
+      // someone (typically the owner of a shared-account session) acted
+      // as the assistant out-of-band. We persist it as `assistant` so
+      // model history stays consistent, but:
+      //   - leave `provider`/`model` unset so it's visibly distinct from
+      //     model-generated turns;
+      //   - stamp `metadata.synthetic = true` (and the originating
+      //     sender, if any) for downstream attribution;
+      //   - do NOT emit `user_message` — there is no user turn here.
+      // No `text_final`/`text_delta` are emitted either; those are
+      // reserved for live model output.
+      const metadata: Record<string, unknown> = {
+        ...(message.metadata ?? {}),
+        synthetic: true,
+        ...(message.sender ? { appendedBy: message.sender } : {}),
+      };
+      await this.queueSideEffect(session, async () => {
+        await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
+          ts,
+          role: 'assistant',
+          messageId: message.messageId,
+          content: message.text,
+          ...(message.attachments ? { attachments: message.attachments } : {}),
+          metadata,
+        });
+      });
+    }
+
+    return { appended: true };
   }
 
   private makeApprovalCallback(

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1105,39 +1105,41 @@ export class AgentRunner implements SessionRuntime {
     message: SessionMessage,
   ): Promise<{ appended: boolean; deduped?: true }> {
     const session = this.getRequiredSession(sessionId);
-    session.updatedAt = new Date().toISOString();
-
-    // Idempotency: if a prior append already recorded this messageId in
-    // this session, return early. Lets host apps retry on flaky networks
-    // without doubling history entries.
-    if (message.messageId) {
-      const existing = await this.store.messages.findEntryIdByMessageId(
-        this.scope, session.spec.sessionId, message.messageId,
-      );
-      if (existing !== null) {
-        return { appended: false, deduped: true };
-      }
-    }
-
     const role: 'user' | 'assistant' = message.appendAs === 'assistant' ? 'assistant' : 'user';
     const ts = message.occurredAt ?? new Date().toISOString();
     const displayName = message.sender?.displayName;
 
-    if (role === 'user') {
-      // User-role backfill: resolve the sender as an authoring user the
-      // same way postMessage does, so userId/userName get stamped on the
-      // entry and `users` table is kept in sync.
-      let messageUserId = session.resolvedUserId;
-      if (message.sender) {
-        const now = new Date().toISOString();
-        const resolved = await this.resolveMessageSender(message.sender, now);
-        if (resolved.userId) {
-          messageUserId = resolved.userId;
-          session.userIds = addUserIdToList(session.userIds, resolved.userId);
+    // For user-role backfill we resolve the sender outside the side-effect
+    // queue (it can touch the users table). userIds mutation is reflected
+    // in the persisted index after the write below.
+    let messageUserId = session.resolvedUserId;
+    if (role === 'user' && message.sender) {
+      const now = new Date().toISOString();
+      const resolved = await this.resolveMessageSender(message.sender, now);
+      if (resolved.userId) {
+        messageUserId = resolved.userId;
+        session.userIds = addUserIdToList(session.userIds, resolved.userId);
+      }
+    }
+
+    // Run idempotency check + log write inside the per-session side-effect
+    // queue so concurrent appends with the same messageId from this process
+    // serialize and the second one observes the first's row before writing.
+    // (Cross-process dedup still relies on caller retry semantics; the index
+    //  in 0023_session_events_message_id_idx keeps the lookup cheap.)
+    let deduped = false;
+    await this.queueSideEffect(session, async () => {
+      if (message.messageId) {
+        const existing = await this.store.messages.findEntryIdByMessageId(
+          this.scope, session.spec.sessionId, message.messageId,
+        );
+        if (existing !== null) {
+          deduped = true;
+          return;
         }
       }
 
-      await this.queueSideEffect(session, async () => {
+      if (role === 'user') {
         await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
           ts,
           role: 'user',
@@ -1148,32 +1150,19 @@ export class AgentRunner implements SessionRuntime {
           ...(displayName ? { userName: displayName } : {}),
           ...(message.metadata ? { metadata: message.metadata } : {}),
         });
-      });
-
-      void this.events.publish({
-        type: 'user_message',
-        sessionId,
-        text: message.text,
-        ...(displayName ? { name: displayName } : {}),
-      });
-    } else {
-      // Assistant-role backfill: the agent did not generate this turn —
-      // someone (typically the owner of a shared-account session) acted
-      // as the assistant out-of-band. We persist it as `assistant` so
-      // model history stays consistent, but:
-      //   - leave `provider`/`model` unset so it's visibly distinct from
-      //     model-generated turns;
-      //   - stamp `metadata.synthetic = true` (and the originating
-      //     sender, if any) for downstream attribution;
-      //   - do NOT emit `user_message` — there is no user turn here.
-      // No `text_final`/`text_delta` are emitted either; those are
-      // reserved for live model output.
-      const metadata: Record<string, unknown> = {
-        ...(message.metadata ?? {}),
-        synthetic: true,
-        ...(message.sender ? { appendedBy: message.sender } : {}),
-      };
-      await this.queueSideEffect(session, async () => {
+      } else {
+        // Assistant-role backfill: the agent did not generate this turn —
+        // someone (typically the owner of a shared-account session) acted
+        // as the assistant out-of-band. Leave provider/model unset so it's
+        // visibly distinct from model-generated turns; stamp
+        // metadata.synthetic = true (and the originating sender) for
+        // downstream attribution. No user_message / text_final / text_delta
+        // events are emitted; those are reserved for live turns.
+        const metadata: Record<string, unknown> = {
+          ...(message.metadata ?? {}),
+          synthetic: true,
+          ...(message.sender ? { appendedBy: message.sender } : {}),
+        };
         await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
           ts,
           role: 'assistant',
@@ -1182,6 +1171,22 @@ export class AgentRunner implements SessionRuntime {
           ...(message.attachments ? { attachments: message.attachments } : {}),
           metadata,
         });
+      }
+    });
+
+    if (deduped) {
+      return { appended: false, deduped: true };
+    }
+
+    session.updatedAt = new Date().toISOString();
+    await this.persistSessionIndex(session);
+
+    if (role === 'user') {
+      void this.events.publish({
+        type: 'user_message',
+        sessionId,
+        text: message.text,
+        ...(displayName ? { name: displayName } : {}),
       });
     }
 

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -1061,3 +1061,119 @@ test('AgentRunner populates userIds on session open and reopen', async (t) => {
   assert.ok(session.userIds!.length > 0, 'userIds should have at least one entry');
   assert.ok(session.userIds!.includes('usr-owner'), 'userIds should include the owner');
 });
+
+test('AgentRunner.appendMessage with appendAs=assistant stores synthetic assistant entry without user_message', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([]),
+  });
+
+  const sessionId = 'cli:append-assistant';
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+
+  const result = await runner.appendMessage(sessionId, {
+    messageId: 'msg-assist-1',
+    text: 'owner-as-assistant reply',
+    appendAs: 'assistant',
+    sender: { channel: 'cli', channelUserId: 'owner' },
+  });
+  assert.deepEqual(result, { appended: true });
+  await runner.waitForSessionIdle(sessionId);
+
+  const entries = await readSessionLog(runner, sessionId);
+  const assistantEntry = entries.find(
+    (e) => e.role === 'assistant' && e.content === 'owner-as-assistant reply',
+  );
+  assert.ok(assistantEntry, 'assistant entry should be persisted');
+  const metadata = assistantEntry!.metadata as Record<string, unknown> | undefined;
+  assert.equal(metadata?.synthetic, true, 'metadata.synthetic should be true');
+  assert.ok(metadata?.appendedBy, 'metadata.appendedBy should be set');
+  assert.equal(assistantEntry!.provider, undefined, 'provider should be unset');
+  assert.equal(assistantEntry!.model, undefined, 'model should be unset');
+
+  const backlog = runner.events.getBacklog(sessionId);
+  assert.ok(
+    !backlog.some((entry) => entry.event.type === 'user_message'),
+    'no user_message event should be emitted for assistant-role append',
+  );
+});
+
+test('AgentRunner.appendMessage is idempotent by messageId', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([]),
+  });
+
+  const sessionId = 'cli:append-idempotent';
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+
+  const first = await runner.appendMessage(sessionId, {
+    messageId: 'msg-dup',
+    text: 'first',
+    appendAs: 'user',
+  });
+  assert.deepEqual(first, { appended: true });
+  await runner.waitForSessionIdle(sessionId);
+
+  const second = await runner.appendMessage(sessionId, {
+    messageId: 'msg-dup',
+    text: 'first',
+    appendAs: 'user',
+  });
+  assert.deepEqual(second, { appended: false, deduped: true });
+
+  const entries = await readSessionLog(runner, sessionId);
+  const matches = entries.filter((e) => e.messageId === 'msg-dup');
+  assert.equal(matches.length, 1, 'only one entry persisted for duplicate messageId');
+});
+
+test('AgentRunner.appendMessage honours occurredAt as the persisted ts', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([]),
+  });
+
+  const sessionId = 'cli:append-occurredat';
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+
+  const occurredAt = '2024-01-02T03:04:05.000Z';
+  await runner.appendMessage(sessionId, {
+    messageId: 'msg-ts',
+    text: 'backfilled',
+    appendAs: 'assistant',
+    occurredAt,
+  });
+  await runner.waitForSessionIdle(sessionId);
+
+  const entries = await readSessionLog(runner, sessionId);
+  const entry = entries.find((e) => e.messageId === 'msg-ts');
+  assert.ok(entry, 'entry persisted');
+  assert.equal(entry!.ts, occurredAt, 'persisted ts should match occurredAt');
+});

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1150,8 +1150,18 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     await runtime.ensureSessionLoaded(sessionId, httpCaller);
 
     if (appendMode) {
-      await runtime.appendMessage(sessionId, payload);
-      return c.json({ sessionId, appended: true });
+      const result = await runtime.appendMessage(sessionId, payload);
+      return c.json({ sessionId, ...result });
+    }
+
+    // `appendAs` / `occurredAt` are only meaningful for appendMessage —
+    // postMessage represents a live user turn that drives a generation,
+    // never a backfilled or assistant-role entry. Reject loudly so the
+    // caller can pick the right method.
+    if (payload.appendAs !== undefined || payload.occurredAt !== undefined) {
+      throw new ValidationError(
+        '`appendAs` and `occurredAt` are only supported on appendMessage (POST ?append=true).',
+      );
     }
 
     const waitMode = url.searchParams.get('wait') === 'true';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -498,8 +498,10 @@ export const isSessionMessage = (value: unknown): value is SessionMessage => {
 
   if (value.occurredAt !== undefined) {
     if (typeof value.occurredAt !== 'string') return false;
-    const parsed = Date.parse(value.occurredAt);
-    if (Number.isNaN(parsed)) return false;
+    // Strict ISO 8601 with timezone (Z or ±HH:MM). Date.parse is too lenient.
+    const iso8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+    if (!iso8601.test(value.occurredAt)) return false;
+    if (Number.isNaN(Date.parse(value.occurredAt))) return false;
   }
 
   return true;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -48,6 +48,28 @@ export interface SessionMessage {
   /** Whether the bot was explicitly mentioned. When false in a group session,
    *  the server may inject instead of prompting based on user role. */
   mentioned?: boolean;
+  /**
+   * Record this entry in session history under the given role instead of
+   * the default `'user'`. **Only honoured by `appendMessage`**; rejected
+   * on `postMessage` (which always represents a user-driven turn).
+   *
+   * Restricted to `'user' | 'assistant'`. Other history roles (`tool`,
+   * `error`, `introspection`) are server-internal and cannot be forged
+   * by clients.
+   *
+   * Primary use case: shared-account / autopilot flows where the owner
+   * sometimes acts as the assistant directly inside a third-party
+   * conversation, and the agent's history needs to record those turns
+   * as assistant so the persona stays consistent when autopilot resumes.
+   */
+  appendAs?: 'user' | 'assistant';
+  /**
+   * Wall-clock time the message actually occurred at. When set on
+   * `appendMessage`, used as the persisted entry's `ts`, so out-of-order
+   * backfill preserves chronological history order. ISO 8601. Default =
+   * server-now.
+   */
+  occurredAt?: string;
 }
 
 export type SessionHistoryRole = 'user' | 'assistant' | 'error' | 'tool' | 'introspection';
@@ -468,6 +490,16 @@ export const isSessionMessage = (value: unknown): value is SessionMessage => {
     if (!isRecord(value.metadata) || Array.isArray(value.metadata)) {
       return false;
     }
+  }
+
+  if (value.appendAs !== undefined && value.appendAs !== 'user' && value.appendAs !== 'assistant') {
+    return false;
+  }
+
+  if (value.occurredAt !== undefined) {
+    if (typeof value.occurredAt !== 'string') return false;
+    const parsed = Date.parse(value.occurredAt);
+    if (Number.isNaN(parsed)) return false;
   }
 
   return true;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -94,7 +94,7 @@ export class AgentLocalClient {
   async appendMessage(
     sessionId: string,
     message: SessionMessage,
-  ): Promise<{ sessionId: string; appended: boolean }> {
+  ): Promise<{ sessionId: string; appended: boolean; deduped?: true }> {
     const path = `${agentLocalRoutes.sessionMessages(sessionId)}?append=true`;
     return this.postJson(path, message);
   }

--- a/packages/store/drizzle/0023_session_events_message_id_idx.sql
+++ b/packages/store/drizzle/0023_session_events_message_id_idx.sql
@@ -1,0 +1,6 @@
+-- Expression index on session_events to speed up the messageId-based
+-- idempotency lookup used by appendMessage. Partial: only entries that
+-- carry a messageId (i.e. user/assistant turns from external callers).
+CREATE INDEX IF NOT EXISTS "idx_session_events_agent_session_message_id"
+  ON "session_events" ("agent_id", "session_id", ((payload->>'messageId')))
+  WHERE payload ? 'messageId';

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779000000000,
       "tag": "0022_inbox_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779100000000,
+      "tag": "0023_session_events_message_id_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/message-store.ts
+++ b/packages/store/src/impl/message-store.ts
@@ -123,6 +123,22 @@ export class DbMessageStore implements MessageStore {
     return row!.id;
   }
 
+  async findEntryIdByMessageId(
+    scope: StoreScope,
+    sessionId: string,
+    messageId: string,
+  ): Promise<number | null> {
+    const [row] = await this.db.select({ id: sessionEvents.id })
+      .from(sessionEvents)
+      .where(and(
+        eq(sessionEvents.agentId, scope.agentId),
+        eq(sessionEvents.sessionId, sessionId),
+        sql`${sessionEvents.payload}->>'messageId' = ${messageId}`,
+      ))
+      .limit(1);
+    return row?.id ?? null;
+  }
+
   async writeSessionStarted(scope: StoreScope, spec: SessionSpec, model: { provider: string; model: string }): Promise<void> {
     const entries = createSessionStartedEntries(spec, model);
     await this.appendLogEntry(scope, spec.sessionId, entries.session);

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -47,6 +47,10 @@ export interface SessionStore {
 
 export interface MessageStore {
   appendLogEntry(scope: StoreScope, sessionId: string, entry: SessionLogEntry): Promise<number>;
+  /** Lookup an existing entry's id by the messageId stamped in its payload.
+   *  Used to make idempotent appends a no-op on retry. Returns null if no
+   *  entry with that messageId exists in this session. */
+  findEntryIdByMessageId(scope: StoreScope, sessionId: string, messageId: string): Promise<number | null>;
   writeSessionStarted(scope: StoreScope, spec: SessionSpec, model: { provider: string; model: string }): Promise<void>;
   listHistoryMessages(scope: StoreScope, sessionId: string): Promise<SessionHistoryMessage[]>;
   listMessagesSinceEvent(scope: StoreScope, sessionId: string, afterEventId: number): Promise<MessageRow[]>;


### PR DESCRIPTION
## Summary
- `appendMessage` now accepts `appendAs: 'user' | 'assistant'` so shared-account / autopilot hosts can backfill an assistant turn the owner produced out-of-band. Assistant entries are stamped with `metadata.synthetic = true` + `metadata.appendedBy`, omit `provider`/`model`, and do **not** emit `user_message`.
- New optional `occurredAt` (ISO 8601) sets the persisted entry's `ts`, enabling chronologically correct backfill.
- `messageId`-based idempotency via a new `MessageStore.findEntryIdByMessageId` (JSONB `payload->>'messageId'` lookup). Duplicates return `{ appended: false, deduped: true }`.
- `appendAs` / `occurredAt` are rejected on `postMessage` (`POST` without `?append=true`) to keep live-turn semantics clean.
- SDK return type updated; patch bump `0.3.8 → 0.3.9`.

## Test plan
- [x] `npm run typecheck` clean across all workspaces
- [ ] New unit tests added in `apps/agent/test/agent-runner.test.ts` (assistant-role append, idempotency, `occurredAt`). Note: local test DB schema is drifted (`metadata_json` / `user_ids_json` vs current schema) and fails the whole suite the same way on `main`; CI / a freshly migrated DB should be used to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotent message appends with deduplication to prevent duplicate entries on retries.
  * Support for appending assistant-role messages alongside user messages.
  * Optional custom message timestamps via occurredAt.

* **API Changes**
  * appendMessage now returns deduplication status (deduped) in its response.
  * Gateway enforces that assistant/timestamp fields are only accepted in append mode.

* **Tests**
  * Added coverage for assistant appends, idempotency, and occurredAt timestamp handling.

* **Chores**
  * SDK version bumped to 0.3.9.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/78)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->