### PR TITLE
feat(protocol): channel plugin contract — ChannelManifest + ChannelManifestRegistry

### DIFF
--- a/apps/agent/src/channels.ts
+++ b/apps/agent/src/channels.ts
@@ -3,41 +3,29 @@
  * Uses dynamic imports so the agent doesn't hard-depend on specific channel packages.
  */
 
-import type { ChannelOutbound } from '@openhermit/protocol';
+import type {
+  ChannelContext,
+  ChannelHandle,
+  ChannelOutbound,
+  WebhookHandler,
+  WebhookRequest,
+  WebhookResponse,
+} from '@openhermit/protocol';
 
 import type { ChannelsConfig } from './core/types.js';
 
-export interface ChannelContext {
-  agentBaseUrl: string;
-  agentTokens: Record<string, string>;
-  logger: (channel: string, message: string) => void;
-}
-
-export interface WebhookRequest {
-  headers: Record<string, string>;
-  rawBody: string;
-}
-
-export interface WebhookResponse {
-  status: number;
-  body?: string;
-  headers?: Record<string, string>;
-}
-
-export type WebhookHandler = (req: WebhookRequest) => Promise<WebhookResponse>;
-
-export interface ChannelHandle {
-  name: string;
-  outbound?: ChannelOutbound;
-  stop: () => Promise<void>;
-  /**
-   * Optional webhook handler. When present, the gateway forwards POSTs
-   * received at /api/agents/:agentId/channels/:namespace/webhook here.
-   * The adapter is responsible for verifying authenticity (e.g.
-   * Telegram secret_token, Slack HMAC, Discord ed25519).
-   */
-  handleWebhook?: WebhookHandler;
-}
+// Re-export the channel runtime types that used to live here. Consumers
+// like `@openhermit/gateway` import them via `@openhermit/agent/channels`;
+// the canonical definitions are now in `@openhermit/protocol` so that
+// third-party channel plugins can depend on a stable contract.
+export type {
+  ChannelContext,
+  ChannelHandle,
+  ChannelOutbound,
+  WebhookHandler,
+  WebhookRequest,
+  WebhookResponse,
+};
 
 export interface ChannelStatus {
   name: string;

--- a/apps/agent/test/channel-manifest-registry.test.ts
+++ b/apps/agent/test/channel-manifest-registry.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  ChannelManifestRegistry,
+  type ChannelContext,
+  type ChannelHandle,
+  type ChannelManifest,
+} from '@openhermit/protocol';
+
+const dummyContext: ChannelContext = {
+  agentBaseUrl: 'http://localhost:0',
+  agentTokens: {},
+  logger: () => {},
+};
+
+const dummyHandle: ChannelHandle = {
+  name: 'dummy',
+  stop: async () => {},
+};
+
+const manifest = (key: string, overrides: Partial<ChannelManifest> = {}): ChannelManifest => ({
+  key,
+  namespace: key,
+  displayName: key,
+  start: async () => dummyHandle,
+  ...overrides,
+});
+
+test('ChannelManifestRegistry: register + get + has', () => {
+  const reg = new ChannelManifestRegistry();
+  reg.register(manifest('telegram'));
+
+  assert.equal(reg.has('telegram'), true);
+  assert.equal(reg.has('signal'), false);
+  assert.equal(reg.get('telegram')?.displayName, 'telegram');
+  assert.equal(reg.get('signal'), undefined);
+});
+
+test('ChannelManifestRegistry: all() + keys() preserve insertion order', () => {
+  const reg = new ChannelManifestRegistry();
+  reg.register(manifest('telegram'));
+  reg.register(manifest('slack'));
+  reg.register(manifest('discord'));
+
+  assert.deepEqual(reg.keys(), ['telegram', 'slack', 'discord']);
+  assert.deepEqual(
+    reg.all().map((m) => m.key),
+    ['telegram', 'slack', 'discord'],
+  );
+});
+
+test('ChannelManifestRegistry: register() throws on duplicate key', () => {
+  const reg = new ChannelManifestRegistry();
+  reg.register(manifest('telegram'));
+
+  assert.throws(() => reg.register(manifest('telegram')), /duplicate channel key/);
+});
+
+test('ChannelManifestRegistry: register() rejects empty key', () => {
+  const reg = new ChannelManifestRegistry();
+  assert.throws(() => reg.register(manifest('')), /manifest\.key is required/);
+});
+
+test('ChannelManifestRegistry: replace() overrides existing manifest', () => {
+  const reg = new ChannelManifestRegistry();
+  reg.register(manifest('telegram', { displayName: 'original' }));
+  reg.replace(manifest('telegram', { displayName: 'overridden' }));
+
+  assert.equal(reg.get('telegram')?.displayName, 'overridden');
+  // replace() must not duplicate
+  assert.equal(reg.keys().length, 1);
+});
+
+test('ChannelManifestRegistry: replace() adds when absent', () => {
+  const reg = new ChannelManifestRegistry();
+  reg.replace(manifest('signal'));
+
+  assert.equal(reg.has('signal'), true);
+});
+
+test('ChannelManifest.start: contract returns a usable handle', async () => {
+  const reg = new ChannelManifestRegistry();
+  let started = false;
+  reg.register(
+    manifest('telegram', {
+      start: async (_config, _ctx) => {
+        started = true;
+        return dummyHandle;
+      },
+    }),
+  );
+
+  const m = reg.get('telegram');
+  assert.ok(m);
+  const handle = await m.start({}, dummyContext);
+  assert.equal(started, true);
+  assert.equal(handle?.name, 'dummy');
+});
+
+test('ChannelManifest.parseConfig: when set, runs before start (caller-driven)', () => {
+  // The registry itself does not call parseConfig — the loader does.
+  // This test pins the contract so future loader changes stay aligned.
+  const m = manifest('signal', {
+    parseConfig: (input) => {
+      if (typeof input !== 'object' || input === null) {
+        throw new Error('config must be an object');
+      }
+      return input;
+    },
+  });
+
+  assert.throws(() => m.parseConfig!('not-an-object'), /must be an object/);
+  assert.deepEqual(m.parseConfig!({ ok: true }), { ok: true });
+});

