### PR TITLE
docs(manual): add user-facing manual

### DIFF
--- a/docs/manual/01-introduction.md
+++ b/docs/manual/01-introduction.md
@@ -1,0 +1,64 @@
+---
+title: What OpenHermit Is
+slug: introduction
+order: 1
+part: Part 1 — Getting Started
+description: What OpenHermit is, what problem it solves, what it is good at, and what it is not good at.
+---
+
+# 1. What OpenHermit Is
+
+OpenHermit is **a platform for running AI agents**. You give it a model (Claude, GPT, Gemini, …) and connect it to the places you already talk — Telegram, Discord, Slack, the web, the command line — and your agent then lives in the cloud as a long-running service. You send it a message, it replies. You ask it to run a command, it runs one. You tell it to file a report every weekday morning, it files one every weekday morning.
+
+The main difference from local agents like Claude Code or Cursor is that **OpenHermit is not tied to a single machine**. It has a persistent identity in the cloud — memories, sessions, skills, configuration, scheduled jobs — and any entry point you use sees the same agent.
+
+This manual is for people who already have an OpenHermit agent. Setting up a new OpenHermit instance is a different topic and lives in the operator docs.
+
+---
+
+## What It Solves
+
+If you have used Claude Code or similar local tools, you have probably hit some of these:
+
+- You taught the agent your preferences on your work laptop, then on your home laptop it remembered nothing.
+- You wanted the agent to run a job overnight, but your laptop sleeps.
+- You wanted a friend to use your agent, but its memory and history are tied to your machine.
+- You wanted to reach the agent from Telegram or Slack instead of a terminal, and configuring a bridge turned into a side project.
+
+OpenHermit's design starts from those problems. The agent has durable cloud-side state, multiple entry points reach the same agent, multiple people can share an agent with proper isolation, and the agent keeps working while you are offline.
+
+---
+
+## What You Can Use It For
+
+- **Personal assistant** — remembers your preferences and tasks, reachable from phone or laptop, sends you scheduled reminders or digests.
+- **Shared team assistant** — a few people share one agent: a shared knowledge base, daily standup summaries, customer support triage.
+- **Vertical chatbot** — drop it into a Telegram or Discord group to serve a community around a specific topic.
+- **Background worker** — scheduled jobs to pull data, scrape, write daily reports, check on services.
+- **MCP-driven automation** — connect GitHub, Linear, Slack, or your own internal APIs as MCP tools, then operate them in natural language.
+
+---
+
+## What It Is Not Good At
+
+- **Fully offline work.** OpenHermit assumes a gateway is reachable. For air-gapped environments, a local-only tool is a better fit.
+- **Massive end-user SaaS.** You can build on it, but rate limits, billing, abuse handling — those are still your job.
+- **Replacing an IDE.** It can write code, edit files, and run commands, but it is not VS Code. Code editing inside an IDE is still smoother.
+- **Acting as an unrestricted root.** By default it can touch its workspace and run sandboxed commands; reaching the outside world needs MCP servers or secrets that you provision. It is not free to do anything.
+
+---
+
+## Two Words You Will See Throughout
+
+Even if you are the only person using your agent, two terms are worth holding onto:
+
+- **Agent** — the "it" that replies to you. An OpenHermit instance can host multiple agents (say, one named *work* and one named *home*) that share nothing — memories, configuration, and access lists are all independent.
+- **You as owner** — you created the agent, so you are its **owner**. Owners can change settings, add members, see every session, and use every tool. Anyone else you invite gets a more restricted role: *user* or *guest*. The details are in [Chapter 5 · Users and Identity](05-users-and-identity.md).
+
+---
+
+## Where to Go Next
+
+- Want to get something running first: [Chapter 2 · Quickstart](02-quickstart.md).
+- Want to read concepts before touching anything: [Chapter 3 · Core Concepts](03-concepts.md).
+- Already using it, looking for a specific recipe: open the relevant chapter and scroll to its *How-to recipes* section.

--- a/docs/manual/02-quickstart.md
+++ b/docs/manual/02-quickstart.md
@@ -1,0 +1,128 @@
+---
+title: Quickstart
+slug: quickstart
+order: 2
+part: Part 1 — Getting Started
+description: Install the CLI, create your first agent, and send a first message — in about ten minutes.
+---
+
+# 2. Quickstart
+
+This chapter takes you from nothing to a working agent in about ten minutes. You will install the CLI, start a local gateway, create an agent, send a message, and learn the three or four commands you will use every day.
+
+---
+
+## 2.1 Prerequisites
+
+You need:
+
+- **Node.js 20 or newer** — check with `node --version`.
+- **A PostgreSQL database** — local Postgres, Docker Postgres, or a managed Postgres URL.
+- **At least one model provider API key** — Anthropic, OpenAI, or OpenRouter.
+
+If you do not have Postgres handy, the `docker-compose.yml` at the root of the repo brings one up:
+
+```bash
+docker compose up -d postgres
+```
+
+---
+
+## 2.2 Install the CLI
+
+```bash
+npm install -g openhermit
+```
+
+This installs the `hermit` command. Confirm it works:
+
+```bash
+hermit --version
+```
+
+---
+
+## 2.3 Run the Setup Wizard
+
+The fastest path is the interactive wizard. It walks through the database URL, the model provider, and the first agent in one pass.
+
+```bash
+hermit setup
+```
+
+When the wizard asks for things:
+
+- **Postgres URL** — for example `postgres://postgres:postgres@localhost:5432/openhermit`.
+- **Provider** — `anthropic`, `openrouter`, or `openai`.
+- **API key** — paste the key you got from your provider.
+- **First agent ID** — pick something short, like `main`.
+
+The wizard creates the gateway config, runs database migrations, and starts the gateway in the background.
+
+---
+
+## 2.4 Verify the Setup
+
+```bash
+hermit doctor
+```
+
+`doctor` checks that the gateway is up, the database is reachable, your API key works, and your agent is registered. If it complains, the error tells you which piece is wrong.
+
+```bash
+hermit status
+```
+
+`status` gives you a one-screen overview: which agents exist, whether each is enabled, and which channels are connected.
+
+---
+
+## 2.5 Send Your First Message
+
+Two ways.
+
+**From the terminal** — open an interactive chat:
+
+```bash
+hermit chat --agent main
+```
+
+You will see a prompt. Type a message and press Enter. The agent streams its reply.
+
+**From the web UI** — start the web server:
+
+```bash
+hermit web start
+```
+
+It tells you a URL (default `http://localhost:5173`). Open it in a browser, pick your agent, and chat.
+
+Either way, the conversation is stored as a **session** and persists across restarts.
+
+---
+
+## 2.6 The Five Commands You Will Use Most
+
+These are the commands worth learning today:
+
+| Command | What it does |
+|---|---|
+| `hermit status` | One-screen overview of agents, channels, gateway state. |
+| `hermit chat --agent <id>` | Open an interactive chat with an agent. |
+| `hermit logs -f` | Tail the gateway log; useful when something feels stuck. |
+| `hermit config show --agent <id>` | Print the current configuration for an agent. |
+| `hermit agents list` | List all agents in this instance. |
+
+Full command reference: [Chapter 19 · CLI Cheatsheet](19-cli-cheatsheet.md).
+
+---
+
+## 2.7 What Now
+
+You have a working agent. Some natural next steps:
+
+- **Understand what just happened** — [Chapter 3 · Core Concepts](03-concepts.md) explains the words *agent*, *session*, *channel*, *skill*, *workspace*.
+- **Connect Telegram or Slack** — [Chapter 17 · Channels](17-channels.md).
+- **Let someone else use this agent** — [Chapter 12 · Inviting People](12-inviting-people.md).
+- **Teach the agent persistent rules** — [Chapter 7 · Instructions](07-instructions.md).
+- **Give it a scheduled job** — [Chapter 11 · Schedules](11-schedules.md).

--- a/docs/manual/02-quickstart.md
+++ b/docs/manual/02-quickstart.md
@@ -95,7 +95,7 @@ You will see a prompt. Type a message and press Enter. The agent streams its rep
 hermit web start
 ```
 
-It tells you a URL (default `http://localhost:5173`). Open it in a browser, pick your agent, and chat.
+It tells you a URL (default `http://localhost:4310`). Open it in a browser, pick your agent, and chat. The gateway itself listens on `http://localhost:4000`.
 
 Either way, the conversation is stored as a **session** and persists across restarts.
 

