### PR TITLE
feat(channels): interactive setup contract for QR-link / OAuth flows

### DIFF
--- a/apps/agent/test/channel-setup.test.ts
+++ b/apps/agent/test/channel-setup.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type {
+  ChannelManifest,
+  ChannelSetup,
+  ChannelSetupContext,
+  ChannelSetupState,
+} from '@openhermit/protocol';
+
+// A worked example: a stub Signal-like flow that exercises the full
+// state machine. Plugin authors can use this as a reference shape.
+//
+// Steps:
+//   1. begin({ phone_number }) -> awaiting_external with a fake QR
+//   2. poll(sessionId) until the test "scans" -> done with config
+//   3. cancel drops the session
+class StubSignalSetup implements ChannelSetup {
+  private sessions = new Map<string, { phone: string; scanned: boolean }>();
+
+  async begin(
+    input: Record<string, unknown>,
+    _ctx: ChannelSetupContext,
+  ): Promise<{ sessionId: string; state: ChannelSetupState }> {
+    const phone = String(input.phone_number ?? '').trim();
+    if (!phone) {
+      return {
+        sessionId: 'rejected',
+        state: { kind: 'error', message: 'phone_number is required' },
+      };
+    }
+    const sessionId = `sess-${this.sessions.size + 1}`;
+    this.sessions.set(sessionId, { phone, scanned: false });
+    return {
+      sessionId,
+      state: {
+        kind: 'awaiting_external',
+        instructions: 'Scan this QR in Signal',
+        qrPngBase64: 'iVBORw0KGgo=', // 1-byte stub PNG
+        pollIntervalMs: 1000,
+      },
+    };
+  }
+
+  async poll(
+    sessionId: string,
+    _ctx: ChannelSetupContext,
+  ): Promise<ChannelSetupState> {
+    const sess = this.sessions.get(sessionId);
+    if (!sess) return { kind: 'error', message: 'unknown session' };
+    if (!sess.scanned) {
+      return {
+        kind: 'awaiting_external',
+        instructions: 'Waiting for scan…',
+        pollIntervalMs: 1000,
+      };
+    }
+    return {
+      kind: 'done',
+      config: { phone_number: sess.phone, signal_cli_url: 'http://localhost:8080' },
+    };
+  }
+
+  async cancel(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+  }
+
+  /** Test helper — simulate the user finishing the QR scan. */
+  __markScanned(sessionId: string): void {
+    const sess = this.sessions.get(sessionId);
+    if (sess) sess.scanned = true;
+  }
+}
+
+const ctx: ChannelSetupContext = {
+  agentId: 'agent-1',
+  logger: () => {},
+};
+
+test('ChannelSetup: begin rejects invalid input with error state', async () => {
+  const setup = new StubSignalSetup();
+  const result = await setup.begin({}, ctx);
+  assert.equal(result.state.kind, 'error');
+});
+
+test('ChannelSetup: begin -> poll -> done happy path', async () => {
+  const setup = new StubSignalSetup();
+  const { sessionId, state: first } = await setup.begin({ phone_number: '+1' }, ctx);
+  assert.equal(first.kind, 'awaiting_external');
+  if (first.kind === 'awaiting_external') {
+    assert.ok(first.qrPngBase64);
+    assert.ok(first.pollIntervalMs > 0);
+  }
+
+  const pending = await setup.poll(sessionId, ctx);
+  assert.equal(pending.kind, 'awaiting_external');
+
+  setup.__markScanned(sessionId);
+  const done = await setup.poll(sessionId, ctx);
+  assert.equal(done.kind, 'done');
+  if (done.kind === 'done') {
+    assert.equal(done.config.phone_number, '+1');
+  }
+});
+
+test('ChannelSetup: cancel drops session, subsequent poll errors', async () => {
+  const setup = new StubSignalSetup();
+  const { sessionId } = await setup.begin({ phone_number: '+1' }, ctx);
+  await setup.cancel!(sessionId, ctx);
+  const after = await setup.poll(sessionId, ctx);
+  assert.equal(after.kind, 'error');
+});
+
+test('ChannelManifest: setup is optional', () => {
+  const tokenOnly: ChannelManifest = {
+    manifestVersion: 1,
+    key: 'telegram',
+    namespace: 'telegram',
+    displayName: 'Telegram',
+    start: async () => undefined,
+  };
+  assert.equal(tokenOnly.setup, undefined);
+
+  const interactive: ChannelManifest = {
+    manifestVersion: 1,
+    key: 'signal',
+    namespace: 'signal',
+    displayName: 'Signal',
+    start: async () => undefined,
+    setup: new StubSignalSetup(),
+  };
+  assert.ok(interactive.setup);
+  assert.equal(typeof interactive.setup.begin, 'function');
+  assert.equal(typeof interactive.setup.poll, 'function');
+});