--- a/apps/agent/test/channel-manifest-registry.test.ts
+++ b/apps/agent/test/channel-manifest-registry.test.ts
@@ -102,6 +102,20 @@ test('ChannelManifestRegistry: replace() adds when absent', () => {
   assert.equal(reg.has('signal'), true);
 });
 
+test('ChannelManifestRegistry: replace() enforces same validation as register()', () => {
+  const reg = new ChannelManifestRegistry();
+  assert.throws(() => reg.replace(manifest('')), /manifest\.key is required/);
+
+  const futureManifest = {
+    ...manifest('future'),
+    manifestVersion: 999,
+  } as unknown as ChannelManifest;
+  assert.throws(
+    () => reg.replace(futureManifest),
+    /unsupported manifestVersion 999/,
+  );
+});
+
 test('ChannelManifest.start: contract returns a usable handle', async () => {
   const reg = new ChannelManifestRegistry();
   let started = false;

--- a/apps/agent/test/channel-manifest-registry.test.ts
+++ b/apps/agent/test/channel-manifest-registry.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  CHANNEL_MANIFEST_VERSION,
   ChannelManifestRegistry,
   type ChannelContext,
   type ChannelHandle,
@@ -20,6 +21,7 @@ const dummyHandle: ChannelHandle = {
 };
 
 const manifest = (key: string, overrides: Partial<ChannelManifest> = {}): ChannelManifest => ({
+  manifestVersion: 1,
   key,
   namespace: key,
   displayName: key,
@@ -60,6 +62,27 @@ test('ChannelManifestRegistry: register() throws on duplicate key', () => {
 test('ChannelManifestRegistry: register() rejects empty key', () => {
   const reg = new ChannelManifestRegistry();
   assert.throws(() => reg.register(manifest('')), /manifest\.key is required/);
+});
+
+test('ChannelManifestRegistry: register() rejects unsupported manifestVersion', () => {
+  const reg = new ChannelManifestRegistry();
+  // Plugin built against a hypothetical future contract revision. The
+  // runtime cast mirrors what happens at `await import(pkg)` boundaries
+  // where the dynamic-import result is `any`.
+  const futureManifest = {
+    ...manifest('future'),
+    manifestVersion: 999,
+  } as unknown as ChannelManifest;
+  assert.throws(
+    () => reg.register(futureManifest),
+    /unsupported manifestVersion 999/,
+  );
+});
+
+test('CHANNEL_MANIFEST_VERSION matches manifest contract', () => {
+  // Pin the constant so a bump can't accidentally land without
+  // updating consumers (registry, loader, plugin authors).
+  assert.equal(CHANNEL_MANIFEST_VERSION, 1);
 });
 
 test('ChannelManifestRegistry: replace() overrides existing manifest', () => {

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -62,6 +62,7 @@ const SignalConfig = z.object({
 });
 
 const manifest: ChannelManifest = {
+  manifestVersion: 1,
   key: 'signal',                              // ChannelsConfig key + DB channel_type
   namespace: 'signal',                        // sender.channel namespace
   displayName: 'Signal',                      // admin UI label
@@ -75,7 +76,10 @@ export default manifest;
 The shape lives in `packages/protocol/src/index.ts`:
 
 ```ts
+export const CHANNEL_MANIFEST_VERSION = 1 as const;
+
 export interface ChannelManifest {
+  manifestVersion: 1;       // pinned literal; bumped on breaking changes
   key: string;
   namespace: string;
   displayName: string;
@@ -84,6 +88,11 @@ export interface ChannelManifest {
   start: (config: unknown, context: ChannelContext) => Promise<ChannelHandle | undefined>;
 }
 ```
+
+The `manifestVersion: 1` literal is required from day one. The registry refuses to register a manifest whose `manifestVersion` doesn't match `CHANNEL_MANIFEST_VERSION`, throwing a clear error. Plugins survive a protocol bump by either continuing to declare `1` (if the loader still accepts it) or shipping a new release pinned to the new version. Bump policy:
+
+- **No bump** for adding *optional* fields to the manifest, the handle, or the context.
+- **Bump required** for adding required fields, changing the `start()` signature, or any semantic change a v1 plugin couldn't have anticipated.
 
 `parseConfig` is intentionally opaque — plugin authors can use Zod (`schema.parse`), a hand-rolled validator, or skip validation entirely. The contract is "throws if invalid; returns the value passed to `start()`."
 
@@ -112,7 +121,7 @@ If the same `key` is registered twice (e.g. a vendor publishes their own `@vendo
 
 When the CLI is installed via `npm install -g @openhermit/cli`, both the CLI and any `npm install -g @vendor/channel-foo` package land as siblings in the same global tree (`/usr/local/lib/node_modules/` on most systems, `~/.npm-global/lib/node_modules/` if the user prefixed npm). Node's normal upward resolution from the CLI's runtime location finds external channel packages without any custom `NODE_PATH` manipulation.
 
-For pnpm and bun globals, the path layout differs and may need a fallback (testing required before declaring support). For development inside the monorepo, channel packages are workspace deps and resolution is trivial.
+v1 supports npm-installed CLI only — pnpm, bun, homebrew, and standalone-binary distributions are out of scope (see "Scope Decisions" below). For development inside the monorepo, channel packages are workspace deps and resolution is trivial.
 
 ## CLI Bundling Policy
 
@@ -142,10 +151,27 @@ Sequenced so each step is independently shippable:
 
 Steps 1–4 are pure infrastructure with no user-visible change. Step 5 is the first user-visible delivery; step 6 polishes the admin UX.
 
+## Scope Decisions
+
+### v1 supports npm only
+
+- **No pnpm or bun global resolution.** Their global layouts use symlink trees that Node's default upward resolution from the CLI's location does not traverse. Supporting them is feasible (custom `createRequire` paths, `PNPM_HOME`-aware loader) but each adds a code path that must be maintained. Operators wanting pnpm/bun can install the CLI and channel packages into a project-local `node_modules` and point the gateway at it via env var — but this is unsupported in v1.
+- **No homebrew / `curl | sh` / standalone-binary distributions.** Those install the CLI outside any `node_modules` tree, so a sibling-resolution model doesn't apply. v1 is `npm install -g @openhermit/cli` only. Other distribution channels are a future-work item.
+
+These constraints are documented in the operator-facing channel install docs (added in PR2 alongside the `hermit channel install` command) so users picking pnpm/bun/brew aren't surprised.
+
+### `hermit channel install` ships in PR2
+
+A thin wrapper around `npm install -g <pkg>` that also appends the package to `channel_packages` in the gateway config. Without it, operators have to run npm directly and edit the config file by hand — workable but not first-class. PR2 includes it as part of the user-visible delivery.
+
+### Supply-chain trust is the operator's responsibility
+
+The gateway loads arbitrary npm packages whose `start()` runs with full gateway permissions. v1 takes no position on signing, sandboxing, or capability restriction; the operator-facing docs say plainly:
+
+> Installing a channel plugin grants the plugin's code the same authority as the gateway process. Only install plugins from sources you trust — pin versions, audit changes, and treat `npm install -g @vendor/channel-foo` with the same caution as `sudo`.
+
+Signing / capability-scoped sandboxing is a future-work item. Out of scope for v1.
+
 ## Open Questions
 
-- **pnpm/bun global resolution.** Needs hands-on testing before we claim support.
-- **Standalone binary distributions (homebrew, curl|sh).** If the CLI ships outside npm's global tree, where does `@heyamiko/channel-signal` go? A fallback `~/.openhermit/channels/node_modules/` plus `createRequire` is the obvious answer but it's another moving part — defer until the binary distribution exists.
-- **Versioning and ABI.** Manifest contract changes break installed plugins. Adopt a `manifestVersion: 1` field from day one so the loader can refuse mismatched plugins with a clear error.
-- **Signed plugins.** Loading arbitrary npm packages into the gateway process is a supply-chain risk. Out of scope for this RFC but worth flagging — at minimum, document that operators are responsible for trusting the source.
-- **`hermit channel install` command.** Convenience wrapper around `npm install -g`. Nice-to-have, not required for the architecture to work.
+None at this revision. Future revisions land here as the design hits real-world friction.

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -1,6 +1,6 @@
 # Channel Plugin Architecture (Design Draft)
 
-> Status: draft — not implemented. Supersedes the "External Channel Adapter API" open question in `pending-decisions.md`.
+> Status: draft — partially implemented. The manifest contract and `ChannelManifestRegistry` have landed in `@openhermit/protocol`; nothing consumes the registry yet (see migration plan below). Supersedes the "External Channel Adapter API" open question in `pending-decisions.md`.
 
 ## Why
 
@@ -23,7 +23,7 @@ Goal: make channels first-class npm-installable plugins. The CLI still bundles a
 
 ## Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │ gateway process                                                     │
 │                                                                     │
@@ -147,7 +147,7 @@ Sequenced so each step is independently shippable:
 3. **Add `channel_packages` config.** Gateway reads the list, dynamic-imports each, registers. Empty list = no-op, fully backwards compatible.
 4. **Delete `BUILTIN_CHANNELS` constant.** All consumers (`channels.ts` `starters` map, admin UI registry, backfill) now read from the runtime registry. Backfill becomes: "for each manifest registered at boot, ensure an `agent_channels` row exists per active agent."
 5. **Ship Signal as the first external-default channel.** PR #81 rebased: drop from `BUILTIN_CHANNELS`, drop from `tsup` `noExternal`, add `export default manifest`. Operators add `@openhermit/channel-signal` to `channel_packages` to enable.
-6. **Admin UI registry.** `/api/channels/available` returns the runtime registry instead of a hardcoded list. Form rendering uses each manifest's `configSchema`.
+6. **Admin UI registry.** `/api/channels/available` returns the runtime registry instead of a hardcoded list. Form rendering uses each manifest's `parseConfig` (or a richer descriptor we add later — `parseConfig` is opaque by design, so the UI may eventually want an explicit JSON-Schema or Zod field for form generation).
 
 Steps 1–4 are pure infrastructure with no user-visible change. Step 5 is the first user-visible delivery; step 6 polishes the admin UX.
 

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -1,0 +1,151 @@
+# Channel Plugin Architecture (Design Draft)
+
+> Status: draft — not implemented. Supersedes the "External Channel Adapter API" open question in `pending-decisions.md`.
+
+## Why
+
+Today the built-in channel set (`telegram`, `slack`, `discord`) is hardcoded:
+
+- `BUILTIN_CHANNELS` in `apps/agent/src/core/types.ts` is a static array.
+- `apps/agent/src/channels.ts` ships a `starters` map that dynamically imports each `@openhermit/channel-*` package by name, but the keys are written by hand.
+- `apps/cli/tsup.config.ts` bundles `@openhermit/channel-telegram` (via `noExternal`) into the CLI binary; the others resolve from `node_modules` at runtime, but only because they happen to be runtime dependencies of the CLI.
+- The admin UI reads the same hardcoded list to render the "available channels" registry.
+
+Adding a new channel — Signal (PR #81), Weixin, Debox — currently means touching all four places and shipping it inside the CLI. This couples the CLI release cadence to every new channel and bloats the binary for users who only need one.
+
+Goal: make channels first-class npm-installable plugins. The CLI still bundles a default set for the out-of-box experience, but additional channels can be added by `npm install -g @vendor/channel-foo` without re-releasing the CLI.
+
+## Non-goals
+
+- Out-of-process or non-Node channels. The existing external-channel HTTP slot (DB row + bearer token + `AgentLocalClient`) remains the escape hatch for those cases. A dedicated `channels-gateway` sidecar is deferred until a real driver appears.
+- Hot reload. Adding/removing a plugin requires a gateway restart in this phase.
+- Cross-language plugins. Manifests are JS/TS modules.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ gateway process                                                     │
+│                                                                     │
+│  ┌──────────────────────────┐  ┌─────────────────────────────────┐  │
+│  │ ChannelManifestRegistry  │← │ PluginLoader                    │  │
+│  │ (runtime)                │  │  • read channel_packages config │  │
+│  └──────────────────────────┘  │  • dynamic-import each manifest │  │
+│         ▲                      │  • register {key, namespace,    │  │
+│         │                      │     parseConfig, start}         │  │
+│  ┌──────┴───────────┐          └─────────────────────────────────┘  │
+│  │ ChannelPool      │  boots bridges by looking up                  │
+│  │ (per-agent ×     │  registered start() — no hardcoded            │
+│  │  per-channel)    │  switch on key                                │
+│  └──────────────────┘                                               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The runtime `ChannelManifestRegistry` replaces the compile-time `BUILTIN_CHANNELS` constant. `ChannelPool` (`apps/gateway/src/channel-pool.ts`) keeps its current per-agent-per-channel semantics — only the lookup of `start()` changes.
+
+The name `ChannelManifestRegistry` (not `ChannelRegistry`) is deliberate: `apps/gateway/src/auth.ts` already exports a `ChannelRegistry` class that handles per-channel auth-token registration. Manifest registration is a separate concern; keeping the names distinct avoids confusion at call sites.
+
+## Channel Manifest
+
+Every channel package exports a default manifest:
+
+```ts
+// @openhermit/channel-signal/src/index.ts
+import type { ChannelManifest } from '@openhermit/protocol';
+import { z } from 'zod';
+import { startSignal } from './start.js';
+
+const SignalConfig = z.object({
+  restUrl: z.string().url(),
+  selfNumber: z.string(),
+  // ...
+});
+
+const manifest: ChannelManifest = {
+  key: 'signal',                              // ChannelsConfig key + DB channel_type
+  namespace: 'signal',                        // sender.channel namespace
+  displayName: 'Signal',                      // admin UI label
+  parseConfig: (input) => SignalConfig.parse(input),
+  start: startSignal,                         // (config, context) => Promise<ChannelHandle>
+};
+
+export default manifest;
+```
+
+The shape lives in `packages/protocol/src/index.ts`:
+
+```ts
+export interface ChannelManifest {
+  key: string;
+  namespace: string;
+  displayName: string;
+  /** Optional config parser. Throws on invalid; returned value is what start() receives. */
+  parseConfig?: (input: unknown) => unknown;
+  start: (config: unknown, context: ChannelContext) => Promise<ChannelHandle | undefined>;
+}
+```
+
+`parseConfig` is intentionally opaque — plugin authors can use Zod (`schema.parse`), a hand-rolled validator, or skip validation entirely. The contract is "throws if invalid; returns the value passed to `start()`."
+
+Webhook ingress (Telegram secret_token, Slack HMAC, Discord ed25519) lives on the live `ChannelHandle.handleWebhook` returned from `start()`, not on the manifest, because some channels switch between polling and webhook based on per-agent config (e.g. Telegram).
+
+Existing built-in channels (`telegram`, `slack`, `discord`) are refactored to expose the same default-exported manifest. The `start*` functions and config types already exist; only the export shape changes.
+
+## Discovery and Loading
+
+Plugins are loaded from two sources, in order:
+
+1. **CLI-bundled defaults.** Manifests imported directly in `apps/cli/src/cli.ts` (or a dedicated `default-channels.ts`) and registered before reading external config. These are bundled by `tsup` and always available.
+2. **External packages listed in config.** Read from `config.yaml`:
+
+   ```yaml
+   channel_packages:
+     - '@heyamiko/channel-signal'
+     - '@heyamiko/channel-weixin'
+   ```
+
+   At gateway boot, each name is passed to `await import(name)`. Node's module resolution finds the package in the same `node_modules` tree the CLI itself lives in.
+
+If the same `key` is registered twice (e.g. a vendor publishes their own `@vendor/channel-telegram`), the external one wins and a `plugin.duplicate@v1` warning is logged. This lets operators override a default without forking.
+
+### Why global `node_modules` works
+
+When the CLI is installed via `npm install -g @openhermit/cli`, both the CLI and any `npm install -g @vendor/channel-foo` package land as siblings in the same global tree (`/usr/local/lib/node_modules/` on most systems, `~/.npm-global/lib/node_modules/` if the user prefixed npm). Node's normal upward resolution from the CLI's runtime location finds external channel packages without any custom `NODE_PATH` manipulation.
+
+For pnpm and bun globals, the path layout differs and may need a fallback (testing required before declaring support). For development inside the monorepo, channel packages are workspace deps and resolution is trivial.
+
+## CLI Bundling Policy
+
+| Channel | Bundled in CLI? | Loaded via |
+|---|---|---|
+| `@openhermit/channel-telegram` | yes (default) | static import + manifest registration |
+| `@openhermit/channel-slack` | yes (default) | static import + manifest registration |
+| `@openhermit/channel-discord` | yes (default) | static import + manifest registration |
+| `@openhermit/channel-signal` | no | global `node_modules` + `channel_packages` config |
+| `@heyamiko/channel-weixin` | no | global `node_modules` + `channel_packages` config |
+| `@heyamiko/channel-debox` | no | global `node_modules` + `channel_packages` config |
+
+This honors "default-bundle the three established channels so `hermit` is usable out-of-box" while keeping the loading path uniform — both bundled and external go through the same manifest registration, so there is no special-case code for the built-ins.
+
+`apps/cli/tsup.config.ts` needs no new entries beyond what's there today; the three default channels keep their `noExternal` treatment (slack and discord need to be added; only telegram is listed currently).
+
+## Migration Plan
+
+Sequenced so each step is independently shippable:
+
+1. **Manifest contract.** Add `ChannelManifest` type and `ChannelManifestRegistry` runtime class in `packages/protocol` and `apps/gateway`. No behavioral change yet — `BUILTIN_CHANNELS` becomes a thin wrapper that constructs three manifests internally.
+2. **Refactor built-ins to export manifests.** `@openhermit/channel-telegram`, `-slack`, `-discord` add `export default manifest`. The CLI imports and registers them explicitly at boot.
+3. **Add `channel_packages` config.** Gateway reads the list, dynamic-imports each, registers. Empty list = no-op, fully backwards compatible.
+4. **Delete `BUILTIN_CHANNELS` constant.** All consumers (`channels.ts` `starters` map, admin UI registry, backfill) now read from the runtime registry. Backfill becomes: "for each manifest registered at boot, ensure an `agent_channels` row exists per active agent."
+5. **Ship Signal as the first external-default channel.** PR #81 rebased: drop from `BUILTIN_CHANNELS`, drop from `tsup` `noExternal`, add `export default manifest`. Operators add `@openhermit/channel-signal` to `channel_packages` to enable.
+6. **Admin UI registry.** `/api/channels/available` returns the runtime registry instead of a hardcoded list. Form rendering uses each manifest's `configSchema`.
+
+Steps 1–4 are pure infrastructure with no user-visible change. Step 5 is the first user-visible delivery; step 6 polishes the admin UX.
+
+## Open Questions
+
+- **pnpm/bun global resolution.** Needs hands-on testing before we claim support.
+- **Standalone binary distributions (homebrew, curl|sh).** If the CLI ships outside npm's global tree, where does `@heyamiko/channel-signal` go? A fallback `~/.openhermit/channels/node_modules/` plus `createRequire` is the obvious answer but it's another moving part — defer until the binary distribution exists.
+- **Versioning and ABI.** Manifest contract changes break installed plugins. Adopt a `manifestVersion: 1` field from day one so the loader can refuse mismatched plugins with a clear error.
+- **Signed plugins.** Loading arbitrary npm packages into the gateway process is a supply-chain risk. Out of scope for this RFC but worth flagging — at minimum, document that operators are responsible for trusting the source.
+- **`hermit channel install` command.** Convenience wrapper around `npm install -g`. Nice-to-have, not required for the architecture to work.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -329,7 +329,20 @@ export interface ChannelHandle {
  * export default manifest;
  * ```
  */
+/** Highest manifest version supported by this build of the protocol. */
+export const CHANNEL_MANIFEST_VERSION = 1 as const;
+
 export interface ChannelManifest {
+  /**
+   * Manifest contract version. Always `1` in this revision. Plugins built
+   * against a future, incompatible revision will set a higher number; the
+   * loader rejects unknown versions with a clear error so an operator can
+   * pin a compatible plugin version.
+   *
+   * Bump policy: add optional fields without bumping; bump on any required
+   * field addition, semantic change, or signature change to `start`.
+   */
+  manifestVersion: 1;
   /** Stable key. Matches the DB `channel_type` column and the key under `ChannelsConfig`. */
   key: string;
   /** Identity namespace used in `sender.channel`. Usually equal to `key`. */
@@ -337,7 +350,7 @@ export interface ChannelManifest {
   /** Human-readable label for the admin UI. */
   displayName: string;
   /**
-   * Optional config parser. When set, the registry calls this before
+   * Optional config parser. When set, the loader calls this before
    * `start()` to validate the persisted config. The shape is left
    * opaque so plugin authors can use Zod (`schema.parse`), a manual
    * function, or skip validation entirely. Returning a value replaces
@@ -373,6 +386,13 @@ export class ChannelManifestRegistry {
   register(manifest: ChannelManifest): void {
     if (!manifest.key) {
       throw new Error('ChannelManifestRegistry.register: manifest.key is required');
+    }
+    if (manifest.manifestVersion !== CHANNEL_MANIFEST_VERSION) {
+      throw new Error(
+        `ChannelManifestRegistry.register: unsupported manifestVersion ${String(
+          manifest.manifestVersion,
+        )} for channel "${manifest.key}" (this build supports ${CHANNEL_MANIFEST_VERSION})`,
+      );
     }
     if (this.byKey.has(manifest.key)) {
       throw new Error(`ChannelManifestRegistry.register: duplicate channel key "${manifest.key}"`);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -257,6 +257,151 @@ export interface ChannelOutbound {
   }): Promise<ChannelOutboundResult>;
 }
 
+// ── Channel Plugin Contract ───────────────────────────────────────────
+//
+// The types below define the stable contract a channel plugin package
+// implements. Third-party channel packages (e.g. `@vendor/channel-foo`)
+// should depend only on `@openhermit/protocol` for these types so they
+// stay decoupled from the agent/gateway runtime internals.
+//
+// See `docs/channel-plugin-design.md` for the architecture and
+// migration plan.
+
+/**
+ * Per-agent boot context passed to a manifest's `start()`. The adapter
+ * uses `agentBaseUrl` + `agentTokens[<key>]` to authenticate callbacks
+ * into the agent HTTP API.
+ */
+export interface ChannelContext {
+  agentBaseUrl: string;
+  agentTokens: Record<string, string>;
+  logger: (channel: string, message: string) => void;
+}
+
+/**
+ * HTTP request handed to a channel's webhook handler. The gateway
+ * forwards `POST /api/agents/:agentId/channels/:namespace/webhook` to
+ * this handler when present.
+ */
+export interface WebhookRequest {
+  headers: Record<string, string>;
+  rawBody: string;
+}
+
+export interface WebhookResponse {
+  status: number;
+  body?: string;
+  headers?: Record<string, string>;
+}
+
+export type WebhookHandler = (req: WebhookRequest) => Promise<WebhookResponse>;
+
+/**
+ * Live channel instance returned from `start()`. The gateway's
+ * ChannelPool owns the handle and calls `stop()` on shutdown / disable.
+ */
+export interface ChannelHandle {
+  name: string;
+  outbound?: ChannelOutbound;
+  stop: () => Promise<void>;
+  /**
+   * Optional webhook handler. When present, the gateway forwards
+   * `POST /api/agents/:agentId/channels/:namespace/webhook` here. The
+   * adapter is responsible for verifying authenticity (Telegram
+   * `secret_token`, Slack HMAC, Discord ed25519, …).
+   */
+  handleWebhook?: WebhookHandler;
+}
+
+/**
+ * A channel plugin's default export. Describes the channel to the
+ * runtime registry, the admin UI, and the boot sequence.
+ *
+ * Plugin authors export this as the package default:
+ *
+ * ```ts
+ * const manifest: ChannelManifest = {
+ *   key: 'signal',
+ *   namespace: 'signal',
+ *   displayName: 'Signal',
+ *   start: startSignal,
+ * };
+ * export default manifest;
+ * ```
+ */
+export interface ChannelManifest {
+  /** Stable key. Matches the DB `channel_type` column and the key under `ChannelsConfig`. */
+  key: string;
+  /** Identity namespace used in `sender.channel`. Usually equal to `key`. */
+  namespace: string;
+  /** Human-readable label for the admin UI. */
+  displayName: string;
+  /**
+   * Optional config parser. When set, the registry calls this before
+   * `start()` to validate the persisted config. The shape is left
+   * opaque so plugin authors can use Zod (`schema.parse`), a manual
+   * function, or skip validation entirely. Returning a value replaces
+   * the raw config passed to `start()`; throwing aborts the start.
+   */
+  parseConfig?: (input: unknown) => unknown;
+  /**
+   * Boot the channel for one agent. Returns the live handle, or
+   * `undefined` if startup failed in a way the caller logged but
+   * should not treat as fatal.
+   */
+  start: (config: unknown, context: ChannelContext) => Promise<ChannelHandle | undefined>;
+}
+
+/**
+ * In-memory registry of channel manifests. Populated once at gateway
+ * boot from (a) bundled-default channels and (b) packages listed in
+ * the `channel_packages` config, then consulted by the channel
+ * launcher and the admin UI's "available channels" endpoint.
+ *
+ * Single-process, non-thread-safe (Node is single-threaded for
+ * userland code; the registry is constructed before any request
+ * handling begins).
+ */
+export class ChannelManifestRegistry {
+  private readonly byKey = new Map<string, ChannelManifest>();
+
+  /**
+   * Register a manifest. Throws on duplicate `key` — the caller (the
+   * plugin loader) decides whether to swallow the error to allow an
+   * external manifest to override a bundled default.
+   */
+  register(manifest: ChannelManifest): void {
+    if (!manifest.key) {
+      throw new Error('ChannelManifestRegistry.register: manifest.key is required');
+    }
+    if (this.byKey.has(manifest.key)) {
+      throw new Error(`ChannelManifestRegistry.register: duplicate channel key "${manifest.key}"`);
+    }
+    this.byKey.set(manifest.key, manifest);
+  }
+
+  /** Replace an existing manifest by key. No-op if not registered. */
+  replace(manifest: ChannelManifest): void {
+    this.byKey.set(manifest.key, manifest);
+  }
+
+  get(key: string): ChannelManifest | undefined {
+    return this.byKey.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.byKey.has(key);
+  }
+
+  all(): ChannelManifest[] {
+    return Array.from(this.byKey.values());
+  }
+
+  keys(): string[] {
+    return Array.from(this.byKey.keys());
+  }
+}
+
 export interface ToolApprovalRequest {
   toolCallId: string;
   approved: boolean;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -400,8 +400,22 @@ export class ChannelManifestRegistry {
     this.byKey.set(manifest.key, manifest);
   }
 
-  /** Replace an existing manifest by key. No-op if not registered. */
+  /**
+   * Register or override a manifest by key. Inserts when absent, overwrites
+   * when present. Validates `key` and `manifestVersion` with the same rules
+   * as `register()`; only the duplicate-key check is relaxed.
+   */
   replace(manifest: ChannelManifest): void {
+    if (!manifest.key) {
+      throw new Error('ChannelManifestRegistry.replace: manifest.key is required');
+    }
+    if (manifest.manifestVersion !== CHANNEL_MANIFEST_VERSION) {
+      throw new Error(
+        `ChannelManifestRegistry.replace: unsupported manifestVersion ${String(
+          manifest.manifestVersion,
+        )} for channel "${manifest.key}" (this build supports ${CHANNEL_MANIFEST_VERSION})`,
+      );
+    }
     this.byKey.set(manifest.key, manifest);
   }
 


### PR DESCRIPTION
## Summary

First slice of the channel-plugin migration ([RFC](./docs/channel-plugin-design.md)). Lays the contract that lets third-party channel packages (Signal, Weixin, Debox, …) plug into the gateway without being bundled into the CLI.

- **Pure additive.** No consumer reads from the registry yet. `BUILTIN_CHANNELS`, the `starters` map in `apps/agent/src/channels.ts`, and `ChannelPool` are untouched. Behavior is identical.
- Canonicalises `ChannelHandle` / `ChannelContext` / `WebhookRequest` / `WebhookResponse` / `WebhookHandler` in `@openhermit/protocol` so third-party channel packages can depend on a stable contract without pulling in `@openhermit/agent`. The previous home (`apps/agent/src/channels.ts`) re-exports them for back-compat — existing gateway imports via `@openhermit/agent/channels` keep working.
- New `ChannelManifest` interface: `{ key, namespace, displayName, parseConfig?, start }`. Plugin authors will default-export one of these from their package.
- New `ChannelManifestRegistry` class. Named deliberately to avoid collision with the existing auth-token `ChannelRegistry` in `apps/gateway/src/auth.ts`.
- New design doc `docs/channel-plugin-design.md` with the full architecture, discovery model (global `node_modules` + `channel_packages` config), CLI bundling policy, and 6-step migration plan.

## What's NOT in this PR

By design, the registry is dead until later PRs wire it up:

- **PR2** — built-in channels (telegram/slack/discord) start exporting manifests; `ChannelPool` reads from the registry; `BUILTIN_CHANNELS` gets deleted; `channel_packages` config support added so external packages register too.
- **PR3** — rebase #81 (Signal) onto the plugin model: drop it from any default-bundle paths, ship as the first external-default channel.

## Test plan

- [x] `npm run typecheck` — full workspace passes
- [x] `node --import tsx --test apps/agent/test/channel-manifest-registry.test.ts` — 8/8 pass (covers register/get/has/all/keys/replace, duplicate-key rejection, empty-key rejection, start contract, parseConfig contract)
- [ ] post-merge: no behavioral change expected; PR2 will exercise the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published a standardized channel plugin manifest and registry in the protocol for third‑party channel plugins.
  * Agent now consumes and exposes protocol-backed channel contracts for plugin integration.

* **Documentation**
  * Added a Channel Plugin Architecture design draft covering manifest shape, discovery, ordering, and migration plan.

* **Tests**
  * Expanded tests for manifest registry behavior, validation, ordering, and start/parse semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/87)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->