### PR TITLE
chore(cli): bump to 0.6.10

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Ships the appendMessage assistant-role / occurredAt / idempotency server-side changes from #78 and the new `0023_session_events_message_id_idx` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package version to 0.6.10.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/79)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->