### PR TITLE
feat(admin): channelPackages config + bump sdk 0.4.0 / cli 0.7.0

### DIFF
--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.7",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.7",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.7",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -48,6 +48,6 @@
     "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "^0.3.9"
+    "@openhermit/sdk": "^0.4.0"
   }
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.6.11",
+  "version": "0.7.0",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.3.8",
+    "@openhermit/sdk": "0.4.0",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/apps/gateway/ui/src/components/GatewayConfigPanel.tsx
+++ b/apps/gateway/ui/src/components/GatewayConfigPanel.tsx
@@ -6,6 +6,8 @@ interface GatewayConfig {
   cors?: { origin?: string };
   sandboxPresets?: Record<string, { type: string; config: Record<string, unknown> }>;
   autoProvisionSandbox?: string | null;
+  /** npm package names to dynamic-import as channel plugins at boot. */
+  channelPackages?: string[];
 }
 
 interface ConfigResponse {
@@ -26,6 +28,7 @@ export function GatewayConfigPanel() {
   const [autoProvision, setAutoProvision] = useState('');
   const [presetsText, setPresetsText] = useState('');
   const [presetsError, setPresetsError] = useState('');
+  const [channelPackagesText, setChannelPackagesText] = useState('');
 
   const applyConfig = useCallback((cfg: GatewayConfig) => {
     setConfig(cfg);
@@ -33,6 +36,7 @@ export function GatewayConfigPanel() {
     setAutoProvision(cfg.autoProvisionSandbox ?? '');
     setPresetsText(JSON.stringify(cfg.sandboxPresets ?? {}, null, 2));
     setPresetsError('');
+    setChannelPackagesText((cfg.channelPackages ?? []).join('\n'));
   }, []);
 
   const load = useCallback(async () => {
@@ -67,11 +71,17 @@ export function GatewayConfigPanel() {
       return;
     }
 
+    const channelPackages = channelPackagesText
+      .split(/[\n,]/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+
     const next: GatewayConfig = {
       ...(config ?? {}),
       cors: { origin: corsOrigin },
       sandboxPresets: presets as GatewayConfig['sandboxPresets'],
       autoProvisionSandbox: autoProvision.trim() === '' ? null : autoProvision.trim(),
+      channelPackages,
     };
     // Never send `ui: false` — server rejects it anyway.
     delete next.ui;
@@ -134,6 +144,24 @@ export function GatewayConfigPanel() {
             onChange={(e) => setAutoProvision(e.target.value)}
             placeholder="(empty = disabled)"
           />
+        </label>
+
+        <label className="field">
+          <span className="field__label">Channel packages</span>
+          <textarea
+            className="field__input"
+            value={channelPackagesText}
+            onChange={(e) => setChannelPackagesText(e.target.value)}
+            rows={3}
+            spellCheck={false}
+            placeholder="@openhermit/channel-wechat"
+            style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+          />
+          <span style={{ fontSize: 12, color: 'var(--muted)', marginTop: 4 }}>
+            One npm package name per line (or comma-separated). Each must default-export a
+            ChannelManifest. Install with <code>npm install &lt;pkg&gt;</code> in the gateway
+            install dir, then list it here. Restart required.
+          </span>
         </label>
 
         <label className="field">

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,56 +49,29 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.7",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
-      }
-    },
-    "apps/channels/discord/node_modules/@openhermit/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "apps/channels/slack": {
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.7",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
-      }
-    },
-    "apps/channels/slack/node_modules/@openhermit/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "apps/channels/telegram": {
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.3.7",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
-      }
-    },
-    "apps/channels/telegram/node_modules/@openhermit/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "apps/channels/wechat": {
@@ -106,7 +79,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@openhermit/sdk": "^0.3.9"
+        "@openhermit/sdk": "^0.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -114,7 +87,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -147,22 +120,12 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.3.8",
+        "@openhermit/sdk": "0.4.0",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
         "tsup": "^8.5.1"
       },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "apps/cli/node_modules/@openhermit/sdk": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.8.tgz",
-      "integrity": "sha512-7v6ien53PtogvyXvJadiFohyP6yZyqbzglOCKz1sAuC0fmn2eFXlMo/GQuabAVpFASDzbPAqmiFYeNMew/q9yA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       }
@@ -11245,7 +11208,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- /admin/config now exposes a **Channel packages** textarea so operators can register external channel plugins (e.g. `@openhermit/channel-wechat`) without editing files. Gateway already parses the field; this just surfaces it.
- Bump `@openhermit/sdk` **0.3.9 → 0.4.0** (minor — adds channel manifest types + setup contract now shipped on the public SDK).
- Bump `openhermit` (CLI) **0.6.11 → 0.7.0** to match the SDK minor.
- Sync all channel apps' workspace SDK refs to 0.4.0.

## Test plan
- [ ] `npx vite build apps/gateway/ui` succeeds (verified locally)
- [ ] On test server: pull, rebuild gateway UI (dist is gitignored), restart gateway
- [ ] Open /admin/config → "Channel packages" field is visible, persists across save/reload
- [ ] Publish `@openhermit/sdk@0.4.0` and `openhermit@0.7.0` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added channel packages configuration support to the Gateway admin panel, enabling users to manage channel packages directly.

* **Chores**
  * Updated SDK to version 0.4.0 across all channel integrations.
  * Bumped CLI version to 0.7.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/94)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->