--- a/docs/manual/03-concepts.md
+++ b/docs/manual/03-concepts.md
@@ -1,0 +1,118 @@
+---
+title: Core Concepts
+slug: concepts
+order: 3
+part: Part 1 — Getting Started
+description: The seven words you will see in every chapter — agent, session, channel, skill, MCP server, memory, workspace.
+---
+
+# 3. Core Concepts
+
+Seven words make up the vocabulary used in every later chapter. Read this once and most of the rest of the manual reads naturally.
+
+---
+
+## 3.1 Agent
+
+An **agent** is the persistent "it" that replies to you. From your side, it is a name (`main`, `work`, `home`) attached to:
+
+- a configured **model** (which LLM it thinks with),
+- a set of **skills** and **MCP servers** (what it can do),
+- a **workspace** (what files it can touch),
+- **memory** and **instructions** (what it remembers and what rules it follows),
+- a list of **members** (who is allowed to talk to it and what they can do).
+
+One OpenHermit instance can host many agents. They are isolated: different memories, different configuration, different access lists.
+
+---
+
+## 3.2 Session
+
+A **session** is a single conversation. It has a history of messages, an ID, a list of participants, and a status (active or closed).
+
+You can have many sessions with the same agent in parallel — one per topic, one per channel, one per project, however you like to organize. Closing a session does not erase it; you can resume it later. The agent's long-term memory persists across sessions, but a session's own message history belongs only to that session.
+
+In channels like Telegram or Slack, a session usually corresponds to a chat or a thread.
+
+---
+
+## 3.3 Channel
+
+A **channel** is how messages reach the agent. OpenHermit ships with five:
+
+| Channel | What it is |
+|---|---|
+| **CLI** | The `hermit chat` terminal. |
+| **Web** | Browser-based chat at the admin UI. |
+| **Telegram** | A Telegram bot you connect with a bot token. |
+| **Discord** | A Discord bot (gateway connection). |
+| **Slack** | A Slack app (socket mode). |
+
+The same agent can be reachable on several channels at once. Sessions stay isolated per conversation; memory and configuration are shared.
+
+---
+
+## 3.4 Skill
+
+A **skill** is a packaged capability you can turn on for an agent — a `SKILL.md` plus any supporting files (scripts, prompts, references). Examples: *standup-digest*, *web-research*, *postgres-explorer*.
+
+Skills come in two flavours: **built-in** (ship with OpenHermit) and **workspace** (you register yourself from a local folder). Either way, enabling a skill for an agent makes its instructions and tools available; disabling hides them again.
+
+You control skills with the `hermit skills` family of commands or in the Web admin UI's *Skills* tab.
+
+---
+
+## 3.5 MCP Server
+
+An **MCP server** is an external tool provider — anything from GitHub or Slack to your own internal API — that speaks the [Model Context Protocol](https://modelcontextprotocol.io). Connecting an MCP server lets your agent call its tools as part of normal conversation.
+
+MCP servers are registered globally with OpenHermit and enabled per agent (or fleet-wide). Day-to-day: `hermit mcp` or the *MCP* tab in the admin UI.
+
+---
+
+## 3.6 Memory
+
+**Memory** is what the agent keeps across sessions. Three layers:
+
+- **Session history** — every message in a session. Naturally local to that session.
+- **Working memory** — short-lived notes the agent keeps inside one session (e.g. "the user wants this report in markdown").
+- **Long-term memory** — entries persisted in the database, searchable across sessions. This is where preferences, facts, and learned patterns live.
+
+You teach long-term memory mostly by talking: "remember that I am vegetarian", "remember that our staging URL is …". You can also read and curate it through the admin UI. [Chapter 6 · Memory](06-memory.md) goes deep.
+
+---
+
+## 3.7 Workspace
+
+The **workspace** is the agent's "computer" — a filesystem it can read and write inside a sandbox. Each agent has its own workspace, isolated from others.
+
+This is where uploaded files land, where the agent saves generated artefacts, where it clones a repo if you ask it to. The workspace is **shared across sessions** for one agent: a file you uploaded in one chat is visible to the agent in the next.
+
+The sandbox can be a local Docker container, an E2B cloud sandbox, or a Daytona workspace, depending on how the instance was set up. That choice is operator-side; from your seat, the workspace just looks like the agent's hard drive. Details in [Chapter 10 · Files and Workspace](10-files-and-workspace.md).
+
+---
+
+## 3.8 How They Fit Together
+
+A rough picture:
+
+```
+  ┌─────────────────────────── Agent: "main" ─────────────────────────┐
+  │                                                                   │
+  │   ┌──────────┐    ┌──────────┐    ┌──────────┐                    │
+  │   │ Sessions │    │  Memory  │    │ Instr's  │                    │
+  │   └──────────┘    └──────────┘    └──────────┘                    │
+  │                                                                   │
+  │   ┌──────────┐    ┌──────────┐    ┌──────────┐                    │
+  │   │  Skills  │    │   MCP    │    │ Workspace│                    │
+  │   └──────────┘    └──────────┘    └──────────┘                    │
+  │                                                                   │
+  └───────────────────────────────┬───────────────────────────────────┘
+                                  │
+       ┌────────────┬─────────────┼─────────────┬────────────┐
+     CLI         Web UI      Telegram         Discord       Slack
+```
+
+You reach the agent through any **channel**. Inside a channel, each conversation is a **session**. The agent draws on **memory**, **instructions**, **skills**, **MCP servers**, and its **workspace** to do work. **Members** (you and anyone else you invited) each have a role that decides what they can ask the agent to do.
+
+That is the whole picture. Every later chapter is a closer look at one of these boxes.

--- a/docs/manual/04-talking-to-your-agent.md
+++ b/docs/manual/04-talking-to-your-agent.md
@@ -57,7 +57,7 @@ While inside `chat`, press **Ctrl-C** once to interrupt the current reply (the a
 hermit web start
 ```
 
-Open the URL it prints (usually `http://localhost:5173`). Pick an agent in the sidebar, pick or create a session, type your message.
+Open the URL it prints (default `http://localhost:4310`; the gateway it talks to listens on `http://localhost:4000`). Pick an agent in the sidebar, pick or create a session, type your message.
 
 The web channel has a few things the CLI does not:
 

--- a/docs/manual/04-talking-to-your-agent.md
+++ b/docs/manual/04-talking-to-your-agent.md
@@ -1,0 +1,184 @@
+---
+title: Talking to Your Agent
+slug: talking-to-your-agent
+order: 4
+part: Part 2 — Daily Use
+description: Five ways to reach your agent (CLI, Web, Telegram, Discord, Slack), how sessions work, and how to attach files, interrupt, and resume.
+---
+
+# 4. Talking to Your Agent
+
+Your agent is one thing; the ways to reach it are several. This chapter walks through the five built-in channels, how a conversation is organized into a session, and the four day-to-day actions you will keep wanting: send, attach, interrupt, resume.
+
+---
+
+## 4.1 The Five Channels
+
+| Channel | Best for | Set up in |
+|---|---|---|
+| **CLI** | Quick local chats, scripting, debugging | Works out of the box once `hermit` is installed |
+| **Web** | Daily use from a browser, file uploads, browsing history | Started with `hermit web start` |
+| **Telegram** | Mobile, on-the-go | [Chapter 17 · Channels](17-channels.md) |
+| **Discord** | Community use, group servers | [Chapter 17 · Channels](17-channels.md) |
+| **Slack** | Team use, threads, internal tools | [Chapter 17 · Channels](17-channels.md) |
+
+All five reach the same agent — same memory, same skills, same configuration. The only thing that differs is how the conversation looks on your screen.
+
+---
+
+## 4.2 What a Session Is
+
+Every conversation is a **session**: a thread of messages with an ID, participants, and a status. A session is created automatically the first time you message an agent through a particular conversation context (a Telegram chat, a Slack thread, an interactive CLI invocation, …).
+
+Sessions persist. You can close one, walk away, and resume it later — the agent picks up where you left off. The agent's long-term memory survives across sessions, but a session's own scrollback is private to that session.
+
+---
+
+## 4.3 The CLI Channel
+
+```bash
+hermit chat --agent main
+```
+
+You get a prompt. Type, press Enter, the agent streams its reply. Useful flags:
+
+```bash
+hermit chat --agent main --session <id>     # resume a specific session
+hermit chat --agent main --resume           # resume your most recent session
+```
+
+While inside `chat`, press **Ctrl-C** once to interrupt the current reply (the agent stops mid-stream but the session stays open). Press it twice to exit.
+
+---
+
+## 4.4 The Web Channel
+
+```bash
+hermit web start
+```
+
+Open the URL it prints (usually `http://localhost:5173`). Pick an agent in the sidebar, pick or create a session, type your message.
+
+The web channel has a few things the CLI does not:
+
+- **File attachments** — drag a file onto the chat to upload it into the agent's workspace.
+- **Session list** — every session you participated in, with previews.
+- **Streaming with markdown rendering** — code blocks, tables, links render properly.
+- **Tool call transcripts** — you can expand a step to see exactly what tool the agent called and what it got back.
+
+---
+
+## 4.5 Telegram, Discord, Slack
+
+For these to work, the agent's owner has to connect a bot token first ([Chapter 17 · Channels](17-channels.md)).
+
+Once connected:
+
+- A **direct message** to the bot opens a session bound to your conversation.
+- A **group / channel** message creates a group session including everyone who has posted (subject to access policy; see [Chapter 13 · Access Levels](13-access-levels.md)).
+- Replying to a thread keeps you in that thread's session.
+
+If you write to a freshly connected bot for the first time and the agent does not reply, you might be on the wrong side of [access levels](13-access-levels.md) — ask the owner to add you as a member.
+
+---
+
+## 4.6 Four Things You Will Do Constantly
+
+**Send** — just type.
+
+**Attach** — drag a file into the web UI, or in Telegram/Slack/Discord attach a file natively. The agent sees the file in its workspace and can open, edit, or refer to it.
+
+**Interrupt** — sometimes the agent goes off on the wrong path. To stop it:
+
+- CLI: **Ctrl-C** during the reply.
+- Web: click the **Stop** button next to the streaming message.
+- Telegram/Discord/Slack: send a follow-up like "stop" or "wait" — the runner accepts steering messages mid-turn and will fold them into the next step. Hard interrupt is not available on chat channels.
+
+**Resume** — most channels resume automatically (you message the same Telegram chat → you are in the same session). For the CLI, use `--resume` or `--session <id>`.
+
+---
+
+## 4.7 Role Differences
+
+The same channel can show different things to different people:
+
+- **Owners** see every session for the agent.
+- **Users** see only sessions they participate in.
+- **Guests** see only the session(s) they are part of, and the agent has a reduced toolset for them (no exec, no file editing — see the matrix in [Chapter 5](05-users-and-identity.md#5-4-capability-matrix)).
+
+If you log in expecting to see a session and it is missing, it is usually because your role does not allow it.
+
+---
+
+## 4.8 How-to Recipes
+
+### 4.8.1 Resume a session you left yesterday
+
+**Scenario** — you closed your laptop in the middle of a CLI chat; today you want to pick it up.
+
+**Ways to do it**
+
+CLI:
+
+```bash
+hermit chat --agent main --resume
+```
+
+That drops you back into the most recent session for that agent.
+
+Web: open the agent in the web UI; the most recent session is at the top of the sidebar.
+
+Telegram/Slack/Discord: just send a new message in the same chat or thread. The runner re-hydrates the session automatically.
+
+**Verify** — the agent's first reply references something from yesterday's exchange.
+
+---
+
+### 4.8.2 Start a fresh session even though you are on the same channel
+
+**Scenario** — you are in a Telegram DM with the agent, and you want to switch topics cleanly without dragging the previous thread's context along.
+
+**Ways to do it**
+
+- Telegram / Discord: tell the agent "let's start fresh" — it will not automatically open a new session, but for cleanliness you can ask the owner (via Web UI or CLI) to close the current one. New messages then open a new session.
+- Web: click **New session** in the sidebar.
+- CLI: exit (Ctrl-C twice) and re-run `hermit chat --agent main` without `--resume`.
+
+**Verify** — the new session has no scrollback and the agent does not reference old context (but it may still recall things stored in long-term memory; that is a feature, not a bug — see [Chapter 6 · Memory](06-memory.md)).
+
+---
+
+### 4.8.3 Send a file and ask the agent about it
+
+**Scenario** — you want the agent to read a CSV you have on disk.
+
+**Ways to do it**
+
+Web (easiest): drag the file into the chat window and type your question.
+
+CLI: copy the file into the agent's workspace path first ([Chapter 10 · Files and Workspace](10-files-and-workspace.md)), then reference it by name in your message.
+
+Telegram/Slack/Discord: send the file as an attachment in the chat. The adapter writes it into the workspace and the agent gets a notification it has arrived.
+
+**Verify** — ask "what columns are in `<filename>`?" — the agent should answer with the actual headers.
+
+---
+
+### 4.8.4 Interrupt a reply that is going the wrong way
+
+**Scenario** — the agent has started doing the wrong thing (writing the wrong file, going down the wrong reasoning path) and you want to stop it before it finishes.
+
+**Ways to do it**
+
+- CLI/Web: hit the stop control mid-stream.
+- Chat channels: send a one-line correction. The runner queues it as a *steering message* — it is inserted into the conversation before the agent's next step, so the agent reads your correction and changes direction.
+
+**Verify** — the agent acknowledges the change of direction in its next reply.
+
+---
+
+## 4.9 Pointers
+
+- Connect a new channel: [Chapter 17 · Channels](17-channels.md).
+- Manage who can use this agent: [Chapter 12 · Inviting People](12-inviting-people.md).
+- Why the agent forgets / does not forget across sessions: [Chapter 6 · Memory](06-memory.md).

--- a/docs/manual/05-users-and-identity.md
+++ b/docs/manual/05-users-and-identity.md
@@ -170,16 +170,16 @@ curl -X POST "$GATEWAY/api/agents/<agent-id>/members" \
 
 ```bash
 hermit web start
-# Browser opens with a token already attached, recognising you as owner.
+# Open the printed local web URL, then sign in with the same gateway credentials.
 ```
 
-If you opened the URL manually instead, copy the token printed by `hermit web start` into the browser's "sign in with token" field.
+The web server command starts the UI and prints the listening URL; it does not itself create a browser identity link. If the browser still appears as a separate guest after sign-in, use the identity-link flow from 5.6.2.
 
 *Link the web identity manually.* Same shape as 5.6.1 with `channel = web` and the device fingerprint shown in the Admin UI.
 
 **Verify** — the Admin UI shows the full management surface (Manage tab is visible and editable), not just a chat view.
 
-**Common issues** — using a different browser, or an incognito window, gives you a new fingerprint. You have to re-link or use a fresh token each time, unless you sign in through the same browser profile.
+**Common issues** — using a different browser, or an incognito window, gives you a new web identity. Link that identity again if you want it to resolve to the same user.
 
 ---
 

--- a/docs/manual/05-users-and-identity.md
+++ b/docs/manual/05-users-and-identity.md
@@ -1,0 +1,195 @@
+---
+title: Users and Identity
+slug: users-and-identity
+order: 5
+part: Part 2 — Daily Use
+description: The three roles, how OpenHermit recognises you across channels, the capability matrix, and how to link your Telegram, web, and CLI selves into one user.
+---
+
+# 5. Users and Identity
+
+Whether you are the only person using your agent or you share it with several others, OpenHermit needs to know who is talking right now. It figures that out from your identity at each entry point — your Telegram user ID, your web device fingerprint, your CLI username — and then it decides what you can do based on your role on this particular agent. This chapter covers those two questions: how it recognises you, and what each role can do. The end of the chapter has recipes for the most common identity tangles, like wanting your Telegram self and your web self to count as the same person.
+
+---
+
+## 5.1 The Three Roles
+
+Every member of an agent has one of three **roles**.
+
+**Owner.** The person who created the agent (or someone the original owner promoted). Owners can change every setting, add and remove members, see every session on the agent, and use every tool. There is at least one owner per agent; there can be more.
+
+**User.** A trusted member. Users can have normal conversations, use the agent's tools (web search, file operations, exec, memory), and see the sessions they themselves participate in. They cannot change configuration, manage skills or MCP servers, manage other members, or read sessions they did not participate in.
+
+**Guest.** A low-trust member, often auto-created from an unknown identity on a `public` agent. Guests can chat and use a restricted set of tools (web only — no file editing, no exec, no memory writes), and they see only sessions they took part in.
+
+---
+
+## 5.2 How OpenHermit Recognises You
+
+You do not have a single account. You have one or more **identities**, each of which is a `(channel, channel_user_id)` pair:
+
+- CLI → `(cli, <your OS username>)`
+- Web → `(web, <a browser device fingerprint>)`
+- Telegram → `(telegram, <Telegram user ID>)`
+- Discord → `(discord, <Discord user ID>)`
+- Slack → `(slack, <Slack user ID>)`
+
+All your identities point to a single internal **user**, and your role on the agent is attached to the user — not to any single identity. Add a new identity, and you keep your role.
+
+The first time a new identity messages an agent, OpenHermit decides what to do based on the agent's [access level](13-access-levels.md): create a guest, demand an access token, or reject. Once the identity is on file, the owner can promote it, link it to an existing user, or merge it with another.
+
+---
+
+## 5.3 You Probably Have More Than One Identity
+
+If you set up an agent on the CLI and then opened it from a browser, those are two identities. If you also message it from Telegram, that is a third. By default, OpenHermit does not know they are the same person — to it, three identities means three users, possibly all with different roles.
+
+This is fine until something surprises you:
+
+- You taught the agent something from CLI; from Telegram it has no idea what you mean.
+- You are the owner from CLI but you can only see a guest's view from Telegram.
+- A Members list shows your name twice.
+
+The fix is identity linking. The recipes in 5.5 cover it.
+
+---
+
+## 5.4 Capability Matrix
+
+This is the source of truth that later chapters refer back to. Each ✓ means "yes, by default"; gaps mean "blocked by role". Custom policy can tighten things further; see [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+
+| Capability | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Send messages, chat | ✓ | ✓ | ✓ |
+| Use web tools (search, fetch) | ✓ | ✓ | ✓ |
+| Read/write workspace files | ✓ | ✓ | — |
+| Run sandbox commands (exec) | ✓ | ✓ | — |
+| Read/write long-term memory | ✓ | ✓ | — |
+| Read/write instructions | ✓ | — | — |
+| List sessions | All | Own | Own |
+| Send proactive message to another session | ✓ | — | — |
+| Manage schedules | ✓ | Read | Read |
+| Manage skills | ✓ | — | — |
+| Manage MCP servers | ✓ | — | — |
+| Manage channels | ✓ | — | — |
+| Manage secrets | ✓ | — | — |
+| Add/remove members, change roles | ✓ | — | — |
+| Merge identities | ✓ (any) | Own | — |
+
+---
+
+## 5.5 How-to Recipes
+
+### 5.5.1 Make Telegram see you as yourself, not as a guest
+
+**Scenario** — you created your agent from the web (so the web identity is the owner), then you opened a Telegram chat with the bot. Telegram sees a new identity and either drops your message (on `protected` or `private` access) or creates a guest user.
+
+**Prerequisites** — the agent has Telegram connected ([Chapter 17 · Channels](17-channels.md)). You know your Telegram user ID (ask `@userinfobot` on Telegram, or check the Members panel — guests show up with their channel ID).
+
+**Ways to do it**
+
+*Let the agent do it.* From the web (where you are owner), say:
+
+> Link Telegram user `656756615` to my account.
+
+The agent calls its identity-linking tool and confirms.
+
+*Web admin UI.* Open the agent's *Manage* page, go to the section listing members (typically reached via the `/api/agents/<id>/members` flow surfaced in the UI; if your admin UI does not expose this directly, use the API path below). Find your own entry, add an identity, choose `channel = telegram`, paste the ID.
+
+*HTTP API.* Owner-only:
+
+```bash
+curl -X POST "$GATEWAY/api/agents/<agent-id>/members" \
+  -H "Authorization: Bearer <your-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"telegram","channelUserId":"656756615","userId":"<your-user-id>"}'
+```
+
+**Verify** — send a message from Telegram. Ask the agent "who am I?" — it should answer with your owner display name, not "guest".
+
+**Common issues** — if the agent already auto-created a separate guest user from your Telegram identity before you linked, you have to merge the duplicate into yourself; see 5.5.3.
+
+---
+
+### 5.5.2 Make a browser session see you as owner
+
+**Scenario** — you ran `hermit setup` on the CLI, that made you owner. Now you open the web UI in a browser; the web identity is a different `(web, <fingerprint>)` tuple and you appear as guest or unauthenticated.
+
+**Prerequisites** — none.
+
+**Ways to do it**
+
+*Web login from CLI.* The fastest path:
+
+```bash
+hermit web start
+# Browser opens with a token already attached, recognising you as owner.
+```
+
+If you opened the URL manually instead, copy the token printed by `hermit web start` into the browser's "sign in with token" field.
+
+*Link the web identity manually.* Same shape as 5.5.1 with `channel = web` and the device fingerprint shown in the Admin UI.
+
+**Verify** — the Admin UI shows the full management surface (Manage tab is visible and editable), not just a chat view.
+
+**Common issues** — using a different browser, or an incognito window, gives you a new fingerprint. You have to re-link or use a fresh token each time, unless you sign in through the same browser profile.
+
+---
+
+### 5.5.3 Merge two identities that ended up as two users
+
+**Scenario** — you have two entries in the Members list that are obviously the same person (you, with two channel identities, accidentally created as two users because you did not link in time).
+
+**Prerequisites** — you are an owner.
+
+**Ways to do it**
+
+*Tell the agent.* "Merge user `u_abc` into user `u_xyz`."
+
+The agent calls `user_merge`. After it returns, every old identity attached to `u_abc` now resolves to `u_xyz`. Old sessions and messages keep their original sender attribution, so history is intact.
+
+*HTTP API.* If the admin UI exposes a Merge action, use it. Otherwise issue the same call through the agent.
+
+**Verify** — the Members list now shows one entry with both identities listed.
+
+**Common issues** — merging is one-way. The old user record is marked `merged_into`; identity resolution follows the link, but you cannot un-merge without manual database work.
+
+---
+
+### 5.5.4 Promote a user to owner
+
+**Scenario** — you want to give someone full administrative access to an agent.
+
+**Prerequisites** — you are an owner.
+
+**Ways to do it**
+
+*Tell the agent.* "Set user `u_xyz`'s role on this agent to owner."
+
+The agent calls `user_role_set`. The promoted user keeps their existing identities; on their next message they get the owner toolset.
+
+**Verify** — the promoted person can now open the *Manage* tab and edit settings.
+
+**Common issues** — there is no "demote owner" safeguard. If you give owner to the wrong person, you have to demote them back — be deliberate.
+
+---
+
+## 5.6 FAQ
+
+**The agent calls me "guest" even though I created it. Why?** You probably created it from one channel (say, CLI) and you are messaging from another (say, Telegram). Each channel is a separate identity until you link them. See 5.5.1.
+
+**Can a guest become a user without the owner doing anything?** No. Role changes are owner-only.
+
+**If I merge two users, do their memories merge too?** Long-term memory is per-agent, not per-user, so there is no per-user memory to merge. Session participation is recomputed: sessions where either of the old users participated now show the merged user.
+
+**Can someone be owner on one agent and guest on another?** Yes — roles are per-agent. The same user can have different roles on different agents in the same instance.
+
+**Group chat: who is "the user" when the agent is replying?** The runner attributes each *message* to its sender. The agent sees each message tagged with the sender's display name (and, on group channels, sees that the conversation has multiple people).
+
+---
+
+## 5.7 Pointers
+
+- Want to give someone access for the first time → [Chapter 12 · Inviting People](12-inviting-people.md).
+- Want to restrict what a particular role or user can call → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Want to know how Telegram/Discord/Slack actually get connected → [Chapter 17 · Channels](17-channels.md).

--- a/docs/manual/05-users-and-identity.md
+++ b/docs/manual/05-users-and-identity.md
@@ -56,13 +56,18 @@ The fix is identity linking. The recipes in 5.5 cover it.
 
 ## 5.4 Two Ways to Link an Identity
 
-There are two paths, and which one fits depends on who is making the claim.
+There are two paths, and which one fits depends on who is doing the linking.
 
-**Owner-initiated.** The owner says, from any channel where they are already recognised as owner, "the Telegram user named *William* is also me" — or picks the identity in the admin UI. The agent links it on the spot, no confirmation. This is the path for *your own* identities and for cases where you already know who someone is.
+**Owner-initiated.** The owner picks the identity in the admin UI or, from a channel where they are already recognised as owner, tells the agent "the Telegram user named *William* is also me". The agent links it on the spot. This is the path for an owner cleaning up the members list — including their own duplicate identities — and it requires owner role.
 
-**Request and confirm.** A non-owner identity asks to be linked. From Telegram (still seen as a guest), the person says "I'm William, please link this Telegram account to my web user." The agent does not link unilaterally — it sends a confirmation prompt to the owner (and to the target user, if different). The owner approves or rejects; only then is the link made.
+**Token-based, cross-channel proof.** Any user (including a guest) can link their own identities across channels by proving they control both sides. The flow:
 
-The distinction matters because identity linking is privilege-granting: if Bob's guest identity gets linked to Alice's owner user, Bob effectively becomes Alice on that agent. Owner-initiated is fast because the owner is already trusted. Request-and-confirm is the safe default whenever the request originates from a less-privileged identity.
+1. On channel A, ask the agent to **issue a link token**. It calls `identity_link_request` and prints a short token, valid for about 10 minutes.
+2. You carry that token to channel B yourself — copy it, type it into the other client.
+3. On channel B, give the token to the agent and ask it to **confirm the link**. The agent calls `identity_link_confirm` with the token. The tool verifies that the redeeming side is a *different* channel from the one that issued the token; that mutual possession is the proof.
+4. The two identities are now attached to the same user. If one side was a guest and the other a real user, the guest is absorbed into the real user. If both sides were already non-guest users with distinct roles, the tool refuses and asks an owner to do a manual merge — this prevents a guest's identity from accidentally claiming someone else's user.
+
+No owner approval is needed in the token flow; the security comes from the requirement to actually hold the token on both channels. The owner-initiated path is for cases where you have admin authority and want to skip the token dance.
 
 ---
 
@@ -123,23 +128,33 @@ curl -X POST "$GATEWAY/api/agents/<agent-id>/members" \
 
 ---
 
-### 5.6.2 Request a link from the less-privileged side
+### 5.6.2 Link two of your own channels using a token
 
-**Scenario** — you do not have an owner channel handy right now. You are messaging the agent from Telegram, where it currently sees you as a guest, and you want to be recognised as your real user account.
+**Scenario** — you are the same person on web (recognised as your real user) and on Telegram (currently a guest). No owner is helping you; you are doing it yourself.
 
-**Prerequisites** — the user you want to be linked to exists on the agent. There is an owner reachable to confirm.
+**Prerequisites** — you have already messaged the agent from both channels at least once, so each identity exists on the agent.
 
 **Ways to do it**
 
-*Ask the agent from the less-privileged channel.* For example, from Telegram:
+1. From the channel where you are already recognised as yourself (say, web), tell the agent:
 
-> I'm William. Please link this Telegram account to my web user.
+   > Generate a link token so I can attach another channel to this account.
 
-The agent does **not** link unilaterally. Instead it forwards a confirmation request to the owner (and, when relevant, to the target user). The request shows up in the *Observe* tab as a pending action, and also as a notification on any channel the owner has linked. The owner approves or rejects; on approve, the link is made and your next message from Telegram is recognised as your real user.
+   The agent calls `identity_link_request` and replies with a short token, e.g. `Xq4Aw8Zk`, valid for about 10 minutes.
 
-**Verify** — after the owner approves, ask the agent on Telegram "who am I?" — it should name your real user.
+2. Switch to the other channel (Telegram). Send the agent a message containing that token:
 
-**Common issues** — if no owner is online, the request sits pending until it times out (default a few minutes). Just ask again, or have the owner do the owner-initiated flow (5.6.1) when they are back.
+   > Link this Telegram account using token `Xq4Aw8Zk`.
+
+   The agent calls `identity_link_confirm`. Because the redeeming channel (Telegram) differs from the issuing channel (web), the proof check passes; the Telegram identity is attached to your existing user, and the guest record is absorbed.
+
+**Verify** — ask the agent from Telegram "who am I?" — it should name your real user, not "guest".
+
+**Common issues**
+
+- *"Token expired."* It is only valid for ~10 minutes. Issue a new one.
+- *"Same channel."* Tokens must be redeemed on a different channel from the one that issued them.
+- *"Already linked to a different user."* If both sides are already established non-guest users, the token flow refuses on purpose — ask an owner to run a merge ([5.6.4](#564-merge-two-identities-that-ended-up-as-two-users)).
 
 ---
 

--- a/docs/manual/05-users-and-identity.md
+++ b/docs/manual/05-users-and-identity.md
@@ -84,15 +84,15 @@ This is the source of truth that later chapters refer back to. Each ✓ means "y
 
 **Scenario** — you created your agent from the web (so the web identity is the owner), then you opened a Telegram chat with the bot. Telegram sees a new identity and either drops your message (on `protected` or `private` access) or creates a guest user.
 
-**Prerequisites** — the agent has Telegram connected ([Chapter 17 · Channels](17-channels.md)). You know your Telegram user ID (ask `@userinfobot` on Telegram, or check the Members panel — guests show up with their channel ID).
+**Prerequisites** — the agent has Telegram connected ([Chapter 17 · Channels](17-channels.md)). You have already sent at least one message to the bot from Telegram, so the agent has seen that identity.
 
 **Ways to do it**
 
-*Let the agent do it.* From the web (where you are owner), say:
+*Let the agent do it.* From the web (where you are owner), just describe the other identity in plain words:
 
-> Link Telegram user `656756615` to my account.
+> The user chatting with you on Telegram, named "William", is also my account.
 
-The agent calls its identity-linking tool and confirms.
+The agent looks up the matching Telegram identity, links it to your user record, and confirms. You do not need to dig up the numeric Telegram user ID — naming the display name is enough as long as it is unambiguous.
 
 *Web admin UI.* Open the agent's *Manage* page, go to the section listing members (typically reached via the `/api/agents/<id>/members` flow surfaced in the UI; if your admin UI does not expose this directly, use the API path below). Find your own entry, add an identity, choose `channel = telegram`, paste the ID.
 

--- a/docs/manual/05-users-and-identity.md
+++ b/docs/manual/05-users-and-identity.md
@@ -54,7 +54,19 @@ The fix is identity linking. The recipes in 5.5 cover it.
 
 ---
 
-## 5.4 Capability Matrix
+## 5.4 Two Ways to Link an Identity
+
+There are two paths, and which one fits depends on who is making the claim.
+
+**Owner-initiated.** The owner says, from any channel where they are already recognised as owner, "the Telegram user named *William* is also me" — or picks the identity in the admin UI. The agent links it on the spot, no confirmation. This is the path for *your own* identities and for cases where you already know who someone is.
+
+**Request and confirm.** A non-owner identity asks to be linked. From Telegram (still seen as a guest), the person says "I'm William, please link this Telegram account to my web user." The agent does not link unilaterally — it sends a confirmation prompt to the owner (and to the target user, if different). The owner approves or rejects; only then is the link made.
+
+The distinction matters because identity linking is privilege-granting: if Bob's guest identity gets linked to Alice's owner user, Bob effectively becomes Alice on that agent. Owner-initiated is fast because the owner is already trusted. Request-and-confirm is the safe default whenever the request originates from a less-privileged identity.
+
+---
+
+## 5.5 Capability Matrix
 
 This is the source of truth that later chapters refer back to. Each ✓ means "yes, by default"; gaps mean "blocked by role". Custom policy can tighten things further; see [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
 
@@ -78,9 +90,9 @@ This is the source of truth that later chapters refer back to. Each ✓ means "y
 
 ---
 
-## 5.5 How-to Recipes
+## 5.6 How-to Recipes
 
-### 5.5.1 Make Telegram see you as yourself, not as a guest
+### 5.6.1 Make Telegram see you as yourself, not as a guest
 
 **Scenario** — you created your agent from the web (so the web identity is the owner), then you opened a Telegram chat with the bot. Telegram sees a new identity and either drops your message (on `protected` or `private` access) or creates a guest user.
 
@@ -107,11 +119,31 @@ curl -X POST "$GATEWAY/api/agents/<agent-id>/members" \
 
 **Verify** — send a message from Telegram. Ask the agent "who am I?" — it should answer with your owner display name, not "guest".
 
-**Common issues** — if the agent already auto-created a separate guest user from your Telegram identity before you linked, you have to merge the duplicate into yourself; see 5.5.3.
+**Common issues** — if the agent already auto-created a separate guest user from your Telegram identity before you linked, you have to merge the duplicate into yourself; see 5.6.4.
 
 ---
 
-### 5.5.2 Make a browser session see you as owner
+### 5.6.2 Request a link from the less-privileged side
+
+**Scenario** — you do not have an owner channel handy right now. You are messaging the agent from Telegram, where it currently sees you as a guest, and you want to be recognised as your real user account.
+
+**Prerequisites** — the user you want to be linked to exists on the agent. There is an owner reachable to confirm.
+
+**Ways to do it**
+
+*Ask the agent from the less-privileged channel.* For example, from Telegram:
+
+> I'm William. Please link this Telegram account to my web user.
+
+The agent does **not** link unilaterally. Instead it forwards a confirmation request to the owner (and, when relevant, to the target user). The request shows up in the *Observe* tab as a pending action, and also as a notification on any channel the owner has linked. The owner approves or rejects; on approve, the link is made and your next message from Telegram is recognised as your real user.
+
+**Verify** — after the owner approves, ask the agent on Telegram "who am I?" — it should name your real user.
+
+**Common issues** — if no owner is online, the request sits pending until it times out (default a few minutes). Just ask again, or have the owner do the owner-initiated flow (5.6.1) when they are back.
+
+---
+
+### 5.6.3 Make a browser session see you as owner
 
 **Scenario** — you ran `hermit setup` on the CLI, that made you owner. Now you open the web UI in a browser; the web identity is a different `(web, <fingerprint>)` tuple and you appear as guest or unauthenticated.
 
@@ -128,7 +160,7 @@ hermit web start
 
 If you opened the URL manually instead, copy the token printed by `hermit web start` into the browser's "sign in with token" field.
 
-*Link the web identity manually.* Same shape as 5.5.1 with `channel = web` and the device fingerprint shown in the Admin UI.
+*Link the web identity manually.* Same shape as 5.6.1 with `channel = web` and the device fingerprint shown in the Admin UI.
 
 **Verify** — the Admin UI shows the full management surface (Manage tab is visible and editable), not just a chat view.
 
@@ -136,7 +168,7 @@ If you opened the URL manually instead, copy the token printed by `hermit web st
 
 ---
 
-### 5.5.3 Merge two identities that ended up as two users
+### 5.6.4 Merge two identities that ended up as two users
 
 **Scenario** — you have two entries in the Members list that are obviously the same person (you, with two channel identities, accidentally created as two users because you did not link in time).
 
@@ -156,7 +188,7 @@ The agent calls `user_merge`. After it returns, every old identity attached to `
 
 ---
 
-### 5.5.4 Promote a user to owner
+### 5.6.5 Promote a user to owner
 
 **Scenario** — you want to give someone full administrative access to an agent.
 
@@ -174,9 +206,9 @@ The agent calls `user_role_set`. The promoted user keeps their existing identiti
 
 ---
 
-## 5.6 FAQ
+## 5.7 FAQ
 
-**The agent calls me "guest" even though I created it. Why?** You probably created it from one channel (say, CLI) and you are messaging from another (say, Telegram). Each channel is a separate identity until you link them. See 5.5.1.
+**The agent calls me "guest" even though I created it. Why?** You probably created it from one channel (say, CLI) and you are messaging from another (say, Telegram). Each channel is a separate identity until you link them. See 5.6.1.
 
 **Can a guest become a user without the owner doing anything?** No. Role changes are owner-only.
 
@@ -188,7 +220,7 @@ The agent calls `user_role_set`. The promoted user keeps their existing identiti
 
 ---
 
-## 5.7 Pointers
+## 5.8 Pointers
 
 - Want to give someone access for the first time → [Chapter 12 · Inviting People](12-inviting-people.md).
 - Want to restrict what a particular role or user can call → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).

--- a/docs/manual/06-memory.md
+++ b/docs/manual/06-memory.md
@@ -1,0 +1,167 @@
+---
+title: Memory
+slug: memory
+order: 6
+part: Part 2 — Daily Use
+description: How the agent remembers things across sessions, the three layers of memory, and how to teach, inspect, and forget.
+---
+
+# 6. Memory
+
+Memory is what lets the agent feel less like a search box and more like a colleague. After a few conversations it should know your name, your preferences, the project you are working on, the people you talk about. This chapter covers what it remembers, how it decides to remember, and how you correct or clear what it has stored.
+
+---
+
+## 6.1 Three Layers
+
+OpenHermit organizes memory into three layers, top to bottom in scope:
+
+**Session history.** Every message in a single conversation. Bound to the session; if you start a new session, the agent starts with an empty scrollback. Useful for the back-and-forth within one chat.
+
+**Working memory.** Short-lived notes the agent keeps inside one session — "the user prefers markdown tables", "we are debugging the auth flow". It is reset when the session ends. You rarely interact with working memory directly; the agent manages it.
+
+**Long-term memory.** Persistent entries with keys, content, and tags, stored in the database and searchable across every session for that agent. This is the layer that gives the agent continuity. When people say "the agent remembered my address", this is where it lived.
+
+---
+
+## 6.2 How the Agent Decides What to Remember
+
+The agent has tools for adding, recalling, listing, updating, and deleting long-term memory entries. It uses them on its own as the conversation unfolds:
+
+- You say something it judges worth keeping ("I am vegetarian", "our staging URL is …") → it adds an entry.
+- You ask a question that touches a topic it has notes on → it recalls.
+- Something you said earlier turns out to be wrong → it updates the entry.
+- You explicitly ask it to forget → it deletes.
+
+You do not need to use any special syntax. Plain speech works:
+
+- "Remember that I am based in Berlin."
+- "Forget what I said about Friday's meeting."
+- "What do you remember about the migration project?"
+
+The agent tends to err on the side of remembering more rather than less, so the curation flow is mostly "remove things you don't want", not "make sure it captured everything".
+
+---
+
+## 6.3 Memory Is Per Agent, Not Per User
+
+Long-term memory is attached to the **agent**, not to the person talking to it. Two people sharing one agent share the same memory store. The agent does notice who is speaking (and tags entries with that context), but anything it remembers about Alice is in the same pool as anything it remembers about Bob.
+
+If you need user-private memory, run separate agents — one per person. The cost of that is small (sharing the same instance, just different agent IDs), the isolation is total.
+
+---
+
+## 6.4 Inspecting Memory
+
+To see what the agent is keeping, ask it:
+
+- "List what you remember about me."
+- "What memories do you have tagged `project-x`?"
+- "Show me your last ten memory entries."
+
+It runs `memory_list` or `memory_recall` and prints the results.
+
+Web admin UI: an admin view of the memory store is on the roadmap; until it ships, the agent itself is your best inspector — it is allowed to read everything.
+
+---
+
+## 6.5 Role Differences
+
+| Role | Read memory | Write memory |
+|---|:---:|:---:|
+| Owner | ✓ | ✓ |
+| User | ✓ | ✓ |
+| Guest | — | — |
+
+Guests cannot read or write long-term memory; the memory toolset is hidden from them. This is by design — public agents that auto-create guests should not let strangers write into shared memory.
+
+---
+
+## 6.6 How-to Recipes
+
+### 6.6.1 Teach the agent a long-term preference
+
+**Scenario** — you want the agent to always use metric units in answers.
+
+**Ways to do it**
+
+Just say it:
+
+> Remember that I prefer metric units in all answers, including imperial-to-metric conversion when sources use imperial.
+
+The agent confirms and stores the entry. Future sessions pick it up.
+
+**Verify** — start a fresh session and ask a question that would naturally trigger units ("how far is Berlin from Munich?"). The agent answers in km without prompting.
+
+**Common issues** — if the preference is something you want to enforce as a *rule* (not a soft preference the model might forget), use **instructions** instead ([Chapter 7](07-instructions.md)). Memory is a hint; instructions are mandatory.
+
+---
+
+### 6.6.2 Correct a wrong memory
+
+**Scenario** — the agent has stored "user is allergic to peanuts" but you actually only have a mild sensitivity, not a serious allergy.
+
+**Ways to do it**
+
+Tell it:
+
+> Update your memory: I have a mild peanut sensitivity, not a severe allergy.
+
+It calls `memory_update` on the relevant entry. If multiple entries match, it picks the most recent or asks.
+
+**Verify** — "what do you remember about my allergies?" — the agent should give the corrected version.
+
+---
+
+### 6.6.3 Make the agent forget something
+
+**Scenario** — you tested the agent with fake data and you want the test entries gone.
+
+**Ways to do it**
+
+> Delete every memory entry tagged `test`.
+
+Or:
+
+> Forget what I said about my travel plans last week.
+
+The agent deletes matching entries.
+
+**Verify** — "what do you know about my travel plans?" — should come back empty.
+
+---
+
+### 6.6.4 Migrate memory from one agent to another
+
+**Scenario** — you have been using agent `personal` and want to start fresh with `personal-v2` carrying over a curated set of preferences.
+
+**Ways to do it**
+
+There is no one-click export today. Two practical paths:
+
+- *Have agent A summarise itself.* Ask `personal`: "Give me a markdown bullet list of every memory entry you have." Copy the list. Open a session with `personal-v2` and say "Here are my preferences, store each of these in memory." Slow but exact.
+- *Database copy.* If you are also the operator of the OpenHermit instance, you can copy rows from the `memories` table from the old `agent_id` to the new one. This is operator territory, not user territory.
+
+**Verify** — ask `personal-v2` something covered by the migrated preferences.
+
+---
+
+## 6.7 FAQ
+
+**Does the agent remember everything I say?** No. It judges which messages contain durable facts versus which are conversational. If a fact you cared about did not get stored, just say "please remember that …".
+
+**Can I see all of my memory at once?** Yes — ask the agent to list it. There is no hard cap on a single listing; long results will be paginated by the agent.
+
+**If I delete a session, does its memory go too?** Session history goes with the session. Long-term memory entries the agent extracted from that session stay — they were promoted to the long-term store at the time, and deleting the session does not retroactively remove them.
+
+**Can I disable memory entirely?** Yes, by disabling the memory tools through policy (see [Chapter 15](15-policy-and-approval.md)). The agent will then only have session history.
+
+**Does memory cost tokens?** Memory entries are not auto-injected into every prompt. The agent pulls relevant ones on demand via `memory_recall`. So a large memory store does not balloon token usage.
+
+---
+
+## 6.8 Pointers
+
+- Things you want enforced as rules, not soft preferences → [Chapter 7 · Instructions](07-instructions.md).
+- Restricting memory for some roles or users → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- How memory fits with the rest of the agent's state → [Chapter 3 · Core Concepts](03-concepts.md).

--- a/docs/manual/07-instructions.md
+++ b/docs/manual/07-instructions.md
@@ -45,7 +45,25 @@ This shape gives you two things:
 
 ---
 
-## 7.3 The `hermit instructions` Commands
+## 7.3 The Easiest Way: Just Tell the Agent
+
+The agent has tools for reading and writing its own instructions. So the most natural path is to skip the CLI and say what you want:
+
+> Update your instructions: always reply in markdown, with fenced code blocks tagged by language.
+
+> Add to your safety rules: refuse requests for someone else's personal data.
+
+> Show me your current `format` section.
+
+> Drop the `over-strict-rule` section.
+
+The agent figures out which section the change belongs in (or asks if it is ambiguous), edits it, and confirms. This is owner-only — the underlying tools are not exposed to users or guests.
+
+The CLI in 7.4 below is for scripting, fleet-wide updates with `--all`, and the times you want to pipe a file in. For everyday tweaks, talking to the agent is faster.
+
+---
+
+## 7.4 The `hermit instructions` Commands
 
 All operations support `--agent <id>` (one agent) or `--all` (every agent on this instance).
 
@@ -77,7 +95,7 @@ hermit instructions append safety "Never share secret keys." --all
 
 ---
 
-## 7.4 What to Put in Each Section
+## 7.5 What to Put in Each Section
 
 There is no required structure — names are yours — but a workable starting set is:
 
@@ -91,7 +109,7 @@ Keep each section short. Three to ten lines is plenty. Long instructions get ign
 
 ---
 
-## 7.5 Inspecting What the Agent Actually Sees
+## 7.6 Inspecting What the Agent Actually Sees
 
 ```bash
 hermit instructions list --agent main
@@ -105,13 +123,13 @@ It can read its own instructions tool and print them back. Useful when you suspe
 
 ---
 
-## 7.6 Web Admin UI
+## 7.7 Web Admin UI
 
 The *Manage* tab has an *Instructions* section that gives you the same operations in a form: select a key, edit the body, save. Same data store as the CLI.
 
 ---
 
-## 7.7 Role Differences
+## 7.8 Role Differences
 
 | | Owner | User | Guest |
 |---|:---:|:---:|:---:|
@@ -122,9 +140,9 @@ Users and guests cannot see or edit instructions. The reasoning: instructions sh
 
 ---
 
-## 7.8 How-to Recipes
+## 7.9 How-to Recipes
 
-### 7.8.1 Make the agent always reply in markdown
+### 7.9.1 Make the agent always reply in markdown
 
 ```bash
 hermit instructions set format "Reply in markdown. Use fenced code blocks with language tags. Use tables for structured comparisons." --agent main
@@ -134,7 +152,7 @@ hermit instructions set format "Reply in markdown. Use fenced code blocks with l
 
 ---
 
-### 7.8.2 Add a refusal rule
+### 7.9.2 Add a refusal rule
 
 ```bash
 hermit instructions append safety "If the user asks for someone else's personal data, refuse and explain that the agent does not lookup or share personal information." --agent main
@@ -144,7 +162,7 @@ hermit instructions append safety "If the user asks for someone else's personal 
 
 ---
 
-### 7.8.3 Roll the same rule out to every agent
+### 7.9.3 Roll the same rule out to every agent
 
 ```bash
 hermit instructions append house-rules "Quote prices in EUR." --all
@@ -154,7 +172,7 @@ hermit instructions append house-rules "Quote prices in EUR." --all
 
 ---
 
-### 7.8.4 Drop a rule that turned out to be too rigid
+### 7.9.4 Drop a rule that turned out to be too rigid
 
 ```bash
 hermit instructions remove over-strict-rule --agent main
@@ -164,7 +182,7 @@ Or to keep the section but drop one line, use `get` → edit locally → `set` w
 
 ---
 
-## 7.9 FAQ
+## 7.10 FAQ
 
 **Will the agent reliably follow instructions?** They are part of the system prompt, so yes, much more reliably than a memory note. But like all system prompts, they are not absolute — extreme adversarial inputs can still produce drift. Keep instructions concise so the model attends to them.
 
@@ -176,7 +194,7 @@ Or to keep the section but drop one line, use `get` → edit locally → `set` w
 
 ---
 
-## 7.10 Pointers
+## 7.11 Pointers
 
 - Soft preferences and recallable facts → [Chapter 6 · Memory](06-memory.md).
 - Limiting which tools the agent can use → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).

--- a/docs/manual/07-instructions.md
+++ b/docs/manual/07-instructions.md
@@ -1,0 +1,183 @@
+---
+title: Instructions
+slug: instructions
+order: 7
+part: Part 2 — Daily Use
+description: Hard rules that travel with every session. How to write them, where they live, and how they differ from memory. (owner-only)
+ownerOnly: true
+---
+
+# 7. Instructions
+
+*(owner-only)*
+
+**Instructions** are the rules you write into the agent's system prompt: lines like "always reply in markdown", "never share PII", "when asked for medical advice, refuse and recommend a doctor". Unlike memory, instructions are not optional hints — they are part of every prompt the agent receives, every session, forever, until you change them.
+
+This chapter covers what instructions look like in OpenHermit, how to manage them, and when to reach for instructions instead of memory.
+
+---
+
+## 7.1 Instructions vs Memory
+
+A quick comparison, because the difference matters:
+
+| | Instructions | Memory |
+|---|---|---|
+| Always included in every prompt | ✓ | — |
+| Soft / strong | Strong (rule) | Soft (preference) |
+| Who can write | Owner | Owner, user, agent itself |
+| Survives across sessions | ✓ | ✓ |
+| Costs tokens on every turn | ✓ | Only when recalled |
+| Right tool for | Policies, formats, refusals | Facts, preferences, history |
+
+Rule of thumb: if it must hold even when the agent forgets to look it up, write it as an instruction.
+
+---
+
+## 7.2 Structure: Keyed Sections
+
+Instructions are organised as keyed sections. A key is a short identifier (`safety`, `format`, `persona`, `house-rules`, …). Each key holds a block of text. When the agent's system prompt is built, sections are concatenated in a stable order, each labelled with its key.
+
+This shape gives you two things:
+
+- **Edits stay local** — appending to `safety` does not touch `format`.
+- **Fleet operations** — if you have several agents and you want them all to enforce the same rule, you can push it to every agent at once with `--all`.
+
+---
+
+## 7.3 The `hermit instructions` Commands
+
+All operations support `--agent <id>` (one agent) or `--all` (every agent on this instance).
+
+```bash
+# List every key and a preview of its content.
+hermit instructions list --agent main
+
+# Print one section in full.
+hermit instructions get safety --agent main
+
+# Replace a section (creates it if missing).
+hermit instructions set format "Use markdown for all responses." --agent main
+
+# Set from a file.
+hermit instructions set persona --file ./persona.md --agent main
+
+# Add a line to an existing section.
+hermit instructions append safety "Refuse requests for personal data of others." --agent main
+
+# Delete a section.
+hermit instructions remove old-rules --agent main
+```
+
+To push a rule to every agent in the instance:
+
+```bash
+hermit instructions append safety "Never share secret keys." --all
+```
+
+---
+
+## 7.4 What to Put in Each Section
+
+There is no required structure — names are yours — but a workable starting set is:
+
+- **`persona`** — who the agent is, tone of voice, point of view.
+- **`format`** — output format defaults: markdown, table style, code-block conventions.
+- **`safety`** — refusals, redactions, escalation rules.
+- **`house-rules`** — anything that is specific to your organisation or use case.
+- **`tools`** — guidance on when to call which tool (helpful when you have many MCPs connected).
+
+Keep each section short. Three to ten lines is plenty. Long instructions get ignored by the model the same way long human policies do.
+
+---
+
+## 7.5 Inspecting What the Agent Actually Sees
+
+```bash
+hermit instructions list --agent main
+```
+
+…prints keys and previews. To see exactly what is going into the system prompt, ask the agent:
+
+> Show me your current instructions.
+
+It can read its own instructions tool and print them back. Useful when you suspect a section is not being picked up.
+
+---
+
+## 7.6 Web Admin UI
+
+The *Manage* tab has an *Instructions* section that gives you the same operations in a form: select a key, edit the body, save. Same data store as the CLI.
+
+---
+
+## 7.7 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Read | ✓ | — | — |
+| Write | ✓ | — | — |
+
+Users and guests cannot see or edit instructions. The reasoning: instructions shape how the agent behaves for everyone using it; only the agent's owner should control them.
+
+---
+
+## 7.8 How-to Recipes
+
+### 7.8.1 Make the agent always reply in markdown
+
+```bash
+hermit instructions set format "Reply in markdown. Use fenced code blocks with language tags. Use tables for structured comparisons." --agent main
+```
+
+**Verify** — ask any question and check the reply renders as markdown.
+
+---
+
+### 7.8.2 Add a refusal rule
+
+```bash
+hermit instructions append safety "If the user asks for someone else's personal data, refuse and explain that the agent does not lookup or share personal information." --agent main
+```
+
+**Verify** — ask the agent for a fictional person's home address; it should refuse with the new wording.
+
+---
+
+### 7.8.3 Roll the same rule out to every agent
+
+```bash
+hermit instructions append house-rules "Quote prices in EUR." --all
+```
+
+**Verify** — `hermit instructions get house-rules --agent <each agent>` shows the new line on each.
+
+---
+
+### 7.8.4 Drop a rule that turned out to be too rigid
+
+```bash
+hermit instructions remove over-strict-rule --agent main
+```
+
+Or to keep the section but drop one line, use `get` → edit locally → `set` with the trimmed body.
+
+---
+
+## 7.9 FAQ
+
+**Will the agent reliably follow instructions?** They are part of the system prompt, so yes, much more reliably than a memory note. But like all system prompts, they are not absolute — extreme adversarial inputs can still produce drift. Keep instructions concise so the model attends to them.
+
+**Can instructions contradict the agent's safety rules?** You can write whatever you want; the model still has its own safety training and may refuse to comply with instructions that violate it. That is a feature, not a bug.
+
+**Should one rule live as an instruction or as a memory entry?** Instruction if it should hold for everyone, in every session, every time. Memory if it is a fact about you specifically.
+
+**Can users see instructions?** No. They are owner-only.
+
+---
+
+## 7.10 Pointers
+
+- Soft preferences and recallable facts → [Chapter 6 · Memory](06-memory.md).
+- Limiting which tools the agent can use → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Push instructions across your fleet → use `--all` in any command above.

--- a/docs/manual/08-skills.md
+++ b/docs/manual/08-skills.md
@@ -1,0 +1,208 @@
+---
+title: Skills
+slug: skills
+order: 8
+part: Part 2 — Daily Use
+description: What skills are, how to enable and disable them, where they come from, and how to register your own.
+---
+
+# 8. Skills
+
+A **skill** is a packaged capability you can switch on for an agent. Think of it as a small folder with a `SKILL.md` that explains the capability and any scripts or templates that go with it. Skills are the easiest way to extend what an agent can do without writing code.
+
+This chapter walks through enabling, disabling, and registering skills, and points at how skills relate to MCP servers (Chapter 9).
+
+---
+
+## 8.1 What a Skill Looks Like
+
+At minimum, a skill is a directory with:
+
+```
+my-skill/
+├── SKILL.md         # description, when to use, instructions
+└── (optional helpers — scripts, prompt fragments, references)
+```
+
+The `SKILL.md` frontmatter carries metadata:
+
+```markdown
+---
+name: standup-digest
+description: Summarises the team's standup updates into a daily digest.
+---
+
+# Standup digest
+
+Use this skill when the user asks for a daily standup summary…
+```
+
+When you enable a skill for an agent, the agent gets the `SKILL.md` content as additional context and access to any helper scripts in the skill folder.
+
+---
+
+## 8.2 Two Sources of Skills
+
+**Built-in skills.** Ship with OpenHermit and are discoverable as soon as the gateway is running. They cover common patterns: research, summarisation, GitHub helpers, and similar.
+
+**Workspace / custom skills.** Skills you write yourself, or pull from a third-party repo, and **register** with OpenHermit. Once registered, they behave the same as built-in skills.
+
+Either way, the workflow is identical: list, enable, disable.
+
+---
+
+## 8.3 The `hermit skills` Commands
+
+```bash
+# List skills registered with this instance.
+hermit skills list
+
+# List which skills are enabled on which agents.
+hermit skills assignments
+
+# Scan the gateway's skill directory for new skills.
+hermit skills scan
+
+# Register a new skill (reads SKILL.md frontmatter).
+hermit skills register my-skill --path ./skills/my-skill
+
+# Enable a skill for one agent.
+hermit skills enable standup-digest --agent main
+
+# Enable for every agent in the fleet.
+hermit skills enable standup-digest --all
+
+# Disable for an agent.
+hermit skills disable standup-digest --agent main
+
+# Remove a skill from the registry entirely.
+hermit skills delete my-skill
+```
+
+Enabling a skill is **idempotent** — running enable twice does nothing the second time.
+
+---
+
+## 8.4 How the Agent Uses an Enabled Skill
+
+Two things happen when a skill is enabled:
+
+- The skill's `SKILL.md` body is included in the agent's system prompt under a recognisable header.
+- Helper scripts in the skill folder are reachable from the workspace, so the agent can execute them.
+
+The agent decides on its own when a skill applies. You usually do not need to invoke it by name; just say what you want ("write me the standup digest for today") and the agent picks the right skill from the descriptions.
+
+---
+
+## 8.5 Web Admin UI
+
+The *Manage → Skills* tab shows the registry, the assignments, and toggles to enable or disable per agent. Registering new skills typically still happens through the CLI or by dropping a skill folder into the gateway's skills directory and running `hermit skills scan`.
+
+---
+
+## 8.6 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Use an enabled skill | ✓ | ✓ | ✓ (if the skill's tools are allowed for them) |
+| Enable / disable skills | ✓ | — | — |
+| Register / delete skills | ✓ | — | — |
+
+Users and guests can benefit from skills the owner has enabled; they cannot enable new ones.
+
+---
+
+## 8.7 How-to Recipes
+
+### 8.7.1 Turn on a built-in skill
+
+**Scenario** — you want to add the `web-research` capability to your `main` agent.
+
+```bash
+hermit skills list                       # confirm it is present
+hermit skills enable web-research --agent main
+```
+
+**Verify** — ask the agent "research the latest news about X and summarise" — it should use the skill's pattern.
+
+---
+
+### 8.7.2 Write and register your own skill
+
+**Scenario** — you have a recurring pattern (say, weekly retro generation) and you want to package it.
+
+**Steps**
+
+1. Create the folder:
+
+   ```bash
+   mkdir -p ./skills/weekly-retro
+   ```
+
+2. Write `SKILL.md`:
+
+   ```markdown
+   ---
+   name: weekly-retro
+   description: Generates a weekly retrospective from the past 7 days of sessions.
+   ---
+
+   # Weekly retro
+
+   When asked for a weekly retro, …
+   ```
+
+3. Register and enable:
+
+   ```bash
+   hermit skills register weekly-retro --path ./skills/weekly-retro
+   hermit skills enable weekly-retro --agent main
+   ```
+
+**Verify** — `hermit skills list` shows the new entry; `hermit skills assignments` shows it enabled for `main`.
+
+---
+
+### 8.7.3 Roll a skill out to every agent
+
+```bash
+hermit skills enable critique --all
+```
+
+**Verify** — `hermit skills assignments` shows the skill enabled on every agent.
+
+---
+
+### 8.7.4 Disable a skill you no longer want
+
+```bash
+hermit skills disable old-skill --agent main
+```
+
+Or fleet-wide:
+
+```bash
+hermit skills disable old-skill --all
+```
+
+This does not delete the skill from the registry; it just stops it from being available on the selected agents. To delete entirely: `hermit skills delete old-skill`.
+
+---
+
+## 8.8 FAQ
+
+**Do skills cost tokens?** Yes — an enabled skill's `SKILL.md` is part of the system prompt. Long skill descriptions raise the per-turn token cost. Keep skill docs concise.
+
+**Skills vs MCP servers — when do I pick which?** Skills package *prompting patterns and small helper scripts*. MCP servers package *external systems exposed as tools*. If you want "always do X this way", that is a skill. If you want "be able to call GitHub", that is an MCP server.
+
+**Can a skill require an MCP server?** Yes — a skill's prompt can assume specific MCP tools exist. Document that requirement in the `SKILL.md` so users know to enable both.
+
+**How does the agent pick which skill to use?** It reads each enabled skill's description in the system prompt and matches against the request. Descriptions matter — write them like search queries.
+
+---
+
+## 8.9 Pointers
+
+- External tool integrations → [Chapter 9 · MCP Servers](09-mcp-servers.md).
+- The full list of skills shipping with OpenHermit → run `hermit skills list` on your instance.
+- Restricting which roles can invoke a particular skill's tools → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).

--- a/docs/manual/08-skills.md
+++ b/docs/manual/08-skills.md
@@ -45,9 +45,19 @@ When you enable a skill for an agent, the agent gets the `SKILL.md` content as a
 
 **Built-in skills.** Ship with OpenHermit and are discoverable as soon as the gateway is running. They cover common patterns: research, summarisation, GitHub helpers, and similar.
 
-**Workspace / custom skills.** Skills you write yourself, or pull from a third-party repo, and **register** with OpenHermit. Once registered, they behave the same as built-in skills.
+**User skills.** Skills you write yourself, or pull from a third-party repo. Drop the skill folder under `~/.openhermit/skills/user/` and the gateway picks it up on the next scan. Once registered, user skills behave the same as built-in skills.
 
-Either way, the workflow is identical: list, enable, disable.
+```
+~/.openhermit/skills/user/
+├── weekly-retro/
+│   └── SKILL.md
+├── standup-digest/
+│   ├── SKILL.md
+│   └── helper.sh
+└── …
+```
+
+Either source — built-in or user — the workflow is identical: list, enable, disable.
 
 ---
 
@@ -96,7 +106,7 @@ The agent decides on its own when a skill applies. You usually do not need to in
 
 ## 8.5 Web Admin UI
 
-The *Manage → Skills* tab shows the registry, the assignments, and toggles to enable or disable per agent. Registering new skills typically still happens through the CLI or by dropping a skill folder into the gateway's skills directory and running `hermit skills scan`.
+The *Manage → Skills* tab shows the registry, the assignments, and toggles to enable or disable per agent. Registering new skills typically still happens through the filesystem — drop the folder under `~/.openhermit/skills/user/` and run `hermit skills scan` (or restart the gateway).
 
 ---
 
@@ -133,13 +143,13 @@ hermit skills enable web-research --agent main
 
 **Steps**
 
-1. Create the folder:
+1. Create the folder under the user skills directory:
 
    ```bash
-   mkdir -p ./skills/weekly-retro
+   mkdir -p ~/.openhermit/skills/user/weekly-retro
    ```
 
-2. Write `SKILL.md`:
+2. Write `SKILL.md` inside it:
 
    ```markdown
    ---
@@ -152,10 +162,10 @@ hermit skills enable web-research --agent main
    When asked for a weekly retro, …
    ```
 
-3. Register and enable:
+3. Scan and enable:
 
    ```bash
-   hermit skills register weekly-retro --path ./skills/weekly-retro
+   hermit skills scan
    hermit skills enable weekly-retro --agent main
    ```
 

--- a/docs/manual/09-mcp-servers.md
+++ b/docs/manual/09-mcp-servers.md
@@ -66,12 +66,12 @@ Most useful MCP servers need credentials (a GitHub token, a Slack bot token, an 
 1. Store the credential as a **secret** (see [Chapter 18 · Secrets](18-secrets.md)):
 
    ```bash
-   hermit config secrets set GITHUB_TOKEN ghp_xxx --agent main
+   hermit config --agent main secrets set GITHUB_TOKEN ghp_xxx --pass-through
    ```
 
 2. The MCP server's configuration references the secret as `${{GITHUB_TOKEN}}`. The gateway substitutes the value when the server starts.
 
-You manage the credential rotation through `hermit config secrets`, not through the MCP server's config.
+You manage the credential rotation through `hermit config --agent ... secrets`, not through the MCP server's config.
 
 ---
 
@@ -105,7 +105,7 @@ The agent's role-filtered toolset includes MCP tools by default for users; depen
 
 ```bash
 # 1. Store your GitHub token as a secret.
-hermit config secrets set GITHUB_TOKEN <ghp_...> --agent main
+hermit config --agent main secrets set GITHUB_TOKEN <ghp_...> --pass-through
 
 # 2. Enable the MCP server.
 hermit mcp enable mcp_github --agent main

--- a/docs/manual/09-mcp-servers.md
+++ b/docs/manual/09-mcp-servers.md
@@ -1,0 +1,172 @@
+---
+title: MCP Servers
+slug: mcp-servers
+order: 9
+part: Part 2 — Daily Use
+description: Connect external tools — GitHub, Slack, Linear, your own APIs — through the Model Context Protocol.
+---
+
+# 9. MCP Servers
+
+The **Model Context Protocol** (MCP) is a standard way for AI agents to call external tools. An **MCP server** exposes a set of tools to the agent: read a GitHub issue, post a Slack message, query a database, hit a custom endpoint. Connecting an MCP server is how you give the agent reach beyond its own workspace.
+
+This chapter is about using MCP servers from a user's perspective: register, enable, talk to the agent and have it pick the right tool. Authoring an MCP server is a different topic that lives upstream in the MCP project itself.
+
+---
+
+## 9.1 What MCP Looks Like in Practice
+
+You enable, say, an MCP server called `mcp_github`. After enabling, the agent has access to tools like `list_issues`, `create_pr`, `read_file`. You then talk to the agent normally:
+
+> What issues are open on the `infra` repo right now?
+
+The agent calls `list_issues` with the right arguments, gets the data, summarises it. You did not type any tool names. The MCP layer is invisible at the chat layer; it shows up in the *tool calls* expansion if you look in the web UI.
+
+---
+
+## 9.2 Where MCP Servers Come From
+
+OpenHermit does not ship default MCP servers — the catalog is whatever you (or the wider MCP ecosystem) registers with the instance. Typical sources:
+
+- **Official MCP servers** — published by the protocol authors and ecosystem partners. Often distributed as npm packages or container images.
+- **Community servers** — third parties publishing servers for popular services.
+- **Your own** — internal APIs you wrap as an MCP server.
+
+Registration usually happens through OpenHermit's MCP store / configuration. The exact way an operator added them to your instance varies; from your side, what matters is which ones are present and enabled.
+
+---
+
+## 9.3 The `hermit mcp` Commands
+
+```bash
+# List MCP servers registered with this instance.
+hermit mcp list
+
+# Show which servers are enabled on which agents.
+hermit mcp assignments
+
+# Enable an MCP server for one agent.
+hermit mcp enable mcp_github --agent main
+
+# Enable for every agent.
+hermit mcp enable mcp_github --all
+
+# Disable.
+hermit mcp disable mcp_github --agent main
+```
+
+Toggling an MCP server is hot — the agent picks up the change on the next message.
+
+---
+
+## 9.4 Authentication and Secrets
+
+Most useful MCP servers need credentials (a GitHub token, a Slack bot token, an internal API key). The pattern is:
+
+1. Store the credential as a **secret** (see [Chapter 18 · Secrets](18-secrets.md)):
+
+   ```bash
+   hermit config secrets set GITHUB_TOKEN ghp_xxx --agent main
+   ```
+
+2. The MCP server's configuration references the secret as `${{GITHUB_TOKEN}}`. The gateway substitutes the value when the server starts.
+
+You manage the credential rotation through `hermit config secrets`, not through the MCP server's config.
+
+---
+
+## 9.5 Web Admin UI
+
+The *Manage → MCP* tab lists the registered servers and shows toggles per agent. If your instance exposes an MCP catalog browser, you may also be able to install new servers from there.
+
+---
+
+## 9.6 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Use MCP tools the agent has access to | ✓ | ✓ (default) | ✓ (default) |
+| Enable / disable MCP servers | ✓ | — | — |
+| Register a new MCP server | ✓ | — | — |
+
+The agent's role-filtered toolset includes MCP tools by default for users; depending on the server, you may want to tighten this with policy. For example, an MCP server that can `create_pr` should probably not be reachable by guests — set a policy rule that blocks it, see [Chapter 15](15-policy-and-approval.md).
+
+---
+
+## 9.7 How-to Recipes
+
+### 9.7.1 Enable GitHub access for your agent
+
+**Scenario** — you want the agent to read issues, comment, and open PRs in a few repos.
+
+**Prerequisites** — an MCP server like `mcp_github` is registered with the instance. (If not, ask the operator to install it.)
+
+**Steps**
+
+```bash
+# 1. Store your GitHub token as a secret.
+hermit config secrets set GITHUB_TOKEN <ghp_...> --agent main
+
+# 2. Enable the MCP server.
+hermit mcp enable mcp_github --agent main
+```
+
+**Verify** — ask the agent:
+
+> List the most recent issues on the `org/repo` repository.
+
+It should reply with real data from GitHub.
+
+---
+
+### 9.7.2 Tighten an MCP server to read-only for users
+
+**Scenario** — you enabled `mcp_github` and now you want users (not owners) to be able to *read* but not to open PRs or delete branches.
+
+**Steps**
+
+This is policy work. Open [Chapter 15 · Policy and Approval](15-policy-and-approval.md) and add a deny rule for write-y tools when the principal role is `user`. The MCP server stays enabled; the gateway gates individual tools.
+
+---
+
+### 9.7.3 Switch off an MCP server while you investigate
+
+**Scenario** — an MCP server is behaving badly and you want it gone until you fix it.
+
+```bash
+hermit mcp disable mcp_slack --agent main
+```
+
+Re-enable when ready. No data is lost; the credential and config stay in place.
+
+---
+
+### 9.7.4 Roll an MCP out fleet-wide
+
+```bash
+hermit mcp enable mcp_research --all
+```
+
+**Verify** — `hermit mcp assignments` shows the server enabled on every agent.
+
+---
+
+## 9.8 FAQ
+
+**Why is the agent suddenly slower after I enabled an MCP server?** Each enabled MCP server contributes its tool definitions to every prompt, raising the input token count. Disable servers you do not use.
+
+**Can the agent pick which MCP server to use?** Yes — tool definitions are tagged with the server name, and the agent routes calls to whichever server exposes the matching tool.
+
+**Can multiple MCP servers expose the same tool name?** Yes; the gateway disambiguates by server prefix. If you have collisions, the agent's tool calls will include the prefix.
+
+**Do MCP servers run in the same sandbox as my workspace?** No — MCP servers are separate processes on the gateway side, talking to the agent over the MCP protocol. They do not have access to your workspace files unless they explicitly expose tools that read them.
+
+**Where do I find more MCP servers?** Check the official MCP project's directory and the GitHub topic `mcp-server`. The ecosystem is growing fast.
+
+---
+
+## 9.9 Pointers
+
+- Manage the credential an MCP server uses → [Chapter 18 · Secrets](18-secrets.md).
+- Limit which roles can call a particular MCP tool → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Skills vs MCP — when to reach for which → [Chapter 8 · Skills](08-skills.md), section 8.8.

--- a/docs/manual/10-files-and-workspace.md
+++ b/docs/manual/10-files-and-workspace.md
@@ -1,0 +1,169 @@
+---
+title: Files and Workspace
+slug: files-and-workspace
+order: 10
+part: Part 2 — Daily Use
+description: The agent's filesystem — what it can see, how to upload and download files, and how the sandbox isolates the workspace.
+---
+
+# 10. Files and Workspace
+
+Every agent has its own **workspace** — a filesystem inside a sandboxed environment where the agent can read, write, and execute. This is where the files you attach go, where the agent saves generated output, and where it clones a repo if you ask. Understanding what is in the workspace and how to move things in and out is most of what you need to know.
+
+---
+
+## 10.1 What the Workspace Is
+
+The workspace is the agent's "computer". It is a directory inside a sandbox (a Docker container, an E2B cloud sandbox, or a Daytona workspace, depending on how the instance was configured — that choice is made operator-side). From your seat:
+
+- It is **per agent**: each agent has its own. Two agents on the same instance do not share workspace files.
+- It is **shared across sessions**: a file you uploaded in session A is visible to the agent in session B.
+- It is **persistent**: files survive restarts, gateway upgrades, and agent disable/enable.
+- It is **isolated**: code the agent runs cannot escape the sandbox.
+
+The agent's tools for reaching the workspace are file read, write, search, and shell exec — same tools any reasonable engineer would expect.
+
+---
+
+## 10.2 What the Agent Can See
+
+Inside the workspace, the agent has free read access. There is no per-session file isolation — a file uploaded in a private session with you is still in the workspace and the agent will see it when chatting with someone else (subject to that user's role and policy).
+
+If you have sensitive files you do not want any session to surface, do not upload them, or put them in a path you have explicitly excluded via policy. See [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+
+---
+
+## 10.3 Getting Files In
+
+**Web UI.** Drag a file into the chat window. The adapter writes it into a known path inside the workspace and notifies the agent. The agent's reply will reference the new file by name.
+
+**Telegram / Discord / Slack.** Send a file attachment in the chat. The channel adapter does the same thing — copies into the workspace, hands the agent a notification.
+
+**CLI.** There is no built-in upload command in `hermit chat`. Either drop the file directly into the workspace path (operator-known location), or use the web UI for that one upload and come back to CLI.
+
+**The agent fetches it.** Often the easiest path: paste a URL and say "download this PDF and analyse it". The agent uses its fetch tool (or an MCP server) and the file ends up in the workspace.
+
+---
+
+## 10.4 Getting Files Out
+
+**Ask the agent.** "Show me the contents of `report.md`" or "encode `chart.png` as base64 and paste it" works for small files.
+
+**Web UI.** The web UI typically renders artefacts (markdown, code, images) inline. Right-click to save.
+
+**Channel adapters.** Ask the agent to send a file back as an attachment; Telegram and Slack adapters support this.
+
+**Direct sandbox access.** For bulk operations, the operator can configure direct download from the sandbox; this is not a default user-side feature.
+
+---
+
+## 10.5 The Tools the Agent Uses
+
+You will see these in the *tool calls* view if you expand a reply:
+
+- **File read** — fetch a file's content into context.
+- **File write** — create or overwrite a file.
+- **File search / list** — grep, glob, ls equivalents.
+- **Exec** — run a shell command in the sandbox.
+
+Exec is the most powerful and the most policy-sensitive. By default, owners and users have it; guests do not. Sensitive commands can be deny-listed via policy (see [Chapter 15](15-policy-and-approval.md)).
+
+---
+
+## 10.6 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Read files | ✓ | ✓ | — |
+| Write files | ✓ | ✓ | — |
+| Run shell commands | ✓ | ✓ | — |
+| Upload via channel | ✓ | ✓ | (depends on policy) |
+| Download | ✓ | ✓ | (depends on policy) |
+
+Guests get a no-file-tools experience by default. That keeps a public-facing agent (auto-creating guest users from arbitrary Telegram or web visitors) from getting a stranger's file dropped into shared workspace storage.
+
+---
+
+## 10.7 How-to Recipes
+
+### 10.7.1 Upload a CSV and ask the agent to analyse it
+
+**Scenario** — you have a sales export and you want trends.
+
+**Steps**
+
+1. Open the web UI, pick the agent, drag `sales-q1.csv` onto the chat.
+2. Ask: "Analyse this — what are the top three trends?"
+
+The agent reads the file, runs analysis (often with Python via exec), and replies.
+
+**Verify** — the reply names specific values from your file.
+
+---
+
+### 10.7.2 Have the agent generate a file and download it
+
+**Scenario** — you want a markdown summary of a long conversation.
+
+**Steps**
+
+> Save a markdown summary of this conversation to `summary.md` in the workspace.
+
+The agent writes the file. Then either:
+
+- Ask the agent to read it back inline ("show me `summary.md`") and copy from the reply.
+- In the web UI, navigate to the workspace browser (*Manage → Files*, if your instance exposes one) and download directly.
+
+---
+
+### 10.7.3 Clean up the workspace
+
+**Scenario** — over months of use the workspace has accumulated files you no longer need.
+
+**Steps**
+
+Ask the agent:
+
+> List files in the workspace older than 90 days; for each, summarise its purpose and ask me whether to keep or delete.
+
+Walk through interactively. Or do it bulk:
+
+> Delete every file matching `tmp_*` or `.log`.
+
+**Verify** — `ls` the workspace via the agent or the operator-provided viewer.
+
+**Common issues** — if the agent has been running scripts that write to specific paths, those scripts may break if you delete their working files. Look before you sweep.
+
+---
+
+### 10.7.4 Block guests from a particular path
+
+**Scenario** — a public agent has a few private notes under `private/` and you do not want guests to surface them.
+
+**Steps**
+
+Add a policy rule denying file operations under `private/` for the `guest` role. See [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+
+**Verify** — sign in as guest (or use a fresh public identity) and ask the agent about a file under `private/`; the file read should be refused.
+
+---
+
+## 10.8 FAQ
+
+**Where does my uploaded file go inside the workspace?** Typically a known uploads path; the specific layout depends on the sandbox backend. The agent knows the path and will reference it in replies.
+
+**Can the agent install software in its sandbox?** Yes, within the sandbox — apt/pip/npm and similar work. Changes persist for that agent's workspace.
+
+**If the sandbox dies, do I lose my files?** No. The workspace is backed by persistent storage; restarting the sandbox does not erase it.
+
+**Two agents on the same instance — do they see each other's files?** No. Per-agent isolation.
+
+**Multiple users on one agent — do they see each other's uploads?** Yes. The workspace is per agent, not per user. If you need per-user isolation, run one agent per user.
+
+---
+
+## 10.9 Pointers
+
+- Restrict what the agent can run via exec → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Manage secrets the agent uses inside the sandbox → [Chapter 18 · Secrets](18-secrets.md).
+- The agent's broader memory model → [Chapter 6 · Memory](06-memory.md).

--- a/docs/manual/11-schedules.md
+++ b/docs/manual/11-schedules.md
@@ -1,0 +1,134 @@
+---
+title: Schedules
+slug: schedules
+order: 11
+part: Part 2 — Daily Use
+description: Have the agent run on a cron or at a one-off time — daily digests, weekly reviews, reminders.
+---
+
+# 11. Schedules
+
+A **schedule** is a saved prompt the agent runs on its own at a time you specify. Daily standup digests, weekly retros, "remind me on Friday to send the invoice" — anything you would otherwise have to remember to ask for, the agent can be told to do on its own clock.
+
+---
+
+## 11.1 Two Kinds of Schedule
+
+**Cron** — recurring. "Every weekday at 09:00", "first Monday of the month at 14:00". Uses standard cron expressions.
+
+**One-off** — runs once at an absolute time, then deletes itself. Good for reminders and dated tasks.
+
+Both kinds carry a *prompt* — exactly the text the agent would receive as if you had typed it. When the schedule fires, the gateway opens a new session and submits that prompt.
+
+---
+
+## 11.2 The `hermit schedules` Commands
+
+```bash
+# Create a recurring schedule.
+hermit schedules create \
+  --type cron \
+  --cron "0 9 * * 1-5" \
+  --prompt "Generate the daily standup digest and post it to #standup." \
+  --agent main
+
+# Create a one-off.
+hermit schedules create \
+  --type once \
+  --run-at "2026-05-20T09:00:00Z" \
+  --prompt "Remind me to file the quarterly report." \
+  --agent main
+
+# List schedules on an agent.
+hermit schedules list --agent main
+
+# Delete by ID.
+hermit schedules delete <id> --agent main
+```
+
+Schedules are stored per agent. The agent runs the saved prompt with its full toolset, so the prompt can ask it to read files, call MCP tools, send messages — anything you could do interactively.
+
+---
+
+## 11.3 Where the Output Goes
+
+A scheduled run is a regular session. Its messages show up in the *Observe* tab in the web UI just like any other session, and the agent can be told to post the result somewhere ("…and send it to me on Telegram", "…and write it to `digest.md`").
+
+If you do not tell the agent where to put the output, it produces a reply that nobody reads. Always close the loop in the prompt.
+
+---
+
+## 11.4 Web Admin UI
+
+The *Manage → Schedules* tab shows existing schedules and a form to create new ones. Same data as the CLI.
+
+---
+
+## 11.5 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Create / edit / delete schedules | ✓ | — | — |
+| See scheduled runs in Observe | ✓ | ✓ (their sessions) | — |
+
+Schedules are owner-controlled. Users can ask the agent to remember a reminder, but that lands in memory, not in the scheduler.
+
+---
+
+## 11.6 How-to Recipes
+
+### 11.6.1 Daily Telegram digest at 09:00
+
+```bash
+hermit schedules create \
+  --type cron \
+  --cron "0 9 * * 1-5" \
+  --prompt "Summarise yesterday's GitHub activity for org/repo and send the summary to me on Telegram." \
+  --agent main
+```
+
+**Prerequisites** — `mcp_github` enabled with a token, and the Telegram channel linked to your identity.
+
+**Verify** — wait for 09:00 next weekday, or temporarily set the cron to a minute from now and watch the *Observe* tab.
+
+---
+
+### 11.6.2 One-off reminder
+
+```bash
+hermit schedules create \
+  --type once \
+  --run-at "2026-05-15T14:00:00Z" \
+  --prompt "Send me a Telegram message: 'Time to renew the domain.'" \
+  --agent main
+```
+
+**Verify** — `hermit schedules list --agent main` shows the entry until it fires.
+
+---
+
+### 11.6.3 Cancel a recurring schedule
+
+```bash
+hermit schedules list --agent main          # find the ID
+hermit schedules delete <id> --agent main
+```
+
+---
+
+## 11.7 FAQ
+
+**What timezone does cron use?** UTC by default. If you need local time, either translate manually or include the timezone offset in your cron expression's documentation; the gateway evaluates the expression against UTC.
+
+**What if the gateway is down at the scheduled time?** The run is missed; the gateway does not backfill on restart. For critical reminders, prefer a one-off scheduled close to the event and rely on the channel notification.
+
+**Can a scheduled run trigger another schedule?** No — schedules are created by humans via CLI/UI, not by the agent itself.
+
+**Can I edit a schedule?** Delete and recreate. There is no in-place edit.
+
+---
+
+## 11.8 Pointers
+
+- The prompt the schedule runs has full agent capabilities → see [Chapter 8 · Skills](08-skills.md) and [Chapter 9 · MCP Servers](09-mcp-servers.md).
+- Watch scheduled runs as they happen → [Chapter 20 · Web Admin UI](20-web-admin-ui.md), Observe tab.

--- a/docs/manual/12-inviting-people.md
+++ b/docs/manual/12-inviting-people.md
@@ -40,9 +40,9 @@ You can promote a guest to user later, so when in doubt, start as guest.
 1. The other person finds the bot (you give them the handle).
 2. They send a message — say, `/start` for Telegram.
 3. The gateway creates a guest user pinned to that channel handle.
-4. You (the owner) decide: leave them as guest, link them to an existing user record (if they are someone you already know), or promote them to user with `hermit users update <id> --role user`.
+4. You (the owner) decide: leave them as guest, link them to an existing user record (if they are someone you already know), or promote them to user from the gateway admin UI or by asking the agent to call `user_role_set`.
 
-The exact CLI commands are in [Chapter 14 · Managing Members](14-managing-members.md).
+The supported management surfaces are in [Chapter 14 · Managing Members](14-managing-members.md).
 
 ### Web
 
@@ -85,17 +85,8 @@ Only owners invite and revoke. Users and guests can talk to the agent but cannot
 1. Make sure the Telegram channel is configured on the agent (see [Chapter 17](17-channels.md)).
 2. Share the bot handle (e.g., `@my_agent_bot`).
 3. Wait for them to send their first message — a guest identity is created.
-4. List recent identities and find theirs:
-
-   ```bash
-   hermit users list --agent main
-   ```
-
-5. Promote them:
-
-   ```bash
-   hermit users update <user-id> --role user --agent main
-   ```
+4. List recent identities in the gateway admin UI's *Users* tab, or ask the agent as owner to list users.
+5. Promote them from the admin UI, or ask the agent as owner: "promote `<user-id>` to user on `main`."
 
 **Verify** — they ask the agent to write a file; the file gets written (guests cannot, users can).
 
@@ -117,11 +108,7 @@ Only owners invite and revoke. Users and guests can talk to the agent but cannot
 
 ### 12.6.3 Revoke someone's access
 
-```bash
-hermit users update <user-id> --role guest --agent main   # demote
-# or, to drop them entirely:
-hermit users delete <user-id> --agent main
-```
+Demote them from the gateway admin UI, or ask the agent as owner to demote the user. To drop their membership entirely, use the member API: `DELETE /api/agents/<agent-id>/members/<user-id>`.
 
 If they re-engage the agent, they will create a fresh guest identity (unless the channel itself is access-controlled at the operator level).
 

--- a/docs/manual/12-inviting-people.md
+++ b/docs/manual/12-inviting-people.md
@@ -1,0 +1,144 @@
+---
+title: Inviting People
+slug: inviting-people
+order: 12
+part: Part 3 — Sharing an Agent
+description: Bring other people onto your agent — as users or guests — across CLI, web, and channels.
+---
+
+# 12. Inviting People
+
+Sharing an agent means letting someone else talk to it. The mechanics are: decide their role (user or guest — owners are not invited, they own the instance), give them a way to reach the agent (a channel link or a web URL), and let the identity system tie their channel presence to a stored user record.
+
+This chapter is the practical guide to that flow. The conceptual basis lives in [Chapter 5 · Users and Identity](05-users-and-identity.md).
+
+---
+
+## 12.1 Decide the Role First
+
+- **User** — a known person you trust with the agent's full read/write tools. They can chat, attach files, use enabled skills, call MCP tools that policy allows for users.
+- **Guest** — anyone else. Reduced toolset by default — no file write, no memory write, no exec. Good for public-facing agents, casual sharing, demos.
+
+You can promote a guest to user later, so when in doubt, start as guest.
+
+---
+
+## 12.2 Three Ways to Reach the Agent
+
+**Web URL.** The web UI has a per-agent chat URL. Anyone with the URL can land in a session, subject to whatever access control the agent has (public / protected / private — see [Chapter 13](13-access-levels.md)).
+
+**Channel handles.** If you have linked Telegram / Discord / Slack to the agent, share the bot's handle. The first message someone sends creates an identity tuple (channel, channel_user_id) that defaults to a guest user.
+
+**CLI.** Not really an invite path — CLI access is for owners and trusted users with hermit installed and configured against the same gateway.
+
+---
+
+## 12.3 The Invite Flow (Per Channel)
+
+### Telegram / Discord / Slack
+
+1. The other person finds the bot (you give them the handle).
+2. They send a message — say, `/start` for Telegram.
+3. The gateway creates a guest user pinned to that channel handle.
+4. You (the owner) decide: leave them as guest, link them to an existing user record (if they are someone you already know), or promote them to user with `hermit users update <id> --role user`.
+
+The exact CLI commands are in [Chapter 14 · Managing Members](14-managing-members.md).
+
+### Web
+
+1. You share the agent URL.
+2. They sign in (if the agent is protected) or land directly (if public).
+3. A web identity is created — same flow as a channel.
+4. Same options for the owner afterwards: leave as guest, link, or promote.
+
+---
+
+## 12.4 Owner-Side Checklist Before Inviting
+
+Going one by one:
+
+- **Access level set?** Public, protected, or private. Decide before sharing the URL. See [Chapter 13](13-access-levels.md).
+- **Default role for new identities?** Defaults to guest. If you want a closed invite-only experience, set the access level to private and approve each new identity by hand.
+- **Sensitive files in the workspace?** Anything in the workspace is reachable by anyone who can talk to the agent and has file-tool permissions. Move sensitive content out, or add a policy rule. See [Chapter 10](10-files-and-workspace.md) and [Chapter 15](15-policy-and-approval.md).
+- **MCP credentials**? Tokens for GitHub, Slack, etc. are reachable through the agent's tools — anyone allowed to call the relevant tool can act with those credentials. Apply role policy if a tool should be owner-only.
+
+---
+
+## 12.5 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Invite others | ✓ | — | — |
+| Promote a guest to user | ✓ | — | — |
+| Revoke access | ✓ | — | — |
+
+Only owners invite and revoke. Users and guests can talk to the agent but cannot change who else can.
+
+---
+
+## 12.6 How-to Recipes
+
+### 12.6.1 Invite a co-worker as a user via Telegram
+
+**Steps**
+
+1. Make sure the Telegram channel is configured on the agent (see [Chapter 17](17-channels.md)).
+2. Share the bot handle (e.g., `@my_agent_bot`).
+3. Wait for them to send their first message — a guest identity is created.
+4. List recent identities and find theirs:
+
+   ```bash
+   hermit users list --agent main
+   ```
+
+5. Promote them:
+
+   ```bash
+   hermit users update <user-id> --role user --agent main
+   ```
+
+**Verify** — they ask the agent to write a file; the file gets written (guests cannot, users can).
+
+---
+
+### 12.6.2 Open the agent up to a public web URL with guest access
+
+**Scenario** — you want a public demo agent.
+
+**Steps**
+
+1. Set access to public ([Chapter 13](13-access-levels.md)).
+2. Share the agent's chat URL.
+3. Visitors land as guests automatically; no further action needed from you.
+
+**Common issues** — public agents must have strict policy around tools that touch your credentials or files. A public guest with `mcp_github` enabled can read public issues fine; if your token has write scopes it can also open PRs. Apply policy to deny write tools for the guest role. See [Chapter 15](15-policy-and-approval.md).
+
+---
+
+### 12.6.3 Revoke someone's access
+
+```bash
+hermit users update <user-id> --role guest --agent main   # demote
+# or, to drop them entirely:
+hermit users delete <user-id> --agent main
+```
+
+If they re-engage the agent, they will create a fresh guest identity (unless the channel itself is access-controlled at the operator level).
+
+---
+
+## 12.7 FAQ
+
+**Can I send an email invite?** Not built in. Share the URL or the bot handle through whatever channel you already use.
+
+**Do I need an invite system or signup flow?** No. Identity is created lazily when someone first contacts the agent. You moderate after the fact.
+
+**Can someone be a user on one agent and a guest on another?** Yes. Roles are per agent.
+
+---
+
+## 12.8 Pointers
+
+- Manage who has access after the invite → [Chapter 14 · Managing Members](14-managing-members.md).
+- Set whether the agent is public / protected / private → [Chapter 13 · Access Levels](13-access-levels.md).
+- Restrict what a role can do beyond the defaults → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).

--- a/docs/manual/13-access-levels.md
+++ b/docs/manual/13-access-levels.md
@@ -42,9 +42,9 @@ Default for a freshly created agent is private. Loosening is a deliberate act.
 ## 13.3 Setting the Level
 
 ```bash
-hermit agents update <agent-id> --access-level public
-hermit agents update <agent-id> --access-level protected
-hermit agents update <agent-id> --access-level private
+hermit config --agent <agent-id> security set access public
+hermit config --agent <agent-id> security set access protected
+hermit config --agent <agent-id> security set access private
 ```
 
 Web UI: *Manage → Basic* has the access level selector.
@@ -75,7 +75,7 @@ For channels with their own gating (e.g., a private Slack workspace), that gatin
 ### 13.6.1 Lock down a previously public agent
 
 ```bash
-hermit agents update main --access-level private
+hermit config --agent main security set access private
 ```
 
 Existing guest identities are not auto-removed; they just cannot create new sessions. To clean them out:

--- a/docs/manual/13-access-levels.md
+++ b/docs/manual/13-access-levels.md
@@ -80,10 +80,7 @@ hermit config --agent main security set access private
 
 Existing guest identities are not auto-removed; they just cannot create new sessions. To clean them out:
 
-```bash
-hermit users list --agent main --role guest
-hermit users delete <id> --agent main   # repeat as needed
-```
+Use the gateway admin UI's *Users* tab to find guest members, then remove memberships through the UI or `DELETE /api/agents/main/members/<user-id>`.
 
 ---
 

--- a/docs/manual/13-access-levels.md
+++ b/docs/manual/13-access-levels.md
@@ -1,0 +1,110 @@
+---
+title: Access Levels
+slug: access-levels
+order: 13
+part: Part 3 — Sharing an Agent
+description: Public, protected, private — the three settings that decide who can talk to the agent at all.
+---
+
+# 13. Access Levels
+
+Access level is the front gate of an agent. Before role policy and per-tool gating apply, the access level decides whether a person can even start a session.
+
+---
+
+## 13.1 The Three Levels
+
+**Public.** Anyone with the agent's URL or channel handle can talk to it. New visitors become guest identities automatically.
+
+**Protected.** Sign-in required. Visitors must authenticate before they can chat. After sign-in they default to guest until you promote them.
+
+**Private.** Only identities the owner has explicitly added can talk. New unknown contacts are blocked at the gate; no automatic guest creation.
+
+| | Public | Protected | Private |
+|---|:---:|:---:|:---:|
+| Anyone with URL can chat | ✓ | — | — |
+| Sign-in required | — | ✓ | ✓ |
+| Owner must approve each new identity | — | — | ✓ |
+| Auto-create guest on first message | ✓ | ✓ | — |
+
+---
+
+## 13.2 Picking a Level
+
+- **Public** — demos, support bots, anything you intentionally want strangers to use. Pair with tight role policy.
+- **Protected** — internal tools you want a known group to use. Sign-in keeps drive-by visitors out and gives you a real identity to attach roles to.
+- **Private** — sensitive workspaces, personal agents, anything where unknown contact is a problem.
+
+Default for a freshly created agent is private. Loosening is a deliberate act.
+
+---
+
+## 13.3 Setting the Level
+
+```bash
+hermit agents update <agent-id> --access-level public
+hermit agents update <agent-id> --access-level protected
+hermit agents update <agent-id> --access-level private
+```
+
+Web UI: *Manage → Basic* has the access level selector.
+
+Changes take effect immediately. Existing sessions for already-allowed identities are not interrupted.
+
+---
+
+## 13.4 Channel Interaction
+
+The access level applies to every channel uniformly — there is no "public on web, private on Telegram". If you need that asymmetry, run separate agents.
+
+For channels with their own gating (e.g., a private Slack workspace), that gating composes with the agent's access level. A private Slack channel already restricts who can DM the bot; setting the agent to protected on top is mostly redundant.
+
+---
+
+## 13.5 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Read current access level | ✓ | ✓ | — |
+| Change access level | ✓ | — | — |
+
+---
+
+## 13.6 How-to Recipes
+
+### 13.6.1 Lock down a previously public agent
+
+```bash
+hermit agents update main --access-level private
+```
+
+Existing guest identities are not auto-removed; they just cannot create new sessions. To clean them out:
+
+```bash
+hermit users list --agent main --role guest
+hermit users delete <id> --agent main   # repeat as needed
+```
+
+---
+
+### 13.6.2 Open a single demo agent publicly while keeping the rest private
+
+Access level is per agent. Set the demo agent to public; leave the others private. Same gateway, different doors.
+
+---
+
+## 13.7 FAQ
+
+**Does the access level change what existing users can do?** No — it only governs new identity creation and session start. To change capabilities, edit roles or policy.
+
+**Can I see who tried to access a private agent and was blocked?** Gateway logs record blocked attempts; surfacing them in the UI is on the roadmap.
+
+**Does access level interact with policy?** They stack. Access level is the outer gate. Policy is the inner gate per tool/resource. A private agent with a permissive policy is still private — only allowed identities reach the policy layer at all.
+
+---
+
+## 13.8 Pointers
+
+- How identities are created and tied to people → [Chapter 5 · Users and Identity](05-users-and-identity.md).
+- After someone is in, what they can do → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Bring new people in deliberately → [Chapter 12 · Inviting People](12-inviting-people.md).

--- a/docs/manual/14-managing-members.md
+++ b/docs/manual/14-managing-members.md
@@ -1,0 +1,150 @@
+---
+title: Managing Members
+slug: managing-members
+order: 14
+part: Part 3 — Sharing an Agent
+description: List, promote, demote, link, and delete users — the day-to-day moderation of who is on your agent.
+---
+
+# 14. Managing Members
+
+Once people start showing up — through a channel invite or a public URL — you need to see who they are, decide what role they hold, and occasionally clean up. This chapter is the operator's pocket reference for that work.
+
+---
+
+## 14.1 The `hermit users` Commands
+
+```bash
+# List users on an agent.
+hermit users list --agent main
+
+# Filter by role.
+hermit users list --agent main --role guest
+
+# Show one user with their linked identities.
+hermit users get <user-id> --agent main
+
+# Promote / demote.
+hermit users update <user-id> --role user  --agent main
+hermit users update <user-id> --role guest --agent main
+
+# Link a channel identity to an existing user record.
+hermit users link <user-id> --channel telegram --channel-user-id 12345 --agent main
+
+# Remove a channel identity from a user.
+hermit users unlink <user-id> --channel telegram --agent main
+
+# Delete a user entirely (channel re-engagement creates a fresh guest).
+hermit users delete <user-id> --agent main
+```
+
+Promotion and demotion take effect on the next message.
+
+---
+
+## 14.2 Reading the User List
+
+A row typically shows: user ID, role, display name (best guess from the channel), linked identities (`telegram:12345`, `web:abc-uuid`), created date, last-seen date.
+
+Two columns to skim first:
+
+- **Role** — guests vs users. New rows are usually guests.
+- **Linked identities** — if one user has both `telegram:` and `web:` identities, they have been merged and the agent treats them as one person across channels.
+
+---
+
+## 14.3 Web Admin UI
+
+There is currently no dedicated *Manage → Members* tab in the web UI. Membership operations live in the CLI. The roadmap includes a UI for this.
+
+---
+
+## 14.4 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| List users | ✓ | — | — |
+| Promote / demote | ✓ | — | — |
+| Link / unlink identities | ✓ | — | — |
+| Delete users | ✓ | — | — |
+
+Only owners manage membership.
+
+---
+
+## 14.5 How-to Recipes
+
+### 14.5.1 Merge two identities into one person
+
+**Scenario** — you appear in the user list twice: once from your Telegram identity, once from your web sign-in. You want them collapsed.
+
+**Steps**
+
+1. List and identify both user records:
+
+   ```bash
+   hermit users list --agent main
+   ```
+
+2. Pick the one you want to keep (call it `<keep-id>`) and note the channel identity on the other (`<drop-id>`). Suppose the keeper has the web identity and the other has Telegram.
+3. Link the Telegram identity to the keeper:
+
+   ```bash
+   hermit users link <keep-id> --channel telegram --channel-user-id <telegram-user-id> --agent main
+   ```
+
+4. Delete the now-empty other record:
+
+   ```bash
+   hermit users delete <drop-id> --agent main
+   ```
+
+**Verify** — `hermit users get <keep-id>` shows both linked identities. Send a message from each channel; both should attribute to the same user.
+
+---
+
+### 14.5.2 Promote a guest to user after vetting
+
+```bash
+hermit users update <user-id> --role user --agent main
+```
+
+**Verify** — have them ask the agent to write a file; it succeeds.
+
+---
+
+### 14.5.3 Bulk-clean stale guests
+
+```bash
+# List guests older than 90 days (use --since/--until if your build supports it,
+# otherwise eyeball the last-seen column).
+hermit users list --agent main --role guest
+# Then delete the ones you no longer want:
+hermit users delete <id> --agent main
+```
+
+There is no built-in "delete-all-stale-guests" command; do this when the list gets noisy.
+
+---
+
+### 14.5.4 Audit who acted on a sensitive tool
+
+This is observability, not membership management. See [Chapter 20 · Web Admin UI](20-web-admin-ui.md) — *Observe* tab — for filtering sessions by tool call.
+
+---
+
+## 14.6 FAQ
+
+**Can a user have many channel identities?** Yes — link as many as you want. The agent treats them as one person.
+
+**Can the same channel identity belong to two users?** No. The tuple `(channel, channel_user_id)` resolves to exactly one user. If you re-link to a different user, the old link is detached first.
+
+**Does deleting a user delete their session history?** Sessions are tagged with their user ID; deleting the user does not erase past sessions by default. To purge sessions, use the session admin commands ([Chapter 21 · Troubleshooting](21-troubleshooting.md) lists them).
+
+---
+
+## 14.7 Pointers
+
+- Concepts behind identities and roles → [Chapter 5 · Users and Identity](05-users-and-identity.md).
+- Decide who can reach the agent at all → [Chapter 13 · Access Levels](13-access-levels.md).
+- Limit what each role can do → [Chapter 15 · Policy and Approval](15-policy-and-approval.md).

--- a/docs/manual/14-managing-members.md
+++ b/docs/manual/14-managing-members.md
@@ -12,31 +12,13 @@ Once people start showing up — through a channel invite or a public URL — yo
 
 ---
 
-## 14.1 The `hermit users` Commands
+## 14.1 Current Management Surfaces
 
-```bash
-# List users on an agent.
-hermit users list --agent main
+The current CLI does not include a `hermit users` command. Use one of these supported paths:
 
-# Filter by role.
-hermit users list --agent main --role guest
-
-# Show one user with their linked identities.
-hermit users get <user-id> --agent main
-
-# Promote / demote.
-hermit users update <user-id> --role user  --agent main
-hermit users update <user-id> --role guest --agent main
-
-# Link a channel identity to an existing user record.
-hermit users link <user-id> --channel telegram --channel-user-id 12345 --agent main
-
-# Remove a channel identity from a user.
-hermit users unlink <user-id> --channel telegram --agent main
-
-# Delete a user entirely (channel re-engagement creates a fresh guest).
-hermit users delete <user-id> --agent main
-```
+- **Web admin UI:** the gateway admin UI has a *Users* tab for viewing members and their linked identities.
+- **HTTP API:** `GET /api/agents/<agent-id>/members`, `POST /api/agents/<agent-id>/members`, and `DELETE /api/agents/<agent-id>/members/<user-id>`.
+- **Agent tools:** owners can ask the agent to list users, promote or demote a member, link or unlink an identity, or merge duplicates. The underlying tools are `user_list`, `user_role_set`, `user_identity_link`, `user_identity_unlink`, and `user_merge`.
 
 Promotion and demotion take effect on the next message.
 
@@ -55,7 +37,7 @@ Two columns to skim first:
 
 ## 14.3 Web Admin UI
 
-There is currently no dedicated *Manage → Members* tab in the web UI. Membership operations live in the CLI. The roadmap includes a UI for this.
+The gateway admin UI has a *Users* tab for member inspection. The per-agent web chat management view does not currently expose a dedicated members tab.
 
 ---
 
@@ -80,34 +62,19 @@ Only owners manage membership.
 
 **Steps**
 
-1. List and identify both user records:
-
-   ```bash
-   hermit users list --agent main
-   ```
+1. List and identify both user records in the gateway admin UI's *Users* tab, or ask the agent as owner: "list users and their linked identities".
 
 2. Pick the one you want to keep (call it `<keep-id>`) and note the channel identity on the other (`<drop-id>`). Suppose the keeper has the web identity and the other has Telegram.
-3. Link the Telegram identity to the keeper:
+3. Ask the agent as owner to link the Telegram identity to the keeper, or use the member API to add that identity.
+4. If two established users need to be collapsed, ask the agent as owner to merge `<drop-id>` into `<keep-id>`; it calls `user_merge`.
 
-   ```bash
-   hermit users link <keep-id> --channel telegram --channel-user-id <telegram-user-id> --agent main
-   ```
-
-4. Delete the now-empty other record:
-
-   ```bash
-   hermit users delete <drop-id> --agent main
-   ```
-
-**Verify** — `hermit users get <keep-id>` shows both linked identities. Send a message from each channel; both should attribute to the same user.
+**Verify** — the Users tab or `user_list` shows both linked identities under the keeper. Send a message from each channel; both should attribute to the same user.
 
 ---
 
 ### 14.5.2 Promote a guest to user after vetting
 
-```bash
-hermit users update <user-id> --role user --agent main
-```
+Ask the agent as owner: "promote `<user-id>` to user on `main`." It calls `user_role_set`.
 
 **Verify** — have them ask the agent to write a file; it succeeds.
 
@@ -115,13 +82,7 @@ hermit users update <user-id> --role user --agent main
 
 ### 14.5.3 Bulk-clean stale guests
 
-```bash
-# List guests older than 90 days (use --since/--until if your build supports it,
-# otherwise eyeball the last-seen column).
-hermit users list --agent main --role guest
-# Then delete the ones you no longer want:
-hermit users delete <id> --agent main
-```
+Use the gateway admin UI's *Users* tab or `user_list` to find stale guests, then remove the memberships through the member API.
 
 There is no built-in "delete-all-stale-guests" command; do this when the list gets noisy.
 

--- a/docs/manual/15-policy-and-approval.md
+++ b/docs/manual/15-policy-and-approval.md
@@ -1,0 +1,170 @@
+---
+title: Policy and Approval
+slug: policy-and-approval
+order: 15
+part: Part 3 — Sharing an Agent
+description: Per-tool rules that allow, deny, or require approval — the fine-grained layer below role.
+---
+
+# 15. Policy and Approval
+
+Role gives a coarse split (guest / user / owner). **Policy** is the layer underneath that lets you say "users can call `exec`, but only for read-only commands", or "any tool that touches the GitHub MCP server needs my approval first". Policy is how you make a shared agent safe.
+
+---
+
+## 15.1 The Three Effects
+
+Every policy rule produces one of three outcomes when the agent is about to call a tool:
+
+- **Allow** — the call proceeds.
+- **Deny** — the call is blocked; the agent receives an error in place of the result and decides what to do next.
+- **Require approval** — the call pauses; the owner gets a notification with the tool name and arguments, and must approve or reject before it runs.
+
+When multiple rules match, the most restrictive wins.
+
+---
+
+## 15.2 What a Rule Looks At
+
+A rule can match on:
+
+- **Tool name** — `file_write`, `exec`, `mcp_github.create_pr`, etc.
+- **Tool argument patterns** — e.g., `exec` where the command begins with `rm`.
+- **Principal role** — guest / user / owner.
+- **Resource path** — for file tools, the path the tool would touch.
+- **Channel** — sometimes useful to allow more in CLI/web than in public Telegram.
+
+Rules compose. You usually start with a couple of broad defaults and add specific exceptions as you encounter them.
+
+---
+
+## 15.3 The `hermit policy` Commands
+
+```bash
+# List rules on an agent.
+hermit policy list --agent main
+
+# Add a rule.
+hermit policy add \
+  --agent main \
+  --match "tool=exec,role=guest" \
+  --effect deny
+
+# Add an approval rule for write-y GitHub calls.
+hermit policy add \
+  --agent main \
+  --match "tool=mcp_github.create_pr,role=user" \
+  --effect require_approval
+
+# Remove a rule.
+hermit policy remove <rule-id> --agent main
+```
+
+The exact match syntax depends on your version; `hermit policy --help` and `hermit policy list` are the source of truth for what your gateway accepts.
+
+---
+
+## 15.4 Approvals — The User Side
+
+When a tool requires approval, the agent's reply pauses and the owner receives a notification (in the *Observe* tab in the web UI, and via channel notification if configured). The notification shows:
+
+- Which user / session is making the request.
+- Which tool the agent wants to call.
+- The full arguments.
+- A short rationale from the agent.
+
+The owner clicks approve or reject. The session resumes with that decision; the agent treats the result like any other tool outcome.
+
+Pending approvals time out (default a few minutes); a timeout counts as reject.
+
+---
+
+## 15.5 Sensible Defaults
+
+A starter policy that covers most shared agents:
+
+```bash
+# Guests cannot exec.
+hermit policy add --agent main --match "tool=exec,role=guest" --effect deny
+
+# Guests cannot write files.
+hermit policy add --agent main --match "tool=file_write,role=guest" --effect deny
+
+# Any tool that mutates external systems requires approval for users.
+hermit policy add --agent main --match "tool=mcp_github.create_pr,role=user" --effect require_approval
+hermit policy add --agent main --match "tool=mcp_slack.send_message,role=user" --effect require_approval
+```
+
+Owners are exempt unless you write rules that target them. (You can — sometimes a "make me confirm destructive ops" rule for yourself is wise.)
+
+---
+
+## 15.6 Web Admin UI
+
+The *Manage → Policies* tab shows the rule list with toggles to enable/disable and a form to add new ones.
+
+The *Observe* tab shows pending approvals at the top.
+
+---
+
+## 15.7 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| See policy rules | ✓ | — | — |
+| Add / remove rules | ✓ | — | — |
+| Approve pending requests | ✓ | — | — |
+
+---
+
+## 15.8 How-to Recipes
+
+### 15.8.1 Block file writes outside a sandbox path
+
+```bash
+hermit policy add \
+  --agent main \
+  --match "tool=file_write,path!=sandbox/**" \
+  --effect deny
+```
+
+(`path!=` syntax illustrative — check your version's `--help`.)
+
+**Verify** — ask the agent to write to `/etc/hosts`; it should be denied and recover.
+
+---
+
+### 15.8.2 Require approval for any destructive shell command
+
+```bash
+hermit policy add \
+  --agent main \
+  --match "tool=exec,arg:command~=^(rm|mv|kill|drop)" \
+  --effect require_approval
+```
+
+**Verify** — ask the agent to "delete the temp folder"; you should see an approval prompt.
+
+---
+
+### 15.8.3 Tighten a public agent
+
+For an access-level=public agent, write deny rules for guest role on: `exec`, `file_write`, every MCP tool that costs money, every MCP tool that mutates state in an external system. Allow `file_read` only under a public path.
+
+---
+
+## 15.9 FAQ
+
+**What happens to the agent's reply when a rule denies a call?** The agent sees the denial as a tool error and usually adapts — apologising, suggesting alternatives, or telling you what it wanted to do.
+
+**Can policy rules be time-bounded?** Not natively. If you need temporary loosening, add the rule, use the agent, remove the rule.
+
+**Where do approval notifications go?** *Observe* tab by default. If you have a notification channel configured (e.g., a Telegram chat for the owner), they go there too. Channel adapter support for approval prompts varies — check [Chapter 17](17-channels.md).
+
+---
+
+## 15.10 Pointers
+
+- Coarser, before-policy gating → [Chapter 13 · Access Levels](13-access-levels.md).
+- Who counts as guest / user / owner → [Chapter 5 · Users and Identity](05-users-and-identity.md).
+- Watch tool calls and approvals as they happen → [Chapter 20 · Web Admin UI](20-web-admin-ui.md).

--- a/docs/manual/15-policy-and-approval.md
+++ b/docs/manual/15-policy-and-approval.md
@@ -28,7 +28,7 @@ When multiple rules match, the most restrictive wins.
 
 A rule can match on:
 
-- **Tool name** — `file_write`, `exec`, `mcp_github.create_pr`, etc.
+- **Tool name / resource** — `file_write`, `exec`, or an MCP server id such as `github`.
 - **Tool argument patterns** — e.g., `exec` where the command begins with `rm`.
 - **Principal role** — guest / user / owner.
 - **Resource path** — for file tools, the path the tool would touch.
@@ -38,29 +38,23 @@ Rules compose. You usually start with a couple of broad defaults and add specifi
 
 ---
 
-## 15.3 The `hermit policy` Commands
+## 15.3 The `hermit config policy` Commands
 
 ```bash
 # List rules on an agent.
-hermit policy list --agent main
+hermit config --agent main policy list
 
-# Add a rule.
-hermit policy add \
-  --agent main \
-  --match "tool=exec,role=guest" \
-  --effect deny
+# Deny guests access to exec.
+hermit config --agent main policy set exec '[{"type":"role","value":"guest"}]' --effect deny
 
-# Add an approval rule for write-y GitHub calls.
-hermit policy add \
-  --agent main \
-  --match "tool=mcp_github.create_pr,role=user" \
-  --effect require_approval
+# Require approval for users on a GitHub MCP server.
+hermit config --agent main policy set github '[{"type":"role","value":"user"}]' --resource-type mcp --effect require_approval
 
 # Remove a rule.
-hermit policy remove <rule-id> --agent main
+hermit config --agent main policy delete exec --effect deny
 ```
 
-The exact match syntax depends on your version; `hermit policy --help` and `hermit policy list` are the source of truth for what your gateway accepts.
+`<resource-key>` is usually a tool name such as `exec`, an MCP server id such as `github`, or `*`. Grants are a JSON array such as `[{"type":"role","value":"guest"}]`, `[{"type":"role","value":"user"}]`, or `[{"type":"any"}]`.
 
 ---
 
@@ -85,14 +79,14 @@ A starter policy that covers most shared agents:
 
 ```bash
 # Guests cannot exec.
-hermit policy add --agent main --match "tool=exec,role=guest" --effect deny
+hermit config --agent main policy set exec '[{"type":"role","value":"guest"}]' --effect deny
 
-# Guests cannot write files.
-hermit policy add --agent main --match "tool=file_write,role=guest" --effect deny
+# Guests cannot use write-style shell/file tools.
+hermit config --agent main policy set file_write '[{"type":"role","value":"guest"}]' --effect deny
 
-# Any tool that mutates external systems requires approval for users.
-hermit policy add --agent main --match "tool=mcp_github.create_pr,role=user" --effect require_approval
-hermit policy add --agent main --match "tool=mcp_slack.send_message,role=user" --effect require_approval
+# External systems require approval for users.
+hermit config --agent main policy set github '[{"type":"role","value":"user"}]' --resource-type mcp --effect require_approval
+hermit config --agent main policy set slack  '[{"type":"role","value":"user"}]' --resource-type mcp --effect require_approval
 ```
 
 Owners are exempt unless you write rules that target them. (You can — sometimes a "make me confirm destructive ops" rule for yourself is wise.)
@@ -119,16 +113,13 @@ The *Observe* tab shows pending approvals at the top.
 
 ## 15.8 How-to Recipes
 
-### 15.8.1 Block file writes outside a sandbox path
+### 15.8.1 Block guests from writing files
 
 ```bash
-hermit policy add \
-  --agent main \
-  --match "tool=file_write,path!=sandbox/**" \
-  --effect deny
+hermit config --agent main policy set file_write '[{"type":"role","value":"guest"}]' --effect deny
 ```
 
-(`path!=` syntax illustrative — check your version's `--help`.)
+For path-specific rules, use `--resource-type file` plus a JSON `scope` with `sandbox`, `mode`, and `path`.
 
 **Verify** — ask the agent to write to `/etc/hosts`; it should be denied and recover.
 
@@ -137,10 +128,7 @@ hermit policy add \
 ### 15.8.2 Require approval for any destructive shell command
 
 ```bash
-hermit policy add \
-  --agent main \
-  --match "tool=exec,arg:command~=^(rm|mv|kill|drop)" \
-  --effect require_approval
+hermit config --agent main policy set exec '[{"type":"role","value":"user"}]' --effect require_approval
 ```
 
 **Verify** — ask the agent to "delete the temp folder"; you should see an approval prompt.

--- a/docs/manual/16-models.md
+++ b/docs/manual/16-models.md
@@ -24,18 +24,24 @@ Everything else (memory, instructions, skills, MCPs, workspace) is independent o
 
 ---
 
-## 16.2 The `hermit agents` Command
+## 16.2 The `hermit config` Commands
+
+Model selection lives under the agent's config tree, not as a flag on `hermit agents`. Two keys matter:
+
+- `model.provider` — which provider the gateway routes to (`anthropic`, `openai`, `openrouter`, …).
+- `model.model` — the model identifier the provider expects.
 
 ```bash
-hermit agents list                                # see current model per agent
-hermit agents update <id> --model <model-id>      # switch
+hermit config --agent main show                     # see all current config, including model.*
+hermit config --agent main get model.model          # one key
+hermit config --agent main set model.provider anthropic
+hermit config --agent main set model.model claude-opus-4-7
 
-# Examples.
-hermit agents update main --model claude-opus-4-7
-hermit agents update main --model claude-sonnet-4-6
+# Other useful model knobs:
+hermit config --agent main set model.max_tokens 16384
 ```
 
-The model identifier is whatever string the provider expects. The gateway translates it.
+The model identifier is whatever string the provider expects. The gateway hands it through.
 
 ---
 
@@ -78,7 +84,8 @@ Be aware of context-window mismatches: switching from a 200K-window model to a 3
 ### 16.7.1 Try a stronger model for a hard task
 
 ```bash
-hermit agents update main --model claude-opus-4-7
+hermit config --agent main set model.provider anthropic
+hermit config --agent main set model.model claude-opus-4-7
 ```
 
 Ask the question. If the answer is good and the latency tolerable, leave it. If you only needed the strength for one task, switch back when done.
@@ -90,7 +97,7 @@ Ask the question. If the answer is good and the latency tolerable, leave it. If 
 Pick a faster, smaller model for everyday chat:
 
 ```bash
-hermit agents update main --model claude-haiku-4-5
+hermit config --agent main set model.model claude-haiku-4-5
 ```
 
 Watch tool-use reliability for the first few turns; smaller models occasionally pick the wrong tool. If you see drift, fall back to a mid-tier model.
@@ -99,7 +106,7 @@ Watch tool-use reliability for the first few turns; smaller models occasionally 
 
 ### 16.7.3 Use a self-hosted or alternate endpoint
 
-If your gateway is configured with a custom provider (e.g., a local llama.cpp instance, an Azure OpenAI deployment), the model IDs your operator exposes show up in `hermit agents list --models`. Pick one and set it.
+If your gateway is configured with a custom provider (e.g., a local llama.cpp instance, an Azure OpenAI deployment), set `model.provider` to that provider's name and `model.model` to one of the IDs it accepts. If the provider needs a custom endpoint, the operator wires that on the gateway side.
 
 ---
 
@@ -111,7 +118,7 @@ If your gateway is configured with a custom provider (e.g., a local llama.cpp in
 
 **Can different sessions use different models within one agent?** No — model is an agent-level setting. To get session-level routing, run multiple agents.
 
-**What about temperature, top-p, max-tokens?** Gateway-level defaults usually apply. Some builds expose them per agent; check `hermit agents update --help`.
+**What about temperature, top-p, max-tokens?** `model.max_tokens` is settable per agent. Temperature and top-p use gateway-level defaults unless your build exposes them as additional `model.*` keys — check `hermit config --agent <id> show`.
 
 ---
 

--- a/docs/manual/16-models.md
+++ b/docs/manual/16-models.md
@@ -1,0 +1,121 @@
+---
+title: Models
+slug: models
+order: 16
+part: Part 4 — Configuring Your Agent
+description: Pick which LLM the agent uses, and switch between providers without losing memory or sessions.
+---
+
+# 16. Models
+
+The **model** is the LLM driving the agent's replies. OpenHermit is provider-agnostic — Anthropic Claude, OpenAI, OpenRouter, your own self-hosted endpoint, anything that speaks a supported API. You can change it at any time without losing memory, sessions, or skills.
+
+---
+
+## 16.1 What Choosing a Model Affects
+
+- **Quality of replies** — bigger / newer models reason better.
+- **Latency** — smaller models are faster.
+- **Cost per turn** — varies dramatically; tool-heavy agents amplify the spread.
+- **Tool-use reliability** — some models follow tool schemas more strictly than others. If the agent often picks wrong arguments, the model is a likely culprit.
+- **Context window** — bigger windows let the agent juggle more files in one turn.
+
+Everything else (memory, instructions, skills, MCPs, workspace) is independent of the model.
+
+---
+
+## 16.2 The `hermit agents` Command
+
+```bash
+hermit agents list                                # see current model per agent
+hermit agents update <id> --model <model-id>      # switch
+
+# Examples.
+hermit agents update main --model claude-opus-4-7
+hermit agents update main --model claude-sonnet-4-6
+```
+
+The model identifier is whatever string the provider expects. The gateway translates it.
+
+---
+
+## 16.3 Providers and Credentials
+
+The gateway routes calls to the provider implied by the model ID. Provider credentials are stored as secrets at the gateway level — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and so on. See [Chapter 18 · Secrets](18-secrets.md).
+
+If you switch to a provider whose credential is not set, the agent will error on the next turn with a clear message. Fix the secret and retry.
+
+---
+
+## 16.4 Switching Mid-Conversation
+
+You can change the model in the middle of an active session. The next turn uses the new model, with the same session history. This is useful for:
+
+- Escalating from a cheap model to a strong one when a task gets hard.
+- Dropping to a cheap model for routine follow-ups.
+
+Be aware of context-window mismatches: switching from a 200K-window model to a 32K-window one mid-session can truncate history.
+
+---
+
+## 16.5 Web Admin UI
+
+*Manage → Basic* has the model selector — a dropdown with the models the gateway has been told about.
+
+---
+
+## 16.6 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| See current model | ✓ | ✓ | — |
+| Change model | ✓ | — | — |
+
+---
+
+## 16.7 How-to Recipes
+
+### 16.7.1 Try a stronger model for a hard task
+
+```bash
+hermit agents update main --model claude-opus-4-7
+```
+
+Ask the question. If the answer is good and the latency tolerable, leave it. If you only needed the strength for one task, switch back when done.
+
+---
+
+### 16.7.2 Make the agent cheaper for routine use
+
+Pick a faster, smaller model for everyday chat:
+
+```bash
+hermit agents update main --model claude-haiku-4-5
+```
+
+Watch tool-use reliability for the first few turns; smaller models occasionally pick the wrong tool. If you see drift, fall back to a mid-tier model.
+
+---
+
+### 16.7.3 Use a self-hosted or alternate endpoint
+
+If your gateway is configured with a custom provider (e.g., a local llama.cpp instance, an Azure OpenAI deployment), the model IDs your operator exposes show up in `hermit agents list --models`. Pick one and set it.
+
+---
+
+## 16.8 FAQ
+
+**Will changing the model erase memory or session history?** No. Both are storage-side and provider-independent.
+
+**Can different agents on the same gateway use different models?** Yes — per agent.
+
+**Can different sessions use different models within one agent?** No — model is an agent-level setting. To get session-level routing, run multiple agents.
+
+**What about temperature, top-p, max-tokens?** Gateway-level defaults usually apply. Some builds expose them per agent; check `hermit agents update --help`.
+
+---
+
+## 16.9 Pointers
+
+- Provider credentials → [Chapter 18 · Secrets](18-secrets.md).
+- Cost / latency observation → [Chapter 20 · Web Admin UI](20-web-admin-ui.md), Observe tab.

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -26,24 +26,11 @@ Newer adapters may exist (e.g., Signal); the *Manage → Channels* tab is the so
 
 ---
 
-## 17.2 The `hermit channels` Commands
+## 17.2 Managing Channels
 
-```bash
-# List configured channels for an agent.
-hermit channels list --agent main
+The current CLI does not include a `hermit channels` command. Configure channels in *Manage → Channels* or through the `/api/agents/<agent-id>/channels` API.
 
-# Add (configure) a channel — example for Telegram.
-hermit channels add telegram --agent main --token-secret TELEGRAM_BOT_TOKEN
-
-# Enable / disable an existing channel without removing config.
-hermit channels enable telegram  --agent main
-hermit channels disable telegram --agent main
-
-# Remove configuration entirely.
-hermit channels remove telegram --agent main
-```
-
-The exact options vary per adapter; `hermit channels add <adapter> --help` lists them.
+The API lists configured channels, creates owner-issued external channels, patches existing channel config (`enabled`, secrets, and adapter options), and deletes channels. Built-in channels such as Telegram, Discord, and Slack are seeded as channel rows and are enabled by patching their config.
 
 ---
 
@@ -94,22 +81,19 @@ When someone messages the agent via Telegram for the first time, the gateway rec
 **Prerequisites**
 
 1. Create a bot with BotFather; copy the bot token.
-2. Save the token as a gateway secret:
+2. Save the token as an agent secret:
 
    ```bash
-   hermit config secrets set TELEGRAM_BOT_TOKEN <token> --agent main
+   hermit config --agent main secrets set TELEGRAM_BOT_TOKEN <token> --pass-through
    ```
 
 **Steps**
 
-```bash
-hermit channels add telegram --agent main --token-secret TELEGRAM_BOT_TOKEN
-hermit channels enable telegram --agent main
-```
+Open *Manage → Channels*, choose the Telegram channel, enter the required bot token secret/config fields, and enable it. The same operation is available through `PATCH /api/agents/main/channels/<telegram-channel-id>`.
 
 **Verify** — DM your bot; it replies.
 
-**Common issues** — if it does not reply, check `hermit channels list --agent main` for an error column and the gateway logs.
+**Common issues** — if it does not reply, check *Manage → Channels* for missing secrets or disabled status, then check the gateway logs.
 
 ---
 

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -1,0 +1,142 @@
+---
+title: Channels
+slug: channels
+order: 17
+part: Part 4 — Configuring Your Agent
+description: CLI, Web, Telegram, Discord, Slack — how to attach the agent to the places you actually talk.
+---
+
+# 17. Channels
+
+A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, a Discord bot, a Slack app. The agent is the same in every channel — same memory, same tools, same instructions. The channel just decides where you type and how attachments come in.
+
+---
+
+## 17.1 The Channels You Get
+
+- **CLI** — `hermit chat`. Always available if you have the CLI installed.
+- **Web** — `https://<your-gateway>/chat/<agent>`. Always available once the gateway is reachable.
+- **Telegram** — bot you create via BotFather, registered with the agent.
+- **Discord** — bot application registered with the agent.
+- **Slack** — Slack app installed into your workspace, registered with the agent.
+
+Each non-CLI channel needs a credential (a bot token or app secret). Credentials are stored as secrets — see [Chapter 18](18-secrets.md).
+
+Newer adapters may exist (e.g., Signal); the *Manage → Channels* tab is the source of truth for which adapters your gateway has.
+
+---
+
+## 17.2 The `hermit channels` Commands
+
+```bash
+# List configured channels for an agent.
+hermit channels list --agent main
+
+# Add (configure) a channel — example for Telegram.
+hermit channels add telegram --agent main --token-secret TELEGRAM_BOT_TOKEN
+
+# Enable / disable an existing channel without removing config.
+hermit channels enable telegram  --agent main
+hermit channels disable telegram --agent main
+
+# Remove configuration entirely.
+hermit channels remove telegram --agent main
+```
+
+The exact options vary per adapter; `hermit channels add <adapter> --help` lists them.
+
+---
+
+## 17.3 Adapter-Specific Notes
+
+### Telegram
+
+- One bot can serve one agent. If you want a second agent on Telegram, register a second bot.
+- DMs work by default. Group chat support depends on the bot's privacy setting — see *Manage → Channels* for the toggle.
+- Attachments (files, images) flow into the workspace under the uploads path.
+
+### Discord
+
+- Bot applications are per agent.
+- Slash commands optional; the agent works in plain channel chat once invited.
+
+### Slack
+
+- Slack apps are workspace-scoped. Install per workspace, register per agent.
+- Threading: the adapter creates a thread for each session by default. Quote-reply to continue an existing one.
+- File attachments supported.
+
+### Web / CLI
+
+- No registration step. They are always on.
+
+---
+
+## 17.4 Identity Across Channels
+
+When someone messages the agent via Telegram for the first time, the gateway records `(telegram, <telegram-user-id>) → user X`. Web sign-in similarly produces `(web, <web-uuid>) → user Y`. If X and Y are actually the same human, you link them — see [Chapter 14 · Managing Members](14-managing-members.md).
+
+---
+
+## 17.5 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Configure channels | ✓ | — | — |
+| Use channels the agent has | ✓ | ✓ | ✓ (if access level allows) |
+
+---
+
+## 17.6 How-to Recipes
+
+### 17.6.1 Attach a Telegram bot to your agent
+
+**Prerequisites**
+
+1. Create a bot with BotFather; copy the bot token.
+2. Save the token as a gateway secret:
+
+   ```bash
+   hermit config secrets set TELEGRAM_BOT_TOKEN <token> --agent main
+   ```
+
+**Steps**
+
+```bash
+hermit channels add telegram --agent main --token-secret TELEGRAM_BOT_TOKEN
+hermit channels enable telegram --agent main
+```
+
+**Verify** — DM your bot; it replies.
+
+**Common issues** — if it does not reply, check `hermit channels list --agent main` for an error column and the gateway logs.
+
+---
+
+### 17.6.2 Swap channels without losing memory
+
+Channels are interchangeable surfaces over the same agent. Disable Telegram, enable Slack — memory, instructions, MCP tokens stay put. New sessions just come in over a different transport.
+
+---
+
+### 17.6.3 Run one bot for two agents
+
+Not supported on the same channel handle. Use two distinct bot tokens / apps, one per agent.
+
+---
+
+## 17.7 FAQ
+
+**Does using Telegram leak my data?** Messages traverse Telegram's servers. If you cannot send a piece of information through Telegram, do not send it through a Telegram-attached agent. Same logic for Slack, Discord.
+
+**Can I delete a Telegram message that the agent replied in?** That is a Telegram client question, not OpenHermit. The session history in the gateway is unaffected by client-side deletes.
+
+**Does the channel show in *Observe*?** Yes — each session is tagged with its source channel.
+
+---
+
+## 17.8 Pointers
+
+- Tokens and credentials → [Chapter 18 · Secrets](18-secrets.md).
+- Who can talk on each channel → [Chapter 13 · Access Levels](13-access-levels.md), [Chapter 15 · Policy and Approval](15-policy-and-approval.md).
+- Identity linkage across channels → [Chapter 14 · Managing Members](14-managing-members.md).

--- a/docs/manual/18-secrets.md
+++ b/docs/manual/18-secrets.md
@@ -25,26 +25,26 @@ The pattern is: never paste a credential into the agent's instructions or messag
 
 ---
 
-## 18.2 The `hermit config secrets` Commands
+## 18.2 The `hermit config --agent ... secrets` Commands
 
 ```bash
 # List secret names (values are not shown).
-hermit config secrets list --agent main
+hermit config --agent main secrets list
 
 # Set a secret.
-hermit config secrets set GITHUB_TOKEN <value> --agent main
+hermit config --agent main secrets set GITHUB_TOKEN <value>
 
-# Set a secret that should be passed through to MCP / channel adapter env (default).
-hermit config secrets set GITHUB_TOKEN <value> --agent main --pass-through
+# Set a secret that should be passed through to MCP / channel adapter env.
+hermit config --agent main secrets set GITHUB_TOKEN <value> --pass-through
 
 # Set a secret you do NOT want exposed to subprocess env.
-hermit config secrets set INTERNAL_KEY <value> --agent main --no-pass-through
+hermit config --agent main secrets set INTERNAL_KEY <value> --no-pass-through
 
 # Delete.
-hermit config secrets delete GITHUB_TOKEN --agent main
+hermit config --agent main secrets remove GITHUB_TOKEN
 ```
 
-Gateway-level secrets (shared across all agents) typically live in environment variables on the gateway host, not in `hermit config secrets`. Your operator controls those.
+Gateway-level secrets (shared across all agents) typically live in environment variables on the gateway host, not in `hermit config --agent ... secrets`. Your operator controls those.
 
 ---
 
@@ -92,7 +92,7 @@ Even owners do not see secret values in the UI after setting them — set-only. 
 ### 18.7.1 Rotate a GitHub token
 
 ```bash
-hermit config secrets set GITHUB_TOKEN <new-token> --agent main
+hermit config --agent main secrets set GITHUB_TOKEN <new-token>
 hermit mcp disable mcp_github --agent main
 hermit mcp enable  mcp_github --agent main
 ```
@@ -108,7 +108,7 @@ The disable/enable cycle restarts the MCP server so it picks up the new value. S
 You discover an old `instructions` section contains an API key in plain text. Fix:
 
 ```bash
-hermit config secrets set MY_API_KEY <value> --agent main
+hermit config --agent main secrets set MY_API_KEY <value>
 hermit instructions get tools --agent main         # copy the body
 # Edit locally — replace the raw key with ${{MY_API_KEY}}
 hermit instructions set tools --file ./tools.md --agent main
@@ -121,7 +121,7 @@ hermit instructions set tools --file ./tools.md --agent main
 ### 18.7.3 Audit which secrets an agent has
 
 ```bash
-hermit config secrets list --agent main
+hermit config --agent main secrets list
 ```
 
 If you see names that no longer correspond to an enabled MCP or channel, delete them.

--- a/docs/manual/18-secrets.md
+++ b/docs/manual/18-secrets.md
@@ -1,0 +1,147 @@
+---
+title: Secrets
+slug: secrets
+order: 18
+part: Part 4 — Configuring Your Agent
+description: API keys, bot tokens, and other credentials — how to store them safely and where they get used.
+---
+
+# 18. Secrets
+
+A **secret** is a credential the agent or one of its adapters needs but you do not want sitting in a config file in plain text. GitHub tokens, Slack bot tokens, model provider API keys, internal API credentials — all secrets. OpenHermit keeps them in a separate store and substitutes them into configs at runtime.
+
+---
+
+## 18.1 What Goes Where
+
+| Credential | Used by | Stored as |
+|---|---|---|
+| Anthropic / OpenAI / etc. API key | Model calls | Gateway-level secret |
+| Telegram / Discord / Slack bot token | Channel adapter | Per-agent or gateway secret |
+| GitHub / Slack / etc. token for MCP | MCP server | Per-agent secret |
+| Internal API key | Custom MCP server | Per-agent secret |
+
+The pattern is: never paste a credential into the agent's instructions or messages. Put it in the secret store and reference it.
+
+---
+
+## 18.2 The `hermit config secrets` Commands
+
+```bash
+# List secret names (values are not shown).
+hermit config secrets list --agent main
+
+# Set a secret.
+hermit config secrets set GITHUB_TOKEN <value> --agent main
+
+# Set a secret that should be passed through to MCP / channel adapter env (default).
+hermit config secrets set GITHUB_TOKEN <value> --agent main --pass-through
+
+# Set a secret you do NOT want exposed to subprocess env.
+hermit config secrets set INTERNAL_KEY <value> --agent main --no-pass-through
+
+# Delete.
+hermit config secrets delete GITHUB_TOKEN --agent main
+```
+
+Gateway-level secrets (shared across all agents) typically live in environment variables on the gateway host, not in `hermit config secrets`. Your operator controls those.
+
+---
+
+## 18.3 How Secrets Get Substituted
+
+Configurations reference secrets by name with `${{NAME}}`:
+
+```yaml
+mcp_servers:
+  github:
+    env:
+      GITHUB_TOKEN: ${{GITHUB_TOKEN}}
+```
+
+At startup time, the gateway substitutes the real value. The agent's prompt never sees the raw secret — it only sees the tools that use it.
+
+---
+
+## 18.4 Pass-Through
+
+Many secrets need to reach subprocesses (an MCP server's environment, a channel adapter's runtime). `--pass-through` (default) means yes; `--no-pass-through` means the secret stays inside the gateway and can only be read by config substitution. Use the strict mode for credentials that should never leak into a child process's env table.
+
+---
+
+## 18.5 Web Admin UI
+
+*Manage → Secrets* shows the secret names (values hidden) and lets you set / delete. Same store as the CLI.
+
+---
+
+## 18.6 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Read secret names | ✓ | — | — |
+| Read secret values | ✓ (only via direct gateway access) | — | — |
+| Set / delete | ✓ | — | — |
+
+Even owners do not see secret values in the UI after setting them — set-only. To rotate, set again with the new value.
+
+---
+
+## 18.7 How-to Recipes
+
+### 18.7.1 Rotate a GitHub token
+
+```bash
+hermit config secrets set GITHUB_TOKEN <new-token> --agent main
+hermit mcp disable mcp_github --agent main
+hermit mcp enable  mcp_github --agent main
+```
+
+The disable/enable cycle restarts the MCP server so it picks up the new value. Some adapters pick up changes hot — check your MCP server's behaviour.
+
+**Verify** — ask the agent to do a GitHub action that requires the new permissions.
+
+---
+
+### 18.7.2 Move a credential from an instruction into a secret
+
+You discover an old `instructions` section contains an API key in plain text. Fix:
+
+```bash
+hermit config secrets set MY_API_KEY <value> --agent main
+hermit instructions get tools --agent main         # copy the body
+# Edit locally — replace the raw key with ${{MY_API_KEY}}
+hermit instructions set tools --file ./tools.md --agent main
+```
+
+**Verify** — `hermit instructions get tools` shows the placeholder, not the value.
+
+---
+
+### 18.7.3 Audit which secrets an agent has
+
+```bash
+hermit config secrets list --agent main
+```
+
+If you see names that no longer correspond to an enabled MCP or channel, delete them.
+
+---
+
+## 18.8 FAQ
+
+**Where are secrets actually stored?** In the gateway's database, encrypted at rest with the gateway's key. Backup of that database is operator territory — make sure backups are encrypted too.
+
+**Can the agent see a raw secret value?** No. The agent receives the configuration *after* substitution into the relevant env / tool definitions. It never receives the value in its prompt context.
+
+**Can I version-control my secrets?** No. Treat secret values as ephemeral. Version-control the secret *names* and the reference shape; the values belong only in the secret store.
+
+**What about per-user secrets?** Not supported. Secrets are per agent. If you need per-user credentials, run one agent per user.
+
+---
+
+## 18.9 Pointers
+
+- MCP credential setup → [Chapter 9 · MCP Servers](09-mcp-servers.md).
+- Channel tokens → [Chapter 17 · Channels](17-channels.md).
+- Model provider credentials → [Chapter 16 · Models](16-models.md).

--- a/docs/manual/19-cli-cheatsheet.md
+++ b/docs/manual/19-cli-cheatsheet.md
@@ -18,7 +18,7 @@ A flat reference, grouped by job. Run `hermit <command> --help` for full options
 hermit setup                        # first-time wizard
 hermit chat                         # interactive REPL with the default agent
 hermit chat --agent <id>            # specific agent
-hermit chat "one-shot question"     # send once, print reply, exit
+hermit chat --agent <id> --resume   # resume the latest CLI session
 ```
 
 ---
@@ -27,7 +27,7 @@ hermit chat "one-shot question"     # send once, print reply, exit
 
 ```bash
 hermit agents list
-hermit agents create <id>                          # interactive create
+hermit agents create <id> --name "<name>" --workspace-dir <path>
 hermit agents enable  <id>
 hermit agents disable <id>
 hermit agents restart <id>
@@ -49,14 +49,7 @@ hermit config --agent <id> security set access public|protected|private
 
 ## 19.3 Users (Members)
 
-```bash
-hermit users list   --agent <id> [--role guest|user]
-hermit users get    <user-id> --agent <id>
-hermit users update <user-id> --role guest|user --agent <id>
-hermit users link   <user-id> --channel <ch> --channel-user-id <cuid> --agent <id>
-hermit users unlink <user-id> --channel <ch> --agent <id>
-hermit users delete <user-id> --agent <id>
-```
+There is no `hermit users` command in the current CLI. Manage members through the web admin Users panel, the `/api/agents/<id>/members` API, or the owner-only agent tools (`user_list`, `user_role_set`, `user_identity_link`, `user_identity_unlink`, `user_merge`).
 
 ---
 
@@ -100,15 +93,7 @@ hermit mcp disable <name> [--agent <id>|--all]
 
 ## 19.7 Channels
 
-```bash
-hermit channels list    --agent <id>
-hermit channels add     <adapter> --agent <id> [adapter-specific opts]
-hermit channels enable  <adapter> --agent <id>
-hermit channels disable <adapter> --agent <id>
-hermit channels remove  <adapter> --agent <id>
-```
-
-Adapters: `telegram`, `discord`, `slack`, plus any others your gateway has.
+There is no `hermit channels` command in the current CLI. Configure channels in *Manage → Channels* or through the `/api/agents/<id>/channels` API.
 
 ---
 
@@ -118,7 +103,10 @@ Adapters: `telegram`, `discord`, `slack`, plus any others your gateway has.
 hermit schedules create --type cron --cron "<expr>" --prompt "<text>" --agent <id>
 hermit schedules create --type once --run-at "<iso>" --prompt "<text>" --agent <id>
 hermit schedules list   --agent <id>
+hermit schedules pause  <id> --agent <id>
+hermit schedules resume <id> --agent <id>
 hermit schedules delete <id> --agent <id>
+hermit schedules runs   <id> --agent <id>
 ```
 
 ---
@@ -126,9 +114,9 @@ hermit schedules delete <id> --agent <id>
 ## 19.9 Secrets
 
 ```bash
-hermit config secrets list   --agent <id>
-hermit config secrets set    <KEY> <value> --agent <id> [--pass-through|--no-pass-through]
-hermit config secrets delete <KEY>         --agent <id>
+hermit config --agent <id> secrets list
+hermit config --agent <id> secrets set    <KEY> <value> [--pass-through|--no-pass-through]
+hermit config --agent <id> secrets remove <KEY>
 ```
 
 ---
@@ -136,9 +124,11 @@ hermit config secrets delete <KEY>         --agent <id>
 ## 19.10 Policy
 
 ```bash
-hermit policy list   --agent <id>
-hermit policy add    --agent <id> --match "<expr>" --effect allow|deny|require_approval
-hermit policy remove <rule-id>  --agent <id>
+hermit config --agent <id> policy list
+hermit config --agent <id> policy set <resource-key> '<grants-json>' --effect allow|deny|require_approval
+hermit config --agent <id> policy delete <resource-key> [--effect allow|deny|require_approval]
+hermit config --agent <id> approvals list [--status pending|approved|rejected|expired]
+hermit config --agent <id> approvals review <request-id> approved|rejected
 ```
 
 ---
@@ -149,7 +139,7 @@ hermit policy remove <rule-id>  --agent <id>
 hermit --help
 hermit <command> --help
 hermit doctor                     # connection + auth sanity check
-hermit version
+hermit --version
 ```
 
 ---

--- a/docs/manual/19-cli-cheatsheet.md
+++ b/docs/manual/19-cli-cheatsheet.md
@@ -1,0 +1,160 @@
+---
+title: CLI Cheatsheet
+slug: cli-cheatsheet
+order: 19
+part: Part 5 — Reference
+description: Every `hermit` command on one page, grouped by what you are trying to do.
+---
+
+# 19. CLI Cheatsheet
+
+A flat reference, grouped by job. Run `hermit <command> --help` for full options on any subcommand.
+
+---
+
+## 19.1 Basics
+
+```bash
+hermit setup                        # first-time wizard
+hermit chat                         # interactive REPL with the default agent
+hermit chat --agent <id>            # specific agent
+hermit chat "one-shot question"     # send once, print reply, exit
+```
+
+---
+
+## 19.2 Agents
+
+```bash
+hermit agents list
+hermit agents get <id>
+hermit agents create --name <name> --model <model-id>
+hermit agents update <id> --model <model-id>
+hermit agents update <id> --access-level public|protected|private
+hermit agents delete <id>
+```
+
+---
+
+## 19.3 Users (Members)
+
+```bash
+hermit users list   --agent <id> [--role guest|user]
+hermit users get    <user-id> --agent <id>
+hermit users update <user-id> --role guest|user --agent <id>
+hermit users link   <user-id> --channel <ch> --channel-user-id <cuid> --agent <id>
+hermit users unlink <user-id> --channel <ch> --agent <id>
+hermit users delete <user-id> --agent <id>
+```
+
+---
+
+## 19.4 Instructions
+
+```bash
+hermit instructions list   [--agent <id>|--all]
+hermit instructions get    <key> --agent <id>
+hermit instructions set    <key> "<text>"      [--agent <id>|--all]
+hermit instructions set    <key> --file <path> [--agent <id>|--all]
+hermit instructions append <key> "<text>"      [--agent <id>|--all]
+hermit instructions remove <key>               [--agent <id>|--all]
+```
+
+---
+
+## 19.5 Skills
+
+```bash
+hermit skills list
+hermit skills assignments
+hermit skills scan
+hermit skills register <name> --path <dir>
+hermit skills enable  <name> [--agent <id>|--all]
+hermit skills disable <name> [--agent <id>|--all]
+hermit skills delete  <name>
+```
+
+---
+
+## 19.6 MCP Servers
+
+```bash
+hermit mcp list
+hermit mcp assignments
+hermit mcp enable  <name> [--agent <id>|--all]
+hermit mcp disable <name> [--agent <id>|--all]
+```
+
+---
+
+## 19.7 Channels
+
+```bash
+hermit channels list    --agent <id>
+hermit channels add     <adapter> --agent <id> [adapter-specific opts]
+hermit channels enable  <adapter> --agent <id>
+hermit channels disable <adapter> --agent <id>
+hermit channels remove  <adapter> --agent <id>
+```
+
+Adapters: `telegram`, `discord`, `slack`, plus any others your gateway has.
+
+---
+
+## 19.8 Schedules
+
+```bash
+hermit schedules create --type cron --cron "<expr>" --prompt "<text>" --agent <id>
+hermit schedules create --type once --run-at "<iso>" --prompt "<text>" --agent <id>
+hermit schedules list   --agent <id>
+hermit schedules delete <id> --agent <id>
+```
+
+---
+
+## 19.9 Secrets
+
+```bash
+hermit config secrets list   --agent <id>
+hermit config secrets set    <KEY> <value> --agent <id> [--pass-through|--no-pass-through]
+hermit config secrets delete <KEY>         --agent <id>
+```
+
+---
+
+## 19.10 Policy
+
+```bash
+hermit policy list   --agent <id>
+hermit policy add    --agent <id> --match "<expr>" --effect allow|deny|require_approval
+hermit policy remove <rule-id>  --agent <id>
+```
+
+---
+
+## 19.11 Help and Diagnostics
+
+```bash
+hermit --help
+hermit <command> --help
+hermit doctor                     # connection + auth sanity check
+hermit version
+```
+
+---
+
+## 19.12 `--all` vs `--agent`
+
+Most write commands accept either:
+
+- `--agent <id>` — operate on one agent.
+- `--all` — operate on every agent on this instance.
+
+Read commands (`list`, `get`) usually require `--agent` to scope; if omitted they may default to the configured default agent.
+
+---
+
+## 19.13 Pointers
+
+- Why each command exists → the relevant chapter (Instructions = 7, Skills = 8, etc.).
+- Web equivalents → [Chapter 20 · Web Admin UI](20-web-admin-ui.md).

--- a/docs/manual/19-cli-cheatsheet.md
+++ b/docs/manual/19-cli-cheatsheet.md
@@ -27,11 +27,22 @@ hermit chat "one-shot question"     # send once, print reply, exit
 
 ```bash
 hermit agents list
-hermit agents get <id>
-hermit agents create --name <name> --model <model-id>
-hermit agents update <id> --model <model-id>
-hermit agents update <id> --access-level public|protected|private
-hermit agents delete <id>
+hermit agents create <id>                          # interactive create
+hermit agents enable  <id>
+hermit agents disable <id>
+hermit agents restart <id>
+hermit agents delete  <id>
+
+# Configuration is its own command tree (no `hermit agents update`):
+hermit config --agent <id> show
+hermit config --agent <id> get <key>
+hermit config --agent <id> set <key> <value>
+
+# Common keys:
+#   model.provider           anthropic | openai | openrouter | …
+#   model.model              <provider-specific model id>
+#   model.max_tokens         <int>
+hermit config --agent <id> security set access public|protected|private
 ```
 
 ---

--- a/docs/manual/20-web-admin-ui.md
+++ b/docs/manual/20-web-admin-ui.md
@@ -1,0 +1,105 @@
+---
+title: Web Admin UI
+slug: web-admin-ui
+order: 20
+part: Part 5 — Reference
+description: A tour of the web interface — Chat, Observe, Manage — and what you do in each tab.
+---
+
+# 20. Web Admin UI
+
+The web UI is what most owners spend their time in. Three top-level tabs cover the surface area: **Chat** to talk, **Observe** to watch, **Manage** to configure.
+
+---
+
+## 20.1 Chat
+
+The conversation surface. Pick an agent in the sidebar, start a new session or resume an existing one, type messages, drop attachments. Same content store as channels — anything you do here lands in the same memory and session log.
+
+Useful corners:
+
+- **Session list** in the sidebar — every conversation with this agent, by date.
+- **Tool calls expand** — under each agent reply, expand to see the tools it called, with arguments and results.
+- **Attachments** — drag a file directly into the chat field. It is written to the workspace; the agent is notified.
+
+---
+
+## 20.2 Observe
+
+A read-only window into agent activity across all sessions and channels.
+
+Useful for:
+
+- Watching scheduled runs as they fire.
+- Auditing tool calls — filter by tool name, see arguments and results.
+- Spotting failed turns — the runner reports failures here.
+- Approving pending tool calls (when policy says approval is required).
+
+Filters typically include: agent, user, channel, session, tool name, time window.
+
+---
+
+## 20.3 Manage
+
+Configuration. Sub-tabs (the exact set depends on your gateway version):
+
+- **Basic** — agent name, model, access level.
+- **Secrets** — names and set/delete (values hidden after setting).
+- **Channels** — adapter list, enable/disable toggles, add configuration.
+- **Skills** — registry, assignments, enable/disable toggles.
+- **MCP** — registered servers, assignments, enable/disable toggles.
+- **Schedules** — list and create form.
+- **Policies** — rule list and add form.
+
+The data behind every tab is the same store as the CLI; do not worry about choosing one or the other.
+
+---
+
+## 20.4 Role Differences
+
+| | Owner | User | Guest |
+|---|:---:|:---:|:---:|
+| Chat | ✓ | ✓ | ✓ (subject to access level) |
+| Observe | ✓ | partial (own sessions) | — |
+| Manage | ✓ | — | — |
+
+A signed-in user sees the Chat tab and a limited Observe view; only owners see Manage at all.
+
+---
+
+## 20.5 How-to Recipes
+
+### 20.5.1 Find a specific past conversation
+
+Chat → session list → search by date or by a snippet of text.
+
+If you need to find a session by tool call (e.g., "the session where the agent ran `git push`"), use *Observe* and filter by tool name.
+
+---
+
+### 20.5.2 Watch a scheduled run live
+
+*Observe* → set the filter to your agent → wait for the schedule to fire. The new session shows up in real time; expand to see each tool call as it happens.
+
+---
+
+### 20.5.3 Approve a pending tool call
+
+*Observe* → top banner shows pending approvals. Click the request → review tool + args → approve or reject. The session resumes.
+
+---
+
+## 20.6 FAQ
+
+**Where is the file browser?** Some gateway builds expose a workspace file browser under *Manage → Files*. If yours does not, list files through the agent itself ("list workspace files").
+
+**Can I export observations?** Click into a session and use the browser print/save — there is no formal export yet.
+
+**Two browsers, two owners — any conflict?** No. Edits are last-write-wins; the data is consistent across sessions.
+
+---
+
+## 20.7 Pointers
+
+- Equivalent CLI for every Manage operation → [Chapter 19 · CLI Cheatsheet](19-cli-cheatsheet.md).
+- What each Manage sub-tab maps to in this manual → the chapter of the same name.

--- a/docs/manual/20-web-admin-ui.md
+++ b/docs/manual/20-web-admin-ui.md
@@ -51,7 +51,7 @@ Configuration. Sub-tabs (the exact set depends on your gateway version):
 - **Schedules** — list and create form.
 - **Policies** — rule list and add form.
 
-The data behind every tab is the same store as the CLI; do not worry about choosing one or the other.
+The data behind every tab is the same gateway store used by the CLI and API; some surfaces, such as Channels, are currently UI/API-only.
 
 ---
 
@@ -101,5 +101,5 @@ If you need to find a session by tool call (e.g., "the session where the agent r
 
 ## 20.7 Pointers
 
-- Equivalent CLI for every Manage operation → [Chapter 19 · CLI Cheatsheet](19-cli-cheatsheet.md).
+- CLI and API equivalents for management operations → [Chapter 19 · CLI Cheatsheet](19-cli-cheatsheet.md).
 - What each Manage sub-tab maps to in this manual → the chapter of the same name.

--- a/docs/manual/21-troubleshooting.md
+++ b/docs/manual/21-troubleshooting.md
@@ -1,0 +1,136 @@
+---
+title: Troubleshooting
+slug: troubleshooting
+order: 21
+part: Part 5 — Reference
+description: Symptoms, likely causes, and the first three things to check.
+---
+
+# 21. Troubleshooting
+
+A symptom-first reference. For each issue: what you see, what is most likely wrong, what to try first.
+
+---
+
+## 21.1 Agent does not reply
+
+**Likely** — gateway is down, channel adapter is broken, model credential is missing or rotated out.
+
+**Check**
+
+1. `hermit doctor` — basic connectivity to the gateway.
+2. `hermit channels list --agent <id>` — is the channel enabled and free of error?
+3. Try the web UI: if web works but Telegram does not, the channel is the issue, not the agent.
+4. *Observe* tab — is the session showing a model error?
+
+---
+
+## 21.2 Tool call fails repeatedly
+
+**Likely** — credential expired, MCP server crashed, argument schema drift, policy denial.
+
+**Check**
+
+1. Expand the failed call in *Observe*. The error message is usually specific.
+2. If credential-related → rotate the secret, restart the MCP server (`hermit mcp disable` + `enable`).
+3. If schema-related → check whether the MCP server version was bumped.
+4. If denial → look at *Policy* — a rule may be denying without obvious notice.
+
+The agent runner aborts the turn after 15 consecutive tool failures to prevent loops; that abort itself shows in *Observe*.
+
+---
+
+## 21.3 Memory does not stick
+
+**Likely** — the agent did not classify the fact as durable, or the memory tool is policy-denied.
+
+**Check**
+
+1. Ask the agent: "What do you remember about <topic>?" If empty, it was not stored.
+2. Explicit retry: "Please remember that <fact>." Most reliable way to force a store.
+3. Check policy for any rule blocking `memory_*` tools.
+
+---
+
+## 21.4 New schedule never fires
+
+**Likely** — cron expression wrong timezone, gateway was down at fire time, schedule was created on the wrong agent.
+
+**Check**
+
+1. `hermit schedules list --agent <id>` — confirm the schedule is on the right agent.
+2. Read the cron — UTC is the default; if you used a local-time expression it fires at the UTC equivalent.
+3. *Observe* for the agent — does any session appear at the expected time?
+
+---
+
+## 21.5 Someone can do something they should not
+
+**Likely** — role is wrong (they were promoted by mistake), or policy is missing a rule.
+
+**Check**
+
+1. `hermit users get <id> --agent <id>` — their role.
+2. `hermit policy list --agent <id>` — does the relevant deny rule exist for their role?
+3. Test by impersonation: sign in as them on web (or use a test guest identity) and reproduce.
+
+---
+
+## 21.6 Web UI shows stale data
+
+**Likely** — browser cache, or the gateway was restarted with a build mismatch.
+
+**Check**
+
+1. Hard refresh (Cmd-Shift-R / Ctrl-Shift-R).
+2. If the UI is from a stale build (operator just upgraded), the operator may need to rebuild the static assets.
+
+---
+
+## 21.7 CLI says "not authenticated"
+
+**Likely** — the local config does not have credentials for the gateway, or the gateway URL is wrong.
+
+**Check**
+
+1. `hermit setup` again — re-enter gateway URL and token.
+2. `hermit doctor` — should report green.
+
+---
+
+## 21.8 Files I uploaded are missing
+
+**Likely** — they were uploaded to a different agent, or the sandbox path is not what you expected.
+
+**Check**
+
+1. Ask the agent: "List files in your workspace."
+2. Confirm you uploaded to the same agent that you are now asking. Per-agent isolation is total.
+
+---
+
+## 21.9 The agent contradicts itself between sessions
+
+**Likely** — memory was updated in one session and not in another, or two memory entries conflict.
+
+**Check**
+
+1. Ask: "What do you remember about <topic>? List every relevant entry."
+2. Tell it to consolidate: "These two entries conflict. The correct version is X. Update accordingly."
+
+---
+
+## 21.10 When to escalate to your operator
+
+- Gateway-level errors that persist across agents.
+- Secrets at the gateway level (model provider keys) need rotating.
+- A new MCP server needs installing.
+- Workspace storage is full.
+- Backups, upgrades, certificate renewal — anything below the user-facing layer.
+
+---
+
+## 21.11 Pointers
+
+- Find the specific chapter for any feature mentioned above using [the index](README.md).
+- Frequently asked at a higher level → [Chapter 22 · FAQ](22-faq.md).

--- a/docs/manual/21-troubleshooting.md
+++ b/docs/manual/21-troubleshooting.md
@@ -19,7 +19,7 @@ A symptom-first reference. For each issue: what you see, what is most likely wro
 **Check**
 
 1. `hermit doctor` — basic connectivity to the gateway.
-2. `hermit channels list --agent <id>` — is the channel enabled and free of error?
+2. *Manage → Channels* — is the channel enabled and free of missing-secret warnings?
 3. Try the web UI: if web works but Telegram does not, the channel is the issue, not the agent.
 4. *Observe* tab — is the session showing a model error?
 
@@ -70,8 +70,8 @@ The agent runner aborts the turn after 15 consecutive tool failures to prevent l
 
 **Check**
 
-1. `hermit users get <id> --agent <id>` — their role.
-2. `hermit policy list --agent <id>` — does the relevant deny rule exist for their role?
+1. Gateway admin UI *Users* tab, or `user_list` as owner — confirm their role.
+2. `hermit config --agent <id> policy list` — does the relevant deny rule exist for their role?
 3. Test by impersonation: sign in as them on web (or use a test guest identity) and reproduce.
 
 ---

--- a/docs/manual/22-faq.md
+++ b/docs/manual/22-faq.md
@@ -1,0 +1,74 @@
+---
+title: FAQ
+slug: faq
+order: 22
+part: Part 5 — Reference
+description: The questions people ask most often, with short answers.
+---
+
+# 22. FAQ
+
+Short answers to the questions that come up most. Deeper detail is always in the chapter the question links to.
+
+---
+
+**What is the difference between an agent and a session?**
+An agent is the persistent thing — its memory, instructions, skills, MCPs. A session is a single conversation with it. The agent outlives any session. → [Chapter 3](03-concepts.md).
+
+**Can two people share one agent?**
+Yes. They each get an identity tied to the channel they use, and the owner controls roles. Memory is shared per agent. → [Chapter 5](05-users-and-identity.md).
+
+**How do I keep my private memory private from other users on the same agent?**
+You cannot, on one agent. Memory is per-agent, not per-user. For per-user privacy, run one agent per user. → [Chapter 6](06-memory.md).
+
+**Instructions vs memory — which when?**
+Instructions for rules that must hold every session. Memory for facts and preferences the agent can recall when relevant. → [Chapter 7](07-instructions.md).
+
+**Skills vs MCP servers — which when?**
+Skills package prompting patterns and helper scripts. MCP servers connect external systems. Use both together when you need to. → [Chapter 8](08-skills.md) and [Chapter 9](09-mcp-servers.md).
+
+**Can the agent execute code in its environment?**
+Yes — via the `exec` tool, inside its sandboxed workspace. By default owners and users have it; guests do not. → [Chapter 10](10-files-and-workspace.md).
+
+**Will switching models lose my memory or sessions?**
+No. Model is a runtime choice; storage is independent. → [Chapter 16](16-models.md).
+
+**How do I stop a runaway turn?**
+Hit interrupt (Ctrl-C in CLI, the stop button in web). The runner also aborts after 15 consecutive tool failures on its own.
+
+**Can the agent message me on its own?**
+Through schedules, yes. The schedule's prompt tells it where to send the result. → [Chapter 11](11-schedules.md).
+
+**Is OpenHermit open source?**
+Yes. The exact repo and licence are operator-known.
+
+**How do I share an agent with someone outside my company?**
+Set access level to public or protected, share the URL or channel handle. → [Chapter 12](12-inviting-people.md), [Chapter 13](13-access-levels.md).
+
+**How do I make a guest into a user?**
+`hermit users update <id> --role user --agent <id>`. → [Chapter 14](14-managing-members.md).
+
+**Does the agent remember everything I say forever?**
+Long-term memory entries persist until you delete them. Session scrollback is per session. → [Chapter 6](06-memory.md).
+
+**Where are my files stored?**
+In the agent's workspace, on the gateway. Persistent across restarts. → [Chapter 10](10-files-and-workspace.md).
+
+**Can I trust the agent with credentials?**
+Put credentials in the secret store. The agent uses them via tools but does not see raw values in its context. → [Chapter 18](18-secrets.md).
+
+**What if a tool the agent wants to call is dangerous?**
+Policy + approval. Mark the tool as `require_approval`; the owner gets a prompt before the call runs. → [Chapter 15](15-policy-and-approval.md).
+
+**Can I run OpenHermit locally?**
+Yes — the gateway runs on a single host or in a container. Operator territory beyond that.
+
+**Where do I report bugs or request features?**
+Ask your operator or check the project repo. The gateway logs are the first thing they will ask for.
+
+---
+
+## 22.1 Pointers
+
+- Symptom-first issues → [Chapter 21 · Troubleshooting](21-troubleshooting.md).
+- Vocabulary cheatsheet → [Chapter 23 · Glossary](23-glossary.md).

--- a/docs/manual/22-faq.md
+++ b/docs/manual/22-faq.md
@@ -46,7 +46,7 @@ Yes. The exact repo and licence are operator-known.
 Set access level to public or protected, share the URL or channel handle. → [Chapter 12](12-inviting-people.md), [Chapter 13](13-access-levels.md).
 
 **How do I make a guest into a user?**
-`hermit users update <id> --role user --agent <id>`. → [Chapter 14](14-managing-members.md).
+Use the gateway admin UI's *Users* tab, or ask the agent as owner to promote the user. → [Chapter 14](14-managing-members.md).
 
 **Does the agent remember everything I say forever?**
 Long-term memory entries persist until you delete them. Session scrollback is per session. → [Chapter 6](06-memory.md).

--- a/docs/manual/23-glossary.md
+++ b/docs/manual/23-glossary.md
@@ -1,0 +1,72 @@
+---
+title: Glossary
+slug: glossary
+order: 23
+part: Part 5 — Reference
+description: Short definitions for every term used in this manual.
+---
+
+# 23. Glossary
+
+Plain-language definitions, alphabetical. Each term points at the chapter where it is treated in full.
+
+---
+
+**Access level.** Public, protected, or private — the gate that decides who can start a session at all. → [Ch. 13](13-access-levels.md).
+
+**Adapter.** Code that plugs a channel into the gateway. There is a Telegram adapter, a Slack adapter, and so on. → [Ch. 17](17-channels.md).
+
+**Agent.** The persistent thing — model + instructions + memory + skills + MCP connections + workspace. The unit you configure and share. → [Ch. 3](03-concepts.md).
+
+**Approval.** A policy effect that pauses a tool call until the owner says yes or no. → [Ch. 15](15-policy-and-approval.md).
+
+**Channel.** A transport for messages: CLI, web, Telegram, Discord, Slack. → [Ch. 17](17-channels.md).
+
+**Cron.** Recurring schedule expression. → [Ch. 11](11-schedules.md).
+
+**Effect.** What a policy rule does: allow, deny, or require_approval. → [Ch. 15](15-policy-and-approval.md).
+
+**Gateway.** The OpenHermit server. Runs your agents, holds their data, exposes the web UI and APIs.
+
+**Guest.** Lowest-privilege role. Read-only by default, no memory writes, no exec. → [Ch. 5](05-users-and-identity.md).
+
+**Identity.** A tuple of `(channel, channel_user_id)` resolving to one user record. A user can have several. → [Ch. 5](05-users-and-identity.md).
+
+**Instructions.** Rules pinned to the agent's system prompt. Owner-only. → [Ch. 7](07-instructions.md).
+
+**MCP (Model Context Protocol).** Standard for exposing external tools to an agent. → [Ch. 9](09-mcp-servers.md).
+
+**Memory.** Facts and preferences the agent stores and recalls. Three layers: session, working, long-term. → [Ch. 6](06-memory.md).
+
+**Model.** The LLM driving the agent's replies. Swap-able without losing memory. → [Ch. 16](16-models.md).
+
+**Observe.** The web UI tab for read-only inspection of agent activity. → [Ch. 20](20-web-admin-ui.md).
+
+**Owner.** Top-privilege role. Manages users, policy, secrets, instructions. → [Ch. 5](05-users-and-identity.md).
+
+**Policy.** Per-tool rules layered below role. → [Ch. 15](15-policy-and-approval.md).
+
+**Role.** Owner, user, or guest. Determines default capability. → [Ch. 5](05-users-and-identity.md).
+
+**Sandbox.** The isolated environment in which the agent's workspace lives — Docker, E2B, Daytona, depending on operator choice. → [Ch. 10](10-files-and-workspace.md).
+
+**Schedule.** A saved prompt that fires on cron or at a one-off time. → [Ch. 11](11-schedules.md).
+
+**Secret.** A named credential stored separately from configs and substituted at runtime. → [Ch. 18](18-secrets.md).
+
+**Session.** One conversation with the agent. → [Ch. 3](03-concepts.md), [Ch. 4](04-talking-to-your-agent.md).
+
+**Skill.** A folder with a `SKILL.md` and optional helpers that extends what the agent can do. → [Ch. 8](08-skills.md).
+
+**Tool.** A function the agent can call — file read/write, exec, MCP-exposed APIs, memory ops, etc.
+
+**User.** Standard role between guest and owner. Full chat + tools, no admin. → [Ch. 5](05-users-and-identity.md).
+
+**Workspace.** The agent's filesystem inside its sandbox. → [Ch. 10](10-files-and-workspace.md).
+
+---
+
+## 23.1 Pointers
+
+- Start at the top → [Chapter 1 · What OpenHermit Is](01-introduction.md).
+- Or jump to the chapter that matches what you are trying to do → [README](README.md).

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,73 @@
+---
+title: OpenHermit User Manual
+slug: /
+order: 0
+---
+
+# OpenHermit User Manual
+
+This is the user manual for OpenHermit. It is written for **people who have an OpenHermit agent and want to use it** — whether you run it alone or share it with a small team.
+
+If you are looking for how to deploy, operate, or extend OpenHermit itself, that material lives in the rest of `docs/` and is out of scope here.
+
+---
+
+## Contents
+
+### Part 1 — Getting Started
+
+1. [What OpenHermit Is](01-introduction.md)
+2. [Quickstart](02-quickstart.md)
+3. [Core Concepts](03-concepts.md)
+
+### Part 2 — Daily Use
+
+4. [Talking to Your Agent](04-talking-to-your-agent.md)
+5. [Users and Identity](05-users-and-identity.md)
+6. [Memory](06-memory.md)
+7. [Instructions](07-instructions.md)
+8. [Skills](08-skills.md)
+9. [MCP Servers](09-mcp-servers.md)
+10. [Files and Workspace](10-files-and-workspace.md)
+11. [Schedules](11-schedules.md)
+
+### Part 3 — Sharing Your Agent
+
+12. [Inviting People](12-inviting-people.md)
+13. [Access Levels](13-access-levels.md)
+14. [Managing Members](14-managing-members.md)
+15. [Policy and Approval](15-policy-and-approval.md)
+
+### Part 4 — Customizing (owner-only)
+
+16. [Models](16-models.md)
+17. [Channels](17-channels.md)
+18. [Secrets](18-secrets.md)
+
+### Part 5 — Reference
+
+19. [CLI Cheatsheet](19-cli-cheatsheet.md)
+20. [Web Admin UI Tour](20-web-admin-ui.md)
+21. [Troubleshooting](21-troubleshooting.md)
+22. [FAQ](22-faq.md)
+23. [Glossary](23-glossary.md)
+
+---
+
+## How to Read This Manual
+
+- **First time with OpenHermit** — read Part 1 in order (about 15 minutes). You will have an agent up and answering messages by the end.
+- **Already using it, want to do something specific** — jump to the chapter that matches. Each chapter ends with **How-to recipes** that follow a fixed shape: *scenario → prerequisites → ways to do it → verify → common issues*.
+- **Planning to share your agent with others** — Part 3 is written for you.
+- **Stuck** — start with [Troubleshooting](21-troubleshooting.md) and the [FAQ](22-faq.md).
+
+---
+
+## Conventions
+
+- **Bold terms** mark concepts on first appearance; each has a one-line definition in the [Glossary](23-glossary.md).
+- **Role markers**: actions that only the agent owner can take are tagged *(owner-only)*. The full capability table is in [Chapter 5 · Users and Identity](05-users-and-identity.md).
+- **Command prefixes**:
+  - `hermit …` — CLI command
+  - `curl …` — HTTP API call
+  - *Admin UI:* `path → action` — Web admin operation


### PR DESCRIPTION
## Summary
- New \`docs/manual/\` with 23 English chapters, written from the end-user (owner/user/guest) perspective, not the operator or developer view
- 5 parts: Getting Started, Daily Use, Sharing an Agent, Configuring Your Agent, Reference
- Includes how-to recipes, role capability tables, FAQs, and cross-links

## Test plan
- [ ] Render \`docs/manual/README.md\` and spot-check a few chapters
- [ ] Verify frontmatter is consistent across files for downstream consumption by openhermit.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive 23‑chapter user manual covering setup, core concepts, daily use, member management, policy & approval, skills/MCP servers, workspaces/files, schedules, channels, secrets, model selection, and the Web Admin UI.
  * New how‑to guides and references: Quickstart, CLI cheatsheet, troubleshooting, FAQ, glossary, and numerous step‑by‑step recipes illustrating common workflows and role-based behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/84)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->