--- a/apps/agent/test/channel-setup.test.ts
+++ b/apps/agent/test/channel-setup.test.ts
@@ -36,7 +36,7 @@ class StubSignalSetup implements ChannelSetup {
       state: {
         kind: 'awaiting_external',
         instructions: 'Scan this QR in Signal',
-        qrPngBase64: 'iVBORw0KGgo=', // 1-byte stub PNG
+        qrText: 'sgnl://linkdevice?uuid=stub&pub_key=stub',
         pollIntervalMs: 1000,
       },
     };
@@ -88,7 +88,7 @@ test('ChannelSetup: begin -> poll -> done happy path', async () => {
   const { sessionId, state: first } = await setup.begin({ phone_number: '+1' }, ctx);
   assert.equal(first.kind, 'awaiting_external');
   if (first.kind === 'awaiting_external') {
-    assert.ok(first.qrPngBase64);
+    assert.ok(first.qrText);
     assert.ok(first.pollIntervalMs > 0);
   }
 

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -13,7 +13,10 @@ import {
   isSessionMessage,
   isToolApprovalRequest,
   isSessionCheckpointRequest,
+  type ChannelManifest,
   type ChannelManifestRegistry,
+  type ChannelSetup,
+  type ChannelSetupContext,
   type CreateAgentRequest,
   type SessionListQuery,
   type SyncResponse,
@@ -2430,6 +2433,88 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     }
     await store.revoke(channelId);
     options.channelRegistry?.unregister(channelId);
+    return c.json({ ok: true });
+  });
+
+  // ─── Channel setup (interactive auth) ──────────────────────────────────
+  //
+  // Drives `ChannelManifest.setup` over HTTP for channels with a
+  // multi-step auth flow (Signal QR-link, OAuth, etc.). The plugin owns
+  // session state keyed by an opaque `sessionId`; these routes just
+  // shuttle bytes between the UI and `manifest.setup.{begin,poll,submit,cancel}`.
+  //
+  // On `state.kind === 'done'`, the UI takes `state.config` and POSTs
+  // it to `/api/agents/:id/channels` (or PATCHes an existing row) — the
+  // setup contract itself does not persist to the DB.
+
+  const lookupChannelSetup = (
+    channelType: string,
+  ): { manifest: ChannelManifest; setup: ChannelSetup } => {
+    const manifest = options.manifestRegistry.get(channelType);
+    if (!manifest) {
+      throw new NotFoundError(`Channel "${channelType}" is not registered.`);
+    }
+    if (!manifest.setup) {
+      throw new ValidationError(
+        `Channel "${channelType}" does not support interactive setup.`,
+      );
+    }
+    return { manifest, setup: manifest.setup };
+  };
+
+  const setupContext = (
+    agentId: string,
+    channelType: string,
+  ): ChannelSetupContext => ({
+    agentId,
+    logger: (msg) => log(`[${agentId}] [${channelType}/setup] ${msg}`),
+  });
+
+  app.post('/api/agents/:agentId/channels/:channelType/setup/begin', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    const channelType = c.req.param('channelType') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const { setup } = lookupChannelSetup(channelType);
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const result = await setup.begin(body, setupContext(agentId, channelType));
+    return c.json(result);
+  });
+
+  app.get('/api/agents/:agentId/channels/:channelType/setup/:sessionId', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    const channelType = c.req.param('channelType') ?? '';
+    const sessionId = c.req.param('sessionId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const { setup } = lookupChannelSetup(channelType);
+    const state = await setup.poll(sessionId, setupContext(agentId, channelType));
+    return c.json({ sessionId, state });
+  });
+
+  app.post('/api/agents/:agentId/channels/:channelType/setup/:sessionId', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    const channelType = c.req.param('channelType') ?? '';
+    const sessionId = c.req.param('sessionId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const { setup } = lookupChannelSetup(channelType);
+    if (!setup.submit) {
+      throw new ValidationError(
+        `Channel "${channelType}" setup does not accept additional input; poll instead.`,
+      );
+    }
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const state = await setup.submit(sessionId, body, setupContext(agentId, channelType));
+    return c.json({ sessionId, state });
+  });
+
+  app.delete('/api/agents/:agentId/channels/:channelType/setup/:sessionId', async (c) => {
+    const agentId = c.req.param('agentId') ?? '';
+    const channelType = c.req.param('channelType') ?? '';
+    const sessionId = c.req.param('sessionId') ?? '';
+    await requireOwnerOrAdmin(c, agentId);
+    const { setup } = lookupChannelSetup(channelType);
+    if (setup.cancel) {
+      await setup.cancel(sessionId, setupContext(agentId, channelType));
+    }
     return c.json({ ok: true });
   });
 

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -121,7 +121,7 @@ export interface ChannelSetup {
 
 export type ChannelSetupState =
   | { kind: 'awaiting_user_input'; instructions?: string; fields: ChannelSetupFieldSpec[] }
-  | { kind: 'awaiting_external'; instructions: string; qrPngBase64?: string; redirectUrl?: string; pollIntervalMs: number }
+  | { kind: 'awaiting_external'; instructions: string; qrText?: string; redirectUrl?: string; pollIntervalMs: number }
   | { kind: 'done'; config: Record<string, unknown> }
   | { kind: 'error'; message: string };
 ```
@@ -147,14 +147,15 @@ UI                           gateway                     manifest.setup
  │                              │                              │ signal-cli-rest-api:
  │                              │                              │   POST /v1/qrcodelink/+1...
  │                              │                              │   ◄── PNG bytes
+ │                              │                              │ decode PNG → sgnl:// URI
  │                              │                              │
  │ { sessionId, state:          │                              │
  │   awaiting_external,         │                              │
- │   qrPngBase64: '...',        │  ◄── { sessionId, state }    │
+ │   qrText: 'sgnl://...',      │  ◄── { sessionId, state }    │
  │   pollIntervalMs: 1000 }     │                              │
  │ ◄──────────────────────────  │                              │
  │                              │                              │
- │ <img src=data:...> renders   │                              │
+ │ <QRCode value={qrText}/>     │                              │
  │ user scans QR in Signal app  │                              │
  │                              │                              │
  │ GET .../setup/:sessionId     │                              │
@@ -178,8 +179,8 @@ Key design choices:
 
 - **Plugin owns session state.** The gateway is stateless; sessions live in the plugin's own `Map<sessionId, State>` for the gateway lifetime. This matches how `start()` plugins already own their in-process state (sockets, pollers). Plugins are responsible for their own timeouts/GC.
 - **Setup does not write the DB.** `done.config` is returned to the UI, which then calls the existing `POST /api/agents/:id/channels` (or PATCH) to persist the row. This keeps the setup contract focused on producing config and leaves the persistence/enable path unchanged.
-- **The UI wizard is generic.** The admin UI switch-renders on `state.kind` — input form, `awaiting_external` (renders QR and/or "open link" button from `qrPngBase64` / `redirectUrl`, polls every `pollIntervalMs`), done, error. No channel-specific UI code. Channels with truly bespoke needs can ship their own admin-UI panel later (out of scope for this contract).
-- **`awaiting_external` covers QR scans, OAuth device flow, and any "open this URL in your browser, finish, we'll poll for you" pattern.** Plugins set `qrPngBase64`, `redirectUrl`, or both. What is explicitly out of scope for v1 is the classic OAuth redirect flow where the provider posts a `code` back to a callback URL the gateway hosts — that needs per-plugin callback routing and is deferred. Channels that support device-flow OAuth (Google, GitHub, Slack via device code) work today; channels that *only* support the redirect flavor cannot use the setup contract yet and must fall back to the existing token-paste path.
+- **The UI wizard is generic.** The admin UI switch-renders on `state.kind` — input form, `awaiting_external` (renders QR and/or "open link" button from `qrText` / `redirectUrl`, polls every `pollIntervalMs`), done, error. No channel-specific UI code. Channels with truly bespoke needs can ship their own admin-UI panel later (out of scope for this contract).
+- **`awaiting_external` covers QR scans, OAuth device flow, and any "open this URL in your browser, finish, we'll poll for you" pattern.** Plugins set `qrText`, `redirectUrl`, or both. What is explicitly out of scope for v1 is the classic OAuth redirect flow where the provider posts a `code` back to a callback URL the gateway hosts — that needs per-plugin callback routing and is deferred. Channels that support device-flow OAuth (Google, GitHub, Slack via device code) work today; channels that *only* support the redirect flavor cannot use the setup contract yet and must fall back to the existing token-paste path.
 - **All fields except `begin` and `poll` are optional.** Plugins with a single-step external flow (just a QR) don't implement `submit`. Plugins with no external resources (sockets, sub-processes) to clean up don't implement `cancel`.
 
 `setup` is itself optional on `ChannelManifest`. Token-only channels (telegram/slack/discord) leave it unset and continue to use the existing "fill the form, save the row, enable" path.

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -100,6 +100,89 @@ Webhook ingress (Telegram secret_token, Slack HMAC, Discord ed25519) lives on th
 
 Existing built-in channels (`telegram`, `slack`, `discord`) are refactored to expose the same default-exported manifest. The `start*` functions and config types already exist; only the export shape changes.
 
+## Interactive Setup
+
+Token-only channels (telegram, slack, discord) start with a known config: the operator pastes a bot token into the admin UI, the row is saved, the channel is enabled. Some channels — Signal (QR-link via [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api)), WhatsApp-Web, anything OAuth — have a multi-step interactive flow that produces the persistent config only *after* the user completes an external action (scanning a QR, granting consent in a browser).
+
+The `setup` field on `ChannelManifest` describes a state machine for this flow:
+
+```ts
+export interface ChannelManifest {
+  // ...existing fields
+  setup?: ChannelSetup;
+}
+
+export interface ChannelSetup {
+  begin: (input, ctx) => Promise<{ sessionId: string; state: ChannelSetupState }>;
+  poll: (sessionId, ctx) => Promise<ChannelSetupState>;
+  submit?: (sessionId, input, ctx) => Promise<ChannelSetupState>;
+  cancel?: (sessionId, ctx) => Promise<void>;
+}
+
+export type ChannelSetupState =
+  | { kind: 'awaiting_user_input'; instructions?: string; fields: ChannelSetupFieldSpec[] }
+  | { kind: 'awaiting_external'; instructions: string; qrPngBase64?: string; pollIntervalMs: number }
+  | { kind: 'done'; config: Record<string, unknown> }
+  | { kind: 'error'; message: string };
+```
+
+The plugin owns its session state, keyed by an opaque `sessionId` it generates in `begin`. The gateway exposes four REST routes that wrap the four methods:
+
+```
+POST   /api/agents/:id/channels/:type/setup/begin              -> { sessionId, state }
+GET    /api/agents/:id/channels/:type/setup/:sessionId         -> { sessionId, state }   (= poll)
+POST   /api/agents/:id/channels/:type/setup/:sessionId         -> { sessionId, state }   (= submit)
+DELETE /api/agents/:id/channels/:type/setup/:sessionId         -> { ok: true }            (= cancel)
+```
+
+A Signal flow looks like:
+
+```text
+UI                           gateway                     manifest.setup
+ │                              │                              │
+ │ POST .../setup/begin         │                              │
+ │ { phone_number: '+1...' }    │                              │
+ │ ──────────────────────────►  │ begin(input, ctx)            │
+ │                              │ ──────────────────────────►  │
+ │                              │                              │ signal-cli-rest-api:
+ │                              │                              │   POST /v1/qrcodelink/+1...
+ │                              │                              │   ◄── PNG bytes
+ │                              │                              │
+ │ { sessionId, state:          │                              │
+ │   awaiting_external,         │                              │
+ │   qrPngBase64: '...',        │  ◄── { sessionId, state }    │
+ │   pollIntervalMs: 1000 }     │                              │
+ │ ◄──────────────────────────  │                              │
+ │                              │                              │
+ │ <img src=data:...> renders   │                              │
+ │ user scans QR in Signal app  │                              │
+ │                              │                              │
+ │ GET .../setup/:sessionId     │                              │
+ │ (every 1s)                   │ poll(sessionId, ctx)         │
+ │ ──────────────────────────►  │ ──────────────────────────►  │
+ │                              │                              │ check linked-device status
+ │ { state: done,               │                              │
+ │   config: {...} }            │  ◄── { kind: 'done', ... }   │
+ │ ◄──────────────────────────  │                              │
+ │                              │                              │
+ │ POST /api/agents/:id/channels                               │
+ │ { namespace: 'signal',       │                              │
+ │   config: <state.config>,    │                              │
+ │   enabled: true }            │                              │
+ │ ──────────────────────────►  │ (existing channel CRUD;      │
+ │                              │  setup contract does NOT     │
+ │                              │  write to the DB itself)     │
+```
+
+Key design choices:
+
+- **Plugin owns session state.** The gateway is stateless; sessions live in the plugin's own `Map<sessionId, State>` for the gateway lifetime. This matches how `start()` plugins already own their in-process state (sockets, pollers). Plugins are responsible for their own timeouts/GC.
+- **Setup does not write the DB.** `done.config` is returned to the UI, which then calls the existing `POST /api/agents/:id/channels` (or PATCH) to persist the row. This keeps the setup contract focused on producing config and leaves the persistence/enable path unchanged.
+- **The UI wizard is generic.** The admin UI switch-renders on `state.kind` — input form, QR + polling, done, error. No channel-specific UI code. Channels with truly bespoke needs can ship their own admin-UI panel later (out of scope for this contract).
+- **All fields except `begin` and `poll` are optional.** Plugins with a single-step external flow (just a QR) don't implement `submit`. Plugins with no external resources (sockets, sub-processes) to clean up don't implement `cancel`.
+
+`setup` is itself optional on `ChannelManifest`. Token-only channels (telegram/slack/discord) leave it unset and continue to use the existing "fill the form, save the row, enable" path.
+
 ## Discovery and Loading
 
 Plugins are loaded from two sources, in order:

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -121,7 +121,7 @@ export interface ChannelSetup {
 
 export type ChannelSetupState =
   | { kind: 'awaiting_user_input'; instructions?: string; fields: ChannelSetupFieldSpec[] }
-  | { kind: 'awaiting_external'; instructions: string; qrPngBase64?: string; pollIntervalMs: number }
+  | { kind: 'awaiting_external'; instructions: string; qrPngBase64?: string; redirectUrl?: string; pollIntervalMs: number }
   | { kind: 'done'; config: Record<string, unknown> }
   | { kind: 'error'; message: string };
 ```
@@ -178,7 +178,8 @@ Key design choices:
 
 - **Plugin owns session state.** The gateway is stateless; sessions live in the plugin's own `Map<sessionId, State>` for the gateway lifetime. This matches how `start()` plugins already own their in-process state (sockets, pollers). Plugins are responsible for their own timeouts/GC.
 - **Setup does not write the DB.** `done.config` is returned to the UI, which then calls the existing `POST /api/agents/:id/channels` (or PATCH) to persist the row. This keeps the setup contract focused on producing config and leaves the persistence/enable path unchanged.
-- **The UI wizard is generic.** The admin UI switch-renders on `state.kind` — input form, QR + polling, done, error. No channel-specific UI code. Channels with truly bespoke needs can ship their own admin-UI panel later (out of scope for this contract).
+- **The UI wizard is generic.** The admin UI switch-renders on `state.kind` — input form, `awaiting_external` (renders QR and/or "open link" button from `qrPngBase64` / `redirectUrl`, polls every `pollIntervalMs`), done, error. No channel-specific UI code. Channels with truly bespoke needs can ship their own admin-UI panel later (out of scope for this contract).
+- **`awaiting_external` covers QR scans, OAuth device flow, and any "open this URL in your browser, finish, we'll poll for you" pattern.** Plugins set `qrPngBase64`, `redirectUrl`, or both. What is explicitly out of scope for v1 is the classic OAuth redirect flow where the provider posts a `code` back to a callback URL the gateway hosts — that needs per-plugin callback routing and is deferred. Channels that support device-flow OAuth (Google, GitHub, Slack via device code) work today; channels that *only* support the redirect flavor cannot use the setup contract yet and must fall back to the existing token-paste path.
 - **All fields except `begin` and `poll` are optional.** Plugins with a single-step external flow (just a QR) don't implement `submit`. Plugins with no external resources (sockets, sub-processes) to clean up don't implement `cancel`.
 
 `setup` is itself optional on `ChannelManifest`. Token-only channels (telegram/slack/discord) leave it unset and continue to use the existing "fill the form, save the row, enable" path.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -439,16 +439,20 @@ export type ChannelSetupState =
       /** Human-readable prompt (e.g. "Scan this QR code in Signal"). */
       instructions: string;
       /**
-       * Base64-encoded PNG of a QR code. Rendered as
-       * `<img src="data:image/png;base64,${qrPngBase64}">`. Used for
-       * scan-from-phone flows (Signal, WeChat web login).
+       * Underlying string (URI, token, anything) for the UI to encode as
+       * a QR code with its own renderer. Used for scan-from-another-device
+       * flows — Signal's `sgnl://linkdevice?...`, WeChat web login, etc.
+       *
+       * Plugins whose upstream only returns a pre-rendered PNG (e.g.
+       * signal-cli-rest-api) decode it once with a QR-decode library and
+       * return the embedded text here.
        */
-      qrPngBase64?: string;
+      qrText?: string;
       /**
-       * URL the user should open in a browser to complete authentication
-       * (OAuth device flow, hosted login pages). Rendered as a button or
-       * link. May be combined with `qrPngBase64` so the same target can
-       * be opened on this device *or* scanned from another.
+       * URL the user should open in *this* browser to complete
+       * authentication (OAuth device flow, hosted login pages). Rendered
+       * as a button or link. May be combined with `qrText` when the same
+       * target can be opened on this device or scanned from another.
        *
        * Note: the gateway does not host a callback endpoint for this URL.
        * Plugins detect completion by polling their own backend; classic

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -440,9 +440,22 @@ export type ChannelSetupState =
       instructions: string;
       /**
        * Base64-encoded PNG of a QR code. Rendered as
-       * `<img src="data:image/png;base64,${qrPngBase64}">`.
+       * `<img src="data:image/png;base64,${qrPngBase64}">`. Used for
+       * scan-from-phone flows (Signal, WeChat web login).
        */
       qrPngBase64?: string;
+      /**
+       * URL the user should open in a browser to complete authentication
+       * (OAuth device flow, hosted login pages). Rendered as a button or
+       * link. May be combined with `qrPngBase64` so the same target can
+       * be opened on this device *or* scanned from another.
+       *
+       * Note: the gateway does not host a callback endpoint for this URL.
+       * Plugins detect completion by polling their own backend; classic
+       * OAuth redirect flows that require an inbound callback are out of
+       * scope for v1.
+       */
+      redirectUrl?: string;
       /** Hint to the UI about how often to poll, in ms. */
       pollIntervalMs: number;
     }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -340,7 +340,8 @@ export interface ChannelManifest {
    * pin a compatible plugin version.
    *
    * Bump policy: add optional fields without bumping; bump on any required
-   * field addition, semantic change, or signature change to `start`.
+   * field addition, semantic change, or signature change to `start` or
+   * `setup`.
    */
   manifestVersion: 1;
   /** Stable key. Matches the DB `channel_type` column and the key under `ChannelsConfig`. */
@@ -363,6 +364,144 @@ export interface ChannelManifest {
    * should not treat as fatal.
    */
   start: (config: unknown, context: ChannelContext) => Promise<ChannelHandle | undefined>;
+  /**
+   * Optional interactive setup machine. Channels that need a multi-step
+   * auth flow (Signal QR-link, WhatsApp pairing, OAuth, etc.) implement
+   * this; the gateway exposes REST routes that drive it and the admin
+   * UI renders a generic wizard from the returned `ChannelSetupState`.
+   *
+   * Token-only channels (telegram/slack/discord) leave this unset — the
+   * existing "fill the secrets form, save the row" path keeps working.
+   */
+  setup?: ChannelSetup;
+}
+
+// ─── Channel setup contract ──────────────────────────────────────────────
+//
+// The setup machine runs *before* a channel row's persistent config is
+// written. The plugin owns its own session state (keyed by an opaque
+// `sessionId` it generates in `begin`); the gateway only routes HTTP
+// calls into it and shuttles `ChannelSetupState` back to the UI.
+//
+// Lifecycle (driven by the UI):
+//   1. UI POSTs initial input  -> manifest.setup.begin()  -> { sessionId, state }
+//   2. UI renders `state` and either:
+//        - polls (state.kind === 'awaiting_external')      -> manifest.setup.poll()
+//        - collects more input (state.kind === 'awaiting_user_input') -> manifest.setup.submit()
+//   3. On `state.kind === 'done'`, the UI takes `state.config` and POSTs
+//      it to the existing `POST /api/agents/:id/channels` (or PATCH) to
+//      persist the channel row. The setup session is then dropped.
+//   4. UI may DELETE the session at any time -> manifest.setup.cancel().
+//
+// Session lifetime is the plugin's responsibility; the gateway should
+// surface a sensible default (e.g. 10 min) but does not enforce it.
+
+/** Context passed to every setup method. */
+export interface ChannelSetupContext {
+  /** Agent the setup is running for. */
+  agentId: string;
+  /** Per-session logger (prefixed with channel key + agent id by caller). */
+  logger: (message: string) => void;
+}
+
+/**
+ * A single form field the UI should render during an `awaiting_user_input`
+ * step. The shape is intentionally narrow — channels with truly bespoke
+ * UI needs are expected to ship their own admin-UI plugin in a future
+ * iteration of the spec.
+ */
+export interface ChannelSetupFieldSpec {
+  /** Field name; becomes a key in the input object passed to `submit()`. */
+  key: string;
+  /** Human-readable label rendered next to the input. */
+  label: string;
+  /** Input semantics. `password` masks the value. */
+  type: 'text' | 'phone' | 'password' | 'number';
+  required?: boolean;
+  placeholder?: string;
+  /** Optional help text rendered below the field. */
+  help?: string;
+}
+
+/**
+ * What the UI should show / do next. Returned by every setup method.
+ * Discriminated by `kind` so the UI can switch-render.
+ */
+export type ChannelSetupState =
+  | {
+      kind: 'awaiting_user_input';
+      /** Human-readable prompt rendered above the form. */
+      instructions?: string;
+      fields: ChannelSetupFieldSpec[];
+    }
+  | {
+      kind: 'awaiting_external';
+      /** Human-readable prompt (e.g. "Scan this QR code in Signal"). */
+      instructions: string;
+      /**
+       * Base64-encoded PNG of a QR code. Rendered as
+       * `<img src="data:image/png;base64,${qrPngBase64}">`.
+       */
+      qrPngBase64?: string;
+      /** Hint to the UI about how often to poll, in ms. */
+      pollIntervalMs: number;
+    }
+  | {
+      kind: 'done';
+      /**
+       * The final channel config to persist. The UI takes this and
+       * POSTs it to `/api/agents/:id/channels` (or PATCHes an existing
+       * row) — the setup contract itself does not write to the DB.
+       */
+      config: Record<string, unknown>;
+    }
+  | {
+      kind: 'error';
+      /** Operator-facing message; UI renders verbatim. */
+      message: string;
+    };
+
+/**
+ * Interactive setup machine for a channel. All methods are optional except
+ * `begin` and `poll`; `submit` is only needed when the flow has more than
+ * one user-input step, and `cancel` only when the plugin holds external
+ * resources (sockets, daemon processes) it needs to clean up.
+ */
+export interface ChannelSetup {
+  /**
+   * Open a new setup session. Returns the plugin-chosen `sessionId`
+   * (used by all subsequent calls) and the first `ChannelSetupState`
+   * to show. Most flows start with `awaiting_user_input` to collect
+   * a phone number / account name.
+   */
+  begin: (
+    input: Record<string, unknown>,
+    ctx: ChannelSetupContext,
+  ) => Promise<{ sessionId: string; state: ChannelSetupState }>;
+  /**
+   * Re-check the session's state. Called by the UI on a timer while
+   * `awaiting_external` (e.g. polling for QR scan completion). Plugins
+   * with no async progress can return the same state until something
+   * changes.
+   */
+  poll: (
+    sessionId: string,
+    ctx: ChannelSetupContext,
+  ) => Promise<ChannelSetupState>;
+  /**
+   * Advance the session with new user input. Called when the UI
+   * submits the form fields from an `awaiting_user_input` step.
+   */
+  submit?: (
+    sessionId: string,
+    input: Record<string, unknown>,
+    ctx: ChannelSetupContext,
+  ) => Promise<ChannelSetupState>;
+  /**
+   * Drop in-progress session state. Called on explicit UI cancel; the
+   * gateway also calls this on session timeout. Should be idempotent.
+   */
+  cancel?: (sessionId: string, ctx: ChannelSetupContext) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Rebased onto main (was #89, auto-closed when its stacked base was deleted by #88's merge). Adds an optional `setup` state machine on `ChannelManifest` for channels with multi-step auth (Signal QR-link, WhatsApp pairing, OAuth, …). Token-only channels (telegram/slack/discord) leave it unset and keep working as today.

- New protocol types: `ChannelSetup`, `ChannelSetupContext`, `ChannelSetupFieldSpec`, `ChannelSetupState`. `manifestVersion` stays at 1 (purely additive optional field).
- `awaiting_external` carries `qrText?` (string the UI renders as a QR via its own library — Signal `sgnl://`, WeChat web login) and/or `redirectUrl?` (URL the user opens in *this* browser — OAuth device flow, hosted pages). Plugins set whichever fits; both can be set when the same target works both ways.
- Gateway exposes four routes that wrap the four methods, all behind `requireOwnerOrAdmin`:
  - `POST   /api/agents/:id/channels/:type/setup/begin`
  - `GET    /api/agents/:id/channels/:type/setup/:sessionId`
  - `POST   /api/agents/:id/channels/:type/setup/:sessionId`
  - `DELETE /api/agents/:id/channels/:type/setup/:sessionId`
- Plugin owns session state keyed by an opaque `sessionId`. On `state.kind === 'done'` the UI posts `state.config` to the existing channel CRUD — the setup contract never writes to the DB itself.
- Out of scope for v1: classic OAuth redirect flow with a gateway-hosted callback URL. Documented as a follow-up.

## Test plan

- [x] `npm run typecheck` clean for protocol and gateway
- [x] `apps/agent/test/channel-setup.test.ts` — 4 cases pass (begin error, begin → poll → done, cancel, setup-is-optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive channel setup workflow with begin, poll, submit, and cancel operations.
  * New API endpoints now support channel setup management with owner/admin authentication.
  * Channel plugins can optionally implement setup state machines for user configuration flows.

* **Documentation**
  * Interactive setup design documentation added, including REST endpoint specifications and example QR-based flows.

* **Tests**
  * Comprehensive test coverage for setup state machine lifecycle and session management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->