### PR TITLE
fix(policy): dedupe concurrent SELECTs + retry + surface err.cause

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2968,7 +2968,18 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     if (error instanceof OpenHermitError) {
       return c.json(jsonError(error), error.statusCode);
     }
-    console.error('[openhermit-gateway] unhandled error', error);
+    // Drizzle/pg wrap the underlying driver error on `.cause`. Without
+    // dumping it the only thing we see is "Failed query: select ...",
+    // which makes runtime/pool issues (connection eviction, terminated
+    // backend, prepared-statement conflicts) effectively unfixable from
+    // production logs alone.
+    const cause = (error as { cause?: unknown }).cause;
+    const code = (error as { code?: unknown }).code
+      ?? (cause as { code?: unknown } | undefined)?.code;
+    console.error('[openhermit-gateway] unhandled error', error, {
+      ...(code !== undefined ? { code } : {}),
+      ...(cause !== undefined ? { cause } : {}),
+    });
     return c.json(jsonError(getErrorMessage(error), 'internal_error'), 500);
   });
 

--- a/packages/store/src/impl/policy-store.ts
+++ b/packages/store/src/impl/policy-store.ts
@@ -13,6 +13,16 @@ import type { DrizzleDb } from './index.js';
 export class DbPolicyStore implements PolicyStore {
   private pool?: pg.Pool;
 
+  /**
+   * In-flight `list` promises keyed by `agentId|resourceType` (or
+   * `agentId|*` for "all types"). Concurrent callers within the same
+   * tick share a single SELECT — this is the hot path during
+   * `openSession`, where two parallel sessions on the same agent each
+   * load 'tool' and 'mcp' policies. Cleared as soon as the promise
+   * settles, so no staleness risk.
+   */
+  private readonly inFlightList = new Map<string, Promise<PolicyRecord[]>>();
+
   constructor(private readonly db: DrizzleDb) {}
 
   static async open(databaseUrl?: string): Promise<DbPolicyStore> {
@@ -31,12 +41,44 @@ export class DbPolicyStore implements PolicyStore {
   }
 
   async list(agentId: string, resourceType?: string): Promise<PolicyRecord[]> {
+    const key = `${agentId}|${resourceType ?? '*'}`;
+    const existing = this.inFlightList.get(key);
+    if (existing) return existing;
+
+    const promise = this.runList(agentId, resourceType);
+    this.inFlightList.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inFlightList.delete(key);
+    }
+  }
+
+  private async runList(agentId: string, resourceType?: string): Promise<PolicyRecord[]> {
     const conditions = resourceType
       ? and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.resourceType, resourceType))
       : eq(agentPolicies.agentId, agentId);
 
-    const rows = await this.db.select().from(agentPolicies).where(conditions);
-    return rows.map(toRecord);
+    // One in-process retry: the SELECT itself is idempotent and the
+    // reported failure mode was transient ("DrizzleQueryError" with no
+    // schema mismatch). Cheaper than 500ing the caller.
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const rows = await this.db.select().from(agentPolicies).where(conditions);
+        return rows.map(toRecord);
+      } catch (err) {
+        lastErr = err;
+        const cause = (err as { cause?: unknown }).cause;
+        const code = (err as { code?: unknown }).code
+          ?? (cause as { code?: unknown } | undefined)?.code;
+        console.warn(
+          `[policy-store] list(${agentId}, ${resourceType ?? '*'}) attempt ${attempt + 1} failed`,
+          { code, cause: cause ?? err },
+        );
+      }
+    }
+    throw lastErr;
   }
 
   async get(


### PR DESCRIPTION
## Summary

amiko-chat reported that two concurrent \`POST /api/agents/<id>/sessions\` on the same agent (self persona + as-owner persona for a shared-account twin) consistently 500 one of the two with a \`DrizzleQueryError\` on \`agent_policies\`. The Drizzle wrapper hid the underlying pg cause, making this undebuggable from production logs.

### Changes
- **\`DbPolicyStore.list\`**: in-flight singleflight by \`agentId|resourceType\`. Two parallel \`openSession\` calls on the same warm agent currently both load \`tool\` + \`mcp\` policies; they now share one in-flight promise. Promise is cleared on settle, no staleness risk.
- **\`DbPolicyStore.list\`**: one in-process retry on failure. The SELECT is idempotent and the reported failure mode looked transient. Each attempt warn-logs \`err.cause\` / \`err.code\`.
- **Gateway \`onError\`**: now logs \`error.cause\` and \`error.code\` (the underlying pg error from node-postgres) alongside the Drizzle wrapper, so the next occurrence is diagnosable from logs alone.

### Notes
- We're not adding a per-agent mutex around \`openSession\` itself — the hydration path (\`AgentInstanceManager.getOrHydrate\`) is already singleflighted (apps/gateway/src/agent-instance.ts:296). The remaining contention surface was the per-session policy load, which this PR addresses.
- If the underlying \`err.cause\` turns out to be e.g. pool eviction on shutdown, we'll see it in logs after deploy and can do a targeted follow-up.

## Test plan
- [x] \`npm run typecheck\` clean across all workspaces
- [ ] Deploy to test, exercise amiko dispatcher's parallel openSession pair, confirm both succeed
- [ ] If a future failure recurs, confirm \`err.cause\` / \`err.code\` now appear in gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of policy store operations with automatic retry and deduplication mechanisms
  * Enhanced error logging with better diagnostics for troubleshooting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->