### PR TITLE
feat(agent): abort turn after 15 consecutive tool failures

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1,7 +1,18 @@
 import { userInfo } from 'node:os';
 import { randomBytes } from 'node:crypto';
 
-import { Agent, type AgentEvent, type AgentMessage } from '@mariozechner/pi-agent-core';
+import {
+  Agent,
+  type AfterToolCallContext,
+  type AfterToolCallResult,
+  type AgentEvent,
+  type AgentMessage,
+} from '@mariozechner/pi-agent-core';
+
+type AfterToolCallHook = (
+  ctx: AfterToolCallContext,
+  signal?: AbortSignal,
+) => Promise<AfterToolCallResult | undefined>;
 import type { MessageSender, SessionHistoryMessage, SessionListQuery, SessionMessage, SessionSpec, SessionSummary } from '@openhermit/protocol';
 import { NotFoundError, ValidationError, getErrorMessage } from '@openhermit/shared';
 import {
@@ -89,6 +100,10 @@ import {
   agentTurnDuration,
   agentTurnsTotal,
 } from './metrics.js';
+
+/** Abort the turn after this many consecutive tool failures. Bounds the
+ *  cost of a model that keeps re-calling a permanently broken tool. */
+const MAX_CONSECUTIVE_TOOL_FAILURES = 15;
 
 const addUserIdToList = (existing: string[], userId: string | undefined): string[] => {
   if (!userId) return existing;
@@ -570,6 +585,21 @@ export class AgentRunner implements SessionRuntime {
       resolvedUserName,
       resolvedChannel,
       resolvedChannelUserId,
+      async (ctx) => {
+        if (!session) return undefined;
+        if (ctx.isError) {
+          session.consecutiveToolFailures += 1;
+          if (session.consecutiveToolFailures >= MAX_CONSECUTIVE_TOOL_FAILURES) {
+            this.logRuntime(
+              `session ${session.spec.sessionId}: aborting turn after ${session.consecutiveToolFailures} consecutive tool failures`,
+            );
+            session.agent.abort();
+          }
+        } else {
+          session.consecutiveToolFailures = 0;
+        }
+        return undefined;
+      },
     );
     session = {
       spec: effectiveSpec,
@@ -586,6 +616,7 @@ export class AgentRunner implements SessionRuntime {
       status: 'idle',
       messageCount: persisted?.messageCount ?? 0,
       completedTurnCount: persisted?.completedTurnCount ?? 0,
+      consecutiveToolFailures: 0,
       ...(persisted?.description ? { description: persisted.description } : {}),
       ...(persisted?.descriptionSource
         ? { descriptionSource: persisted.descriptionSource }
@@ -1070,6 +1101,7 @@ export class AgentRunner implements SessionRuntime {
       try {
         await this.refreshAgentConfiguration(session);
         session.latestAssistantText = undefined;
+        session.consecutiveToolFailures = 0;
         if (message.messageId !== undefined) {
           session.currentTurnCorrelationId = message.messageId;
         } else {
@@ -1771,6 +1803,7 @@ export class AgentRunner implements SessionRuntime {
     userName?: string,
     channel?: string,
     channelUserId?: string,
+    afterToolCall?: AfterToolCallHook,
   ): Promise<Agent> {
     return this.createConfiguredAgent({
       config,
@@ -1788,6 +1821,7 @@ export class AgentRunner implements SessionRuntime {
       ...(spec.source.type ? { sessionType: spec.source.type } : {}),
       sourceKind: spec.source.kind,
       ...(spec.customInstruction ? { customInstruction: spec.customInstruction } : {}),
+      ...(afterToolCall ? { afterToolCall } : {}),
     });
   }
 
@@ -1809,6 +1843,7 @@ export class AgentRunner implements SessionRuntime {
     sessionType?: import('@openhermit/protocol').SessionType;
     sourceKind?: string;
     customInstruction?: string;
+    afterToolCall?: AfterToolCallHook;
   }): Promise<Agent> {
     const webProvider = this.resolveWebProvider(input.config);
 
@@ -2145,6 +2180,7 @@ export class AgentRunner implements SessionRuntime {
       transformContext: (messages, signal) =>
         this.transformContext(input.contextSessionId, messages, signal),
       transport: 'sse',
+      ...(input.afterToolCall ? { afterToolCall: input.afterToolCall } : {}),
     });
   }
 

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -36,6 +36,11 @@ export interface RunnerSession extends SessionDescriptor {
   resolvedChannelUserId?: string;
   langfuseTurnContext?: LangfuseTurnContext;
   turnStartMs?: number;
+  /** Consecutive failed tool results in the current turn. Resets at turn
+   *  start and on any successful tool result. The agent aborts the turn
+   *  when this reaches `MAX_CONSECUTIVE_TOOL_FAILURES` to prevent the
+   *  model from looping forever against a broken tool. */
+  consecutiveToolFailures: number;
 }
 
 export interface AgentRunnerOptions {


### PR DESCRIPTION
## Summary
- Add a per-session `consecutiveToolFailures` counter on `RunnerSession` that increments on every errored tool result, resets on any successful tool result, and resets at the start of each turn.
- Wire an `afterToolCall` hook through `createAgent` → `createConfiguredAgent` → `new Agent({...})` to drive the counter. When it hits `MAX_CONSECUTIVE_TOOL_FAILURES = 15`, call `session.agent.abort()` so the upstream agent loop exits cleanly with `stopReason: 'aborted'`.

## Why
The pi-agent-core agent loop has no built-in stopping rule for repeated tool failures — a model that keeps re-invoking a permanently broken tool will burn tokens until the context window fills and compaction kicks in. A simple per-turn circuit breaker bounds the cost.

## Test plan
- [ ] Manually verify with a deliberately broken tool that the turn ends after 15 consecutive errors.
- [ ] Confirm a single successful tool result resets the counter mid-turn.
- [ ] Confirm a fresh user message starts the counter at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent infinite tool execution loops. Agent now tracks consecutive tool failures per session turn and automatically aborts turns when failures exceed the configured threshold, preventing the agent from getting stuck in problematic loops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/82)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->