### PR TITLE
feat(channels): wire built-ins through manifest registry

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -57,8 +57,5 @@
     "langfuse": "^3.38.6",
     "prom-client": "^15.1.3",
     "zod": "^4.3.6"
-  },
-  "optionalDependencies": {
-    "@openhermit/channel-telegram": "0.2.0"
   }
 }

--- a/apps/agent/src/channels.ts
+++ b/apps/agent/src/channels.ts
@@ -1,22 +1,25 @@
 /**
- * Channel launcher — starts configured channel adapters after the agent API is ready.
- * Uses dynamic imports so the agent doesn't hard-depend on specific channel packages.
+ * Channel launcher helpers shared between the gateway's ChannelPool and
+ * any other caller that needs to start one channel from a manifest.
+ *
+ * Built-in channel wrappers used to live here as hardcoded
+ * startTelegram/startSlack/startDiscord functions; they have moved
+ * into each channel package as the default-exported `ChannelManifest`.
  */
 
 import type {
   ChannelContext,
   ChannelHandle,
+  ChannelManifest,
   ChannelOutbound,
   WebhookHandler,
   WebhookRequest,
   WebhookResponse,
 } from '@openhermit/protocol';
 
-import type { ChannelsConfig } from './core/types.js';
-
 // Re-export the channel runtime types that used to live here. Consumers
 // like `@openhermit/gateway` import them via `@openhermit/agent/channels`;
