### PR TITLE
chore(channels-wechat): prepare 0.1.0 for npm publish

### DIFF
--- a/apps/channels/wechat/LICENSE
+++ b/apps/channels/wechat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenHermit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,17 +1,53 @@
 {
   "name": "@openhermit/channel-wechat",
-  "private": true,
   "version": "0.1.0",
+  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text-only v0.",
+  "license": "MIT",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HCF-STUDIOS/openhermit.git",
+    "directory": "apps/channels/wechat"
+  },
+  "homepage": "https://github.com/HCF-STUDIOS/openhermit/tree/main/apps/channels/wechat",
+  "bugs": "https://github.com/HCF-STUDIOS/openhermit/issues",
+  "keywords": [
+    "openhermit",
+    "channel",
+    "wechat",
+    "weixin",
+    "ilink",
+    "chatbot"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "ilink_appid": "",
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "prepublishOnly": "npm run build",
+    "prepack": "node scripts/strip-dev-condition.mjs",
+    "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.7",
-    "@openhermit/shared": "0.2.0"
+    "@openhermit/sdk": "^0.3.9"
   }
 }

--- a/apps/channels/wechat/scripts/restore-package-json.mjs
+++ b/apps/channels/wechat/scripts/restore-package-json.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// postpack: restore package.json from the backup written by prepack.
+import { existsSync, renameSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+if (existsSync(backupPath)) {
+  renameSync(backupPath, pkgPath);
+  console.log('[channel-wechat] restored package.json after publish');
+}

--- a/apps/channels/wechat/scripts/strip-dev-condition.mjs
+++ b/apps/channels/wechat/scripts/strip-dev-condition.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// prepack: back up package.json and remove the `development` export
+// condition so the published tarball only exposes built artifacts.
+// Restored by scripts/restore-package-json.mjs in postpack.
+import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+copyFileSync(pkgPath, backupPath);
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const dot = pkg.exports?.['.'];
+if (dot && typeof dot === 'object' && 'development' in dot) {
+  delete dot.development;
+}
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log('[channel-wechat] stripped development export condition for publish');

--- a/apps/channels/wechat/tsconfig.json
+++ b/apps/channels/wechat/tsconfig.json
@@ -6,8 +6,7 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "references": [
-    { "path": "../../../packages/sdk" },
-    { "path": "../../../packages/shared" }
+    { "path": "../../../packages/sdk" }
   ],
   "include": [
     "src"

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,16 +104,10 @@
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
       "version": "0.1.0",
-      "dependencies": {
-        "@openhermit/sdk": "0.3.7",
-        "@openhermit/shared": "0.2.0"
-      }
-    },
-    "apps/channels/wechat/node_modules/@openhermit/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
       "license": "MIT",
+      "dependencies": {
+        "@openhermit/sdk": "^0.3.9"
+      },
       "engines": {
         "node": ">=20"
       }


### PR DESCRIPTION
## Summary

- Drop `"private": true` on `@openhermit/channel-wechat`; add license, repository, homepage, keywords, engines, `publishConfig.access=public`.
- Switch `main` to compiled `dist/index.js`; keep a `development` export condition for monorepo dev (tsx loads `src/index.ts` via `-C development`).
- `files` allowlist ships JS + .map + README + LICENSE only (no `.d.ts`, since the package imports types from the private `@openhermit/protocol`).
- Drop unused `@openhermit/shared` runtime dep; bump `@openhermit/sdk` to `^0.3.9`.
- Add `prepack`/`postpack` scripts that strip the `development` export condition before publish — mirrors `packages/sdk`.
- Add MIT LICENSE.

After merge: `cd apps/channels/wechat && npm publish`.

## Test plan

- [x] `npm run build` produces `dist/index.js` with the manifest as default export.
- [x] `npm pack --dry-run` shows 19 files, 16.7 kB tarball, `development` condition stripped at pack time, restored after.
- [x] Monorepo gateway dev (`tsx -C development`) still resolves the package via the `development` condition.
- [ ] Post-publish: `npm install @openhermit/channel-wechat` in a fresh dir resolves cleanly without `@openhermit/shared` or `@openhermit/protocol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added MIT License with copyright attribution
  * Reorganized package entry points for development and production environments
  * Added package management scripts
  * Updated dependencies and modified package references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->