-// the canonical definitions are now in `@openhermit/protocol` so that
+// the canonical definitions are in `@openhermit/protocol` so that
 // third-party channel plugins can depend on a stable contract.
 export type {
   ChannelContext,
@@ -33,52 +36,34 @@ export interface ChannelStatus {
   error?: string;
 }
 
-export interface StartChannelsResult {
-  handles: ChannelHandle[];
-  statuses: ChannelStatus[];
+export interface SingleChannelResult {
+  handle?: ChannelHandle;
+  status: ChannelStatus;
 }
 
-export const startChannels = async (
-  channels: ChannelsConfig | undefined,
+/**
+ * Start a single channel by manifest. Applies `parseConfig` if the
+ * manifest declares one, then invokes `start()`. Errors are caught and
+ * surfaced as an error status — the caller decides whether the failure
+ * is fatal.
+ */
+export const startSingleChannel = async (
+  manifest: ChannelManifest,
+  config: unknown,
   context: ChannelContext,
-): Promise<StartChannelsResult> => {
-  if (!channels) return { handles: [], statuses: [] };
-
-  const handles: ChannelHandle[] = [];
-  const statuses: ChannelStatus[] = [];
-
-  const tryStart = async (name: string, fn: () => Promise<ChannelHandle | undefined>): Promise<void> => {
-    try {
-      const handle = await fn();
-      if (handle) {
-        handles.push(handle);
-        statuses.push({ name, status: 'connected' });
-      } else {
-        statuses.push({ name, status: 'error', error: 'Failed to start' });
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      context.logger(name, `failed to start ${name} channel: ${msg}`);
-      statuses.push({ name, status: 'error', error: msg });
+): Promise<SingleChannelResult> => {
+  try {
+    const parsed = manifest.parseConfig ? manifest.parseConfig(config) : config;
+    const handle = await manifest.start(parsed, context);
+    if (handle) {
+      return { handle, status: { name: manifest.key, status: 'connected' } };
     }
-  };
-
-  // Start all enabled channels in parallel — each is an independent network
-  // connection (Telegram poll, Slack RTM, Discord WS) and they don't share
-  // state, so serial startup just delays the slowest one.
-  const tasks: Array<Promise<void>> = [];
-  if (channels.telegram?.enabled) {
-    tasks.push(tryStart('telegram', () => startTelegram(channels.telegram!, context)));
+    return { status: { name: manifest.key, status: 'error', error: 'Failed to start' } };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    context.logger(manifest.key, `failed to start ${manifest.key} channel: ${msg}`);
+    return { status: { name: manifest.key, status: 'error', error: msg } };
   }
-  if (channels.slack?.enabled) {
-    tasks.push(tryStart('slack', () => startSlack(channels.slack!, context)));
-  }
-  if (channels.discord?.enabled) {
-    tasks.push(tryStart('discord', () => startDiscord(channels.discord!, context)));
-  }
-  await Promise.all(tasks);
-
-  return { handles, statuses };
 };
 
 export const stopChannels = async (handles: ChannelHandle[]): Promise<void> => {
@@ -91,165 +76,3 @@ export const stopChannels = async (handles: ChannelHandle[]): Promise<void> => {
     }
   }
 };
-
-export interface SingleChannelResult {
-  handle?: ChannelHandle;
-  status: ChannelStatus;
-}
-
-const starters: Record<string, (config: ChannelsConfig, context: ChannelContext) => Promise<ChannelHandle | undefined>> = {
-  telegram: (cfg, ctx) => startTelegram(cfg.telegram!, ctx),
-  slack: (cfg, ctx) => startSlack(cfg.slack!, ctx),
-  discord: (cfg, ctx) => startDiscord(cfg.discord!, ctx),
-};
-
-export const startSingleChannel = async (
-  name: string,
-  channels: ChannelsConfig,
-  context: ChannelContext,
-): Promise<SingleChannelResult> => {
-  const starter = starters[name];
-  if (!starter) {
-    return { status: { name, status: 'error', error: `Unknown channel: ${name}` } };
-  }
-  try {
-    const handle = await starter(channels, context);
-    if (handle) {
-      return { handle, status: { name, status: 'connected' } };
-    }
-    return { status: { name, status: 'error', error: 'Failed to start' } };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    context.logger(name, `failed to start ${name} channel: ${msg}`);
-    return { status: { name, status: 'error', error: msg } };
-  }
-};
-
-async function startDiscord(
-  config: NonNullable<ChannelsConfig['discord']>,
-  context: ChannelContext,
-): Promise<ChannelHandle | undefined> {
-  const log = (msg: string) => context.logger('discord', msg);
-
-  try {
-    const { DiscordApi, DiscordBridge, DiscordBot } = await import(
-      '@openhermit/channel-discord'
-    );
-
-    const api = new DiscordApi(config.bot_token);
-    const bridge = new DiscordBridge(api, {
-      baseUrl: context.agentBaseUrl,
-      token: context.agentTokens['discord'] ?? '',
-    }, log);
-
-    const bot = new DiscordBot({
-      botToken: config.bot_token,
-      discord: api,
-      bridge,
-      logger: log,
-    });
-
-    await bot.start();
-
-    return {
-      name: 'discord',
-      outbound: bridge,
-      stop: () => bot.stop(),
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log(`failed to start discord channel: ${message}`);
-    return undefined;
-  }
-}
-
-async function startSlack(
-  config: NonNullable<ChannelsConfig['slack']>,
-  context: ChannelContext,
-): Promise<ChannelHandle | undefined> {
-  const log = (msg: string) => context.logger('slack', msg);
-
-  try {
-    const { SlackApi, SlackBridge, SlackBot } = await import(
-      '@openhermit/channel-slack'
-    );
-
-    const api = new SlackApi(config.bot_token);
-    const bridge = new SlackBridge(api, {
-      baseUrl: context.agentBaseUrl,
-      token: context.agentTokens['slack'] ?? '',
-    }, log);
-
-    const bot = new SlackBot({
-      appToken: config.app_token,
-      slack: api,
-      bridge,
-      logger: log,
-    });
-
-    await bot.start();
-
-    return {
-      name: 'slack',
-      outbound: bridge,
-      stop: () => bot.stop(),
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log(`failed to start slack channel: ${message}`);
-    return undefined;
-  }
-}
-
-async function startTelegram(
-  config: NonNullable<ChannelsConfig['telegram']>,
-  context: ChannelContext,
-): Promise<ChannelHandle | undefined> {
-  const log = (msg: string) => context.logger('telegram', msg);
-
-  try {
-    const { TelegramApi, TelegramBridge, TelegramBot } = await import(
-      '@openhermit/channel-telegram'
-    );
-
-    const api = new TelegramApi(config.bot_token);
-    const bridge = new TelegramBridge(api, {
-      baseUrl: context.agentBaseUrl,
-      token: context.agentTokens['telegram'] ?? '',
-    }, log);
-
-    const mode = config.mode ?? 'polling';
-    const botOptions: ConstructorParameters<typeof TelegramBot>[0] = {
-      botToken: config.bot_token,
-      bridge,
-      mode,
-      logger: log,
-    };
-    if (mode === 'webhook') {
-      // Gateway-hosted webhook URL (single port, single TLS cert).
-      const derivedUrl = config.webhook_url || `${context.agentBaseUrl}/channels/telegram/webhook`;
-      botOptions.webhookUrl = derivedUrl;
-      // Use the per-channel token as Telegram's secret_token; we verify
-      // X-Telegram-Bot-Api-Secret-Token on each incoming request.
-      const secret = context.agentTokens['telegram'];
-      if (secret) botOptions.webhookSecret = secret;
-    }
-
-    const bot = new TelegramBot(botOptions);
-    await bot.start();
-
-    const handle: ChannelHandle = {
-      name: 'telegram',
-      outbound: bridge,
-      stop: () => bot.stop(),
-    };
-    if (mode === 'webhook') {
-      handle.handleWebhook = (req) => bot.handleWebhookRequest(req);
-    }
-    return handle;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log(`failed to start telegram channel: ${message}`);
-    return undefined;
-  }
-}

--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -81,24 +81,6 @@ export interface ChannelsConfig {
   discord?: DiscordChannelConfig;
 }
 
-/**
- * Built-in channel definitions. Each entry maps a ChannelsConfig key to the
- * identity namespace the channel bridge uses in `sender.channel`.
- * When adding a new built-in channel, add an entry here.
- */
-export const BUILTIN_CHANNELS: readonly BuiltinChannelDef[] = [
-  { key: 'telegram', namespace: 'telegram' },
-  { key: 'slack', namespace: 'slack' },
-  { key: 'discord', namespace: 'discord' },
-] satisfies readonly { key: keyof ChannelsConfig; namespace: string }[];
-
-export interface BuiltinChannelDef {
-  /** Key in ChannelsConfig. */
-  key: keyof ChannelsConfig;
-  /** Identity namespace used by the bridge in sender.channel. */
-  namespace: string;
-}
-
 export type WorkspaceContainerStartPolicy = 'session' | 'ondemand';
 export type WorkspaceContainerStopPolicy = 'session' | 'idle';
 

--- a/apps/channels/discord/src/index.ts
+++ b/apps/channels/discord/src/index.ts
@@ -46,6 +46,9 @@ export { DiscordBot } from './bot.js';
 export type { DiscordAdapterConfig } from './config.js';
 export type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
 
+// Default export: ChannelManifest consumed by the gateway plugin registry.
+export { default } from './manifest.js';
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));

--- a/apps/channels/discord/src/manifest.ts
+++ b/apps/channels/discord/src/manifest.ts
@@ -1,0 +1,51 @@
+/**
+ * Channel plugin manifest for Discord. Consumed by the gateway's
+ * ChannelManifestRegistry; see `docs/channel-plugin-design.md`.
+ */
+import type { ChannelManifest } from '@openhermit/protocol';
+
+import { DiscordApi } from './discord-api.js';
+import { DiscordBridge } from './bridge.js';
+import { DiscordBot } from './bot.js';
+
+interface DiscordRuntimeConfig {
+  enabled?: boolean;
+  bot_token: string;
+}
+
+const manifest: ChannelManifest = {
+  manifestVersion: 1,
+  key: 'discord',
+  namespace: 'discord',
+  displayName: 'Discord',
+  start: async (rawConfig, context) => {
+    const config = rawConfig as DiscordRuntimeConfig;
+    const log = (msg: string): void => context.logger('discord', msg);
+
+    const api = new DiscordApi(config.bot_token);
+    const bridge = new DiscordBridge(
+      api,
+      {
+        baseUrl: context.agentBaseUrl,
+        token: context.agentTokens['discord'] ?? '',
+      },
+      log,
+    );
+
+    const bot = new DiscordBot({
+      botToken: config.bot_token,
+      discord: api,
+      bridge,
+      logger: log,
+    });
+    await bot.start();
+
+    return {
+      name: 'discord',
+      outbound: bridge,
+      stop: () => bot.stop(),
+    };
+  },
+};
+
+export default manifest;

--- a/apps/channels/slack/src/index.ts
+++ b/apps/channels/slack/src/index.ts
@@ -46,6 +46,9 @@ export { SlackBot } from './bot.js';
 export type { SlackAdapterConfig } from './config.js';
 export type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
 
+// Default export: ChannelManifest consumed by the gateway plugin registry.
+export { default } from './manifest.js';
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));

--- a/apps/channels/slack/src/manifest.ts
+++ b/apps/channels/slack/src/manifest.ts
@@ -1,0 +1,52 @@
+/**
+ * Channel plugin manifest for Slack. Consumed by the gateway's
+ * ChannelManifestRegistry; see `docs/channel-plugin-design.md`.
+ */
+import type { ChannelManifest } from '@openhermit/protocol';
+
+import { SlackApi } from './slack-api.js';
+import { SlackBridge } from './bridge.js';
+import { SlackBot } from './bot.js';
+
+interface SlackRuntimeConfig {
+  enabled?: boolean;
+  bot_token: string;
+  app_token: string;
+}
+
+const manifest: ChannelManifest = {
+  manifestVersion: 1,
+  key: 'slack',
+  namespace: 'slack',
+  displayName: 'Slack',
+  start: async (rawConfig, context) => {
+    const config = rawConfig as SlackRuntimeConfig;
+    const log = (msg: string): void => context.logger('slack', msg);
+
+    const api = new SlackApi(config.bot_token);
+    const bridge = new SlackBridge(
+      api,
+      {
+        baseUrl: context.agentBaseUrl,
+        token: context.agentTokens['slack'] ?? '',
+      },
+      log,
+    );
+
+    const bot = new SlackBot({
+      appToken: config.app_token,
+      slack: api,
+      bridge,
+      logger: log,
+    });
+    await bot.start();
+
+    return {
+      name: 'slack',
+      outbound: bridge,
+      stop: () => bot.stop(),
+    };
+  },
+};
+
+export default manifest;

--- a/apps/channels/telegram/src/index.ts
+++ b/apps/channels/telegram/src/index.ts
@@ -51,6 +51,9 @@ export { TelegramBot } from './bot.js';
 export type { TelegramAdapterConfig } from './config.js';
 export type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
 
+// Default export: ChannelManifest consumed by the gateway plugin registry.
+export { default } from './manifest.js';
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   await main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));

--- a/apps/channels/telegram/src/manifest.ts
+++ b/apps/channels/telegram/src/manifest.ts
@@ -13,7 +13,6 @@ interface TelegramRuntimeConfig {
   bot_token: string;
   mode?: 'polling' | 'webhook';
   webhook_url?: string;
-  webhook_port?: number;
 }
 
 const manifest: ChannelManifest = {

--- a/apps/channels/telegram/src/manifest.ts
+++ b/apps/channels/telegram/src/manifest.ts
@@ -1,0 +1,68 @@
+/**
+ * Channel plugin manifest for Telegram. Consumed by the gateway's
+ * ChannelManifestRegistry; see `docs/channel-plugin-design.md`.
+ */
+import type { ChannelManifest } from '@openhermit/protocol';
+
+import { TelegramApi } from './telegram-api.js';
+import { TelegramBridge } from './bridge.js';
+import { TelegramBot } from './bot.js';
+
+interface TelegramRuntimeConfig {
+  enabled?: boolean;
+  bot_token: string;
+  mode?: 'polling' | 'webhook';
+  webhook_url?: string;
+  webhook_port?: number;
+}
+
+const manifest: ChannelManifest = {
+  manifestVersion: 1,
+  key: 'telegram',
+  namespace: 'telegram',
+  displayName: 'Telegram',
+  start: async (rawConfig, context) => {
+    const config = rawConfig as TelegramRuntimeConfig;
+    const log = (msg: string): void => context.logger('telegram', msg);
+
+    const api = new TelegramApi(config.bot_token);
+    const bridge = new TelegramBridge(
+      api,
+      {
+        baseUrl: context.agentBaseUrl,
+        token: context.agentTokens['telegram'] ?? '',
+      },
+      log,
+    );
+
+    const mode = config.mode ?? 'polling';
+    const botOptions: ConstructorParameters<typeof TelegramBot>[0] = {
+      botToken: config.bot_token,
+      bridge,
+      mode,
+      logger: log,
+    };
+    if (mode === 'webhook') {
+      const derivedUrl =
+        config.webhook_url ||
+        `${context.agentBaseUrl}/channels/telegram/webhook`;
+      botOptions.webhookUrl = derivedUrl;
+      const secret = context.agentTokens['telegram'];
+      if (secret) botOptions.webhookSecret = secret;
+    }
+
+    const bot = new TelegramBot(botOptions);
+    await bot.start();
+
+    return {
+      name: 'telegram',
+      outbound: bridge,
+      stop: () => bot.stop(),
+      ...(mode === 'webhook'
+        ? { handleWebhook: (req) => bot.handleWebhookRequest(req) }
+        : {}),
+    };
+  },
+};
+
+export default manifest;

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -10,6 +10,8 @@ const internalPackages = [
   '@openhermit/agent/*',
   '@openhermit/web',
   '@openhermit/channel-telegram',
+  '@openhermit/channel-slack',
+  '@openhermit/channel-discord',
   '@openhermit/gateway',
 ];
 

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -30,5 +30,10 @@
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.4.1",
     "vite": "^6.3.2"
+  },
+  "optionalDependencies": {
+    "@openhermit/channel-telegram": "0.2.0",
+    "@openhermit/channel-slack": "0.2.0",
+    "@openhermit/channel-discord": "0.2.0"
   }
 }

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -13,6 +13,7 @@ import {
   isSessionMessage,
   isToolApprovalRequest,
   isSessionCheckpointRequest,
+  type ChannelManifestRegistry,
   type CreateAgentRequest,
   type SessionListQuery,
   type SyncResponse,
@@ -48,7 +49,7 @@ import {
 
 import type { AgentRunner, SessionEventEnvelope } from '@openhermit/agent/agent-runner';
 import { metricsRegistry, startDefaultMetrics } from '@openhermit/agent/metrics';
-import { BUILTIN_CHANNELS, buildDefaultAgentConfig, listAllOpenHermitContainers } from '@openhermit/agent/core';
+import { buildDefaultAgentConfig, listAllOpenHermitContainers } from '@openhermit/agent/core';
 import { listProviderCatalog } from '@openhermit/agent/model-catalog';
 
 import type { AgentInstanceManager } from './agent-instance.js';
@@ -229,6 +230,8 @@ export interface GatewayAppOptions {
   autoProvisionSandbox?: string | null | undefined;
   /** Live ChannelRegistry — handlers mutate this when channels are created/revoked. */
   channelRegistry?: ChannelRegistry | undefined;
+  /** Channel manifest registry — drives builtin channel iteration in agent create. */
+  manifestRegistry: ChannelManifestRegistry;
   auth?: AuthResolverOptions | undefined;
   adminToken?: string | undefined;
   logger?: ((message: string) => void) | undefined;
@@ -917,10 +920,10 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     // can flip them on later from the admin / web UI without having to
     // create rows from scratch.
     if (options.agentChannelStore) {
-      for (const def of BUILTIN_CHANNELS) {
+      for (const key of options.manifestRegistry.keys()) {
         await options.agentChannelStore.createBuiltin({
           agentId: record.agentId,
-          channelType: def.key,
+          channelType: key,
           enabled: false,
         });
       }

--- a/apps/gateway/src/channel-manifests.ts
+++ b/apps/gateway/src/channel-manifests.ts
@@ -1,0 +1,95 @@
+/**
+ * Builds the runtime `ChannelManifestRegistry` for the gateway.
+ *
+ * Loads two sources, in order:
+ *   1. Bundled-default channel packages (telegram/slack/discord).
+ *   2. External packages listed in the `channelPackages` gateway config.
+ *
+ * Both paths use the same `await import(pkg)` mechanism — only the
+ * source of the package list differs. External packages may override
+ * a built-in by key (via `registry.replace()`); a log line records
+ * each override so an operator can see what's happening.
+ *
+ * Failures loading any single package are logged but do not abort
+ * the gateway. A missing optional channel package is a recoverable
+ * config error, not a fatal one — agents with the missing channel
+ * enabled will simply fail to start that channel and surface in the
+ * pool's status map.
+ */
+import {
+  ChannelManifestRegistry,
+  type ChannelManifest,
+} from '@openhermit/protocol';
+
+const BUILTIN_PACKAGES: readonly string[] = [
+  '@openhermit/channel-telegram',
+  '@openhermit/channel-slack',
+  '@openhermit/channel-discord',
+];
+
+const isManifestLike = (value: unknown): value is ChannelManifest => {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Partial<ChannelManifest>;
+  return (
+    typeof m.key === 'string' &&
+    typeof m.namespace === 'string' &&
+    typeof m.displayName === 'string' &&
+    typeof m.start === 'function' &&
+    m.manifestVersion === 1
+  );
+};
+
+const loadOne = async (
+  registry: ChannelManifestRegistry,
+  pkg: string,
+  origin: 'built-in' | 'external',
+  log: (msg: string) => void,
+): Promise<void> => {
+  let mod: { default?: unknown };
+  try {
+    mod = (await import(pkg)) as { default?: unknown };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`channel package "${pkg}" (${origin}) failed to load: ${msg}`);
+    return;
+  }
+
+  const candidate = mod.default;
+  if (!isManifestLike(candidate)) {
+    log(
+      `channel package "${pkg}" (${origin}) has no valid default-exported ChannelManifest — skipping`,
+    );
+    return;
+  }
+
+  try {
+    if (registry.has(candidate.key)) {
+      if (origin === 'external') {
+        registry.replace(candidate);
+        log(`channel "${candidate.key}" overridden by external package "${pkg}"`);
+      } else {
+        log(`channel package "${pkg}" (built-in) duplicates key "${candidate.key}" — skipping`);
+      }
+    } else {
+      registry.register(candidate);
+      log(`registered ${origin} channel "${candidate.key}" from ${pkg}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`channel package "${pkg}" (${origin}) rejected by registry: ${msg}`);
+  }
+};
+
+export async function buildChannelManifestRegistry(
+  externalPackages: readonly string[],
+  log: (msg: string) => void,
+): Promise<ChannelManifestRegistry> {
+  const registry = new ChannelManifestRegistry();
+  for (const pkg of BUILTIN_PACKAGES) {
+    await loadOne(registry, pkg, 'built-in', log);
+  }
+  for (const pkg of externalPackages) {
+    await loadOne(registry, pkg, 'external', log);
+  }
+  return registry;
+}

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -227,11 +227,17 @@ export class ChannelPool {
 
     const manifest = this.opts.manifestRegistry.get(channelName);
     if (!manifest) {
-      return {
+      const errorStatus: ChannelStatus = {
         name: channelName,
         status: 'error',
         error: `no manifest registered for channel "${channelName}"`,
       };
+      const statuses = this.statuses.get(agentId) ?? [];
+      const existingIdx = statuses.findIndex((s) => s.name === channelName);
+      if (existingIdx !== -1) statuses[existingIdx] = errorStatus;
+      else statuses.push(errorStatus);
+      this.statuses.set(agentId, statuses);
+      return errorStatus;
     }
 
     const security = await this.loadSecurity(agentId);

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -14,7 +14,7 @@
  */
 import type { AgentRunner } from '@openhermit/agent/agent-runner';
 import {
-  startSingleChannel as startOneChannel,
+  startSingleChannel,
   stopChannels as stopChannelHandles,
   type ChannelHandle,
   type ChannelStatus,
@@ -22,6 +22,7 @@ import {
   type WebhookResponse,
 } from '@openhermit/agent/channels';
 import { AgentSecurity, AgentWorkspace } from '@openhermit/agent/core';
+import type { ChannelManifestRegistry } from '@openhermit/protocol';
 import type {
   AgentConfigStore,
   AgentStore,
@@ -37,6 +38,7 @@ export interface ChannelPoolOptions {
   configStore: AgentConfigStore;
   secretStore: SecretStore;
   channelRegistry: ChannelRegistry;
+  manifestRegistry: ChannelManifestRegistry;
   gatewayBaseUrl: string;
   /** Live-runner lookup so enable/disable can update the hot runner's outbounds. */
   getRunner: (agentId: string) => AgentRunner | undefined;
@@ -117,11 +119,22 @@ export class ChannelPool {
     const startedStatuses: ChannelStatus[] = [];
 
     for (const row of rows) {
+      const manifest = this.opts.manifestRegistry.get(row.channelType);
+      if (!manifest) {
+        this.opts.log(
+          `[${agentId}] [${row.channelType}] no manifest registered — skipping`,
+        );
+        startedStatuses.push({
+          name: row.channelType,
+          status: 'error',
+          error: `no manifest registered for channel "${row.channelType}"`,
+        });
+        continue;
+      }
       const resolved = await security.expandSecrets({ ...row.config, enabled: true });
-      const channelsConfig: Record<string, unknown> = { [row.channelType]: resolved };
-      const { handle, status } = await startOneChannel(row.channelType, channelsConfig as never, {
+      const { handle, status } = await startSingleChannel(manifest, resolved, {
         agentBaseUrl,
-        agentTokens: { [row.channelType]: row.token },
+        agentTokens: { [manifest.key]: row.token },
         logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
       });
       if (handle) startedHandles.push(handle);
@@ -212,14 +225,22 @@ export class ChannelPool {
       agentId,
     });
 
+    const manifest = this.opts.manifestRegistry.get(channelName);
+    if (!manifest) {
+      return {
+        name: channelName,
+        status: 'error',
+        error: `no manifest registered for channel "${channelName}"`,
+      };
+    }
+
     const security = await this.loadSecurity(agentId);
     const resolved = await security.expandSecrets({ ...row.config, enabled: true });
-    const channelsConfig: Record<string, unknown> = { [channelName]: resolved };
     const agentBaseUrl = `${this.opts.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
 
-    const { handle, status } = await startOneChannel(channelName, channelsConfig as never, {
+    const { handle, status } = await startSingleChannel(manifest, resolved, {
       agentBaseUrl,
-      agentTokens: { [channelName]: loaded.token },
+      agentTokens: { [manifest.key]: loaded.token },
       logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
     });
 

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -85,7 +85,7 @@ const parseChannelPackages = (raw: unknown): string[] => {
     if (typeof v !== 'string' || v.trim() === '') {
       throw new Error(`channelPackages[${i}] must be a non-empty string`);
     }
-    return v;
+    return v.trim();
   });
 };
 

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -18,6 +18,12 @@ export interface GatewayConfig {
    * explicit `sandbox` field. `null` (or missing) disables auto-provisioning.
    */
   autoProvisionSandbox: string | null;
+  /**
+   * Additional channel packages to dynamic-import at gateway boot. Each
+   * package must default-export a `ChannelManifest`. External packages
+   * may override a built-in channel by matching its key.
+   */
+  channelPackages: string[];
 }
 
 export const META_KEY = 'gateway.config';
@@ -34,6 +40,7 @@ const DEFAULT_CONFIG: GatewayConfig = {
   cors: { origin: '*' },
   sandboxPresets: DEFAULT_PRESETS,
   autoProvisionSandbox: 'docker-ubuntu',
+  channelPackages: [],
 };
 
 export const defaultGatewayConfig = (): GatewayConfig =>
@@ -67,6 +74,19 @@ const parsePresets = (raw: unknown): Record<string, SandboxPreset> | undefined =
     out[name] = { type: type as SandboxPreset['type'], config };
   }
   return out;
+};
+
+const parseChannelPackages = (raw: unknown): string[] => {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error('channelPackages must be an array of package name strings');
+  }
+  return raw.map((v, i) => {
+    if (typeof v !== 'string' || v.trim() === '') {
+      throw new Error(`channelPackages[${i}] must be a non-empty string`);
+    }
+    return v;
+  });
 };
 
 const parseAutoProvision = (
@@ -107,6 +127,7 @@ export const parseGatewayConfig = (raw: Record<string, unknown>): GatewayConfig 
     },
     sandboxPresets: presets,
     autoProvisionSandbox: autoProvision,
+    channelPackages: parseChannelPackages(raw['channelPackages']),
   };
 };
 

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -40,6 +40,7 @@ import { ChannelPool } from './channel-pool.js';
 import { CentralScheduler } from './central-scheduler.js';
 import { backfillSandboxes } from './sandbox-backfill.js';
 import { createGatewayApp } from './app.js';
+import { buildChannelManifestRegistry } from './channel-manifests.js';
 import { loadGatewayConfig } from './config.js';
 import { attachGatewayWs } from './ws-handler.js';
 import {
@@ -160,6 +161,14 @@ export const main = async (): Promise<void> => {
   );
   logStartup(`config loaded (source: ${configSource})`);
 
+  // Build the channel manifest registry: dynamic-import built-in channel
+  // packages first, then any external packages from config.channelPackages.
+  // External packages may override a built-in by matching its key.
+  const manifestRegistry = await buildChannelManifestRegistry(
+    config.channelPackages,
+    logStartup,
+  );
+
   // Auth configuration (secrets stay in env). ChannelRegistry is seeded
   // by ChannelPool.start() at gateway boot — every channel row (builtin
   // or external) lives in the same agent_channels table and takes the
@@ -167,30 +176,30 @@ export const main = async (): Promise<void> => {
   const channels = new ChannelRegistry();
   if (agentChannelStore) {
     // One-shot backfill: for every existing agent, make sure each
-    // BUILTIN_CHANNELS kind has a row. If the agent's old
+    // registered builtin channel kind has a row. If the agent's old
     // config_json.channels.X document has values, copy them into the
     // new row's config field on first create. Idempotent — runs every
     // boot but only inserts the missing rows.
     if (agentStore && configStore) {
       try {
-        const { BUILTIN_CHANNELS } = await import('@openhermit/agent/core');
+        const builtinKeys = manifestRegistry.keys();
         for (const agent of await agentStore.list()) {
           const legacyConfig = await configStore.getConfig(agent.agentId);
           const legacyChannels = (legacyConfig?.channels ?? {}) as Record<string, Record<string, unknown> | undefined>;
-          for (const def of BUILTIN_CHANNELS) {
-            const existing = await agentChannelStore.findBuiltin(agent.agentId, def.key);
+          for (const key of builtinKeys) {
+            const existing = await agentChannelStore.findBuiltin(agent.agentId, key);
             if (existing) continue;
-            const legacy = legacyChannels[def.key];
+            const legacy = legacyChannels[key];
             const enabled = !!legacy?.enabled;
             const cfg = legacy ? { ...legacy } : {};
             delete (cfg as { enabled?: unknown }).enabled;
             await agentChannelStore.createBuiltin({
               agentId: agent.agentId,
-              channelType: def.key,
+              channelType: key,
               config: cfg,
               enabled,
             });
-            logStartup(`backfilled builtin channel row: ${agent.agentId}/${def.key} (enabled=${enabled})`);
+            logStartup(`backfilled builtin channel row: ${agent.agentId}/${key} (enabled=${enabled})`);
           }
         }
       } catch (err) {
@@ -340,6 +349,7 @@ export const main = async (): Promise<void> => {
     sandboxPresets: config.sandboxPresets,
     autoProvisionSandbox: config.autoProvisionSandbox,
     channelRegistry: channels,
+    manifestRegistry,
     auth,
     adminToken,
     logger: logStartup,
@@ -413,6 +423,7 @@ export const main = async (): Promise<void> => {
         configStore,
         secretStore,
         channelRegistry: channels,
+        manifestRegistry,
         // Channel adapters connect back from inside the host. Use
         // 127.0.0.1 even when the public listener is 0.0.0.0.
         gatewayBaseUrl: `http://127.0.0.1:${info.port}`,


### PR DESCRIPTION
## Summary

Second step of the channel plugin RFC (after #87). Built-ins now go through the same manifest path as external packages.

- Each built-in channel (telegram/slack/discord) default-exports a `ChannelManifest`.
- Gateway boot dynamic-imports the three built-in packages plus any `channelPackages` from config and builds a `ChannelManifestRegistry`.
- `ChannelPool` and `createGatewayApp` consume the registry instead of the hardcoded `BUILTIN_CHANNELS` list.
- `startSingleChannel(manifest, config, context)` replaces the per-channel wrappers in `apps/agent/src/channels.ts`.
- `apps/cli/tsup.config.ts` bundles slack/discord alongside telegram so the CLI keeps embedding the three default channels.

This unblocks PR3 — adding `@openhermit/channel-signal` (from #81) becomes just a new entry in `channelPackages`.

## Test plan

- [x] `npm run typecheck` clean for changed packages (gateway, agent core, channel packages)
- [x] `apps/agent/test/channel-manifest-registry.test.ts` — all 11 cases pass
- [ ] Smoke test on test.openhermit.ai: gateway boots, the three default channels still appear in the admin UI, enabling a Telegram channel still bridges inbound/outbound

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway can load and register channel plugins (builtin and external) via a manifest registry and configurable package list.

* **Refactor**
  * Channel startup/management moved to a manifest-driven plugin model for clearer, per-channel lifecycle handling.

* **Chores**
  * Package manifests and CLI build config updated to reflect optional channel packages and related build behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/88)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->