### PR TITLE
feat(cli): hermit channel install/uninstall/list

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -19,6 +19,7 @@ import { registerSandboxCommand } from './commands/sandbox.js';
 import { registerMcpCommand } from './commands/mcp.js';
 import { registerStatsCommand } from './commands/stats.js';
 import { registerInstructionsCommand } from './commands/instructions.js';
+import { registerChannelsCommand } from './commands/channels.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
@@ -49,5 +50,6 @@ registerSandboxCommand(program);
 registerMcpCommand(program);
 registerStatsCommand(program);
 registerInstructionsCommand(program);
+registerChannelsCommand(program);
 
 await program.parseAsync(process.argv);

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -1,0 +1,126 @@
+import { spawn } from 'node:child_process';
+
+import type { Command } from 'commander';
+
+import { createGateway, handleError } from './shared.js';
+
+/**
+ * Pull the bare package name out of an npm install spec.
+ * Accepts `name`, `name@version`, `@scope/name`, `@scope/name@version`.
+ * Rejects URL / git / file specs — `channelPackages` needs a name Node can `import()`.
+ */
+const parsePackageName = (spec: string): string => {
+  if (spec.includes('://') || spec.startsWith('file:') || spec.startsWith('git:') || spec.startsWith('github:')) {
+    throw new Error(
+      `URL / git / file install specs aren't supported here — install with \`npm install -g <spec>\` ` +
+      `and then \`hermit gateway config set channelPackages '["<package-name>"]'\` directly.`,
+    );
+  }
+  if (spec.startsWith('@')) {
+    const slash = spec.indexOf('/');
+    if (slash === -1) throw new Error(`Invalid scoped package spec: ${spec}`);
+    const rest = spec.slice(slash + 1);
+    const at = rest.indexOf('@');
+    const name = at === -1 ? rest : rest.slice(0, at);
+    return `${spec.slice(0, slash)}/${name}`;
+  }
+  const at = spec.indexOf('@');
+  return at === -1 ? spec : spec.slice(0, at);
+};
+
+const runNpm = (args: string[]): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const child = spawn('npm', args, { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`npm ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+
+const readChannelPackages = async (): Promise<{ config: Record<string, unknown>; packages: string[] }> => {
+  const gateway = createGateway();
+  const { config } = await gateway.getGatewayConfig();
+  const raw = (config as Record<string, unknown>).channelPackages;
+  const packages = Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
+  return { config: config as Record<string, unknown>, packages };
+};
+
+const writeChannelPackages = async (config: Record<string, unknown>, packages: string[]): Promise<void> => {
+  const gateway = createGateway();
+  await gateway.putGatewayConfig({ ...config, channelPackages: packages });
+};
+
+export const registerChannelsCommand = (program: Command): void => {
+  const ch = program
+    .command('channel')
+    .alias('channels')
+    .description('Install and manage channel plugin packages (npm-based).');
+
+  ch.command('install <pkg>')
+    .description(
+      'Install a channel plugin: runs `npm install -g <pkg>` then appends the package name to ' +
+      'the gateway `channelPackages` config. Restart the gateway to load it.',
+    )
+    .action(async (spec: string) => {
+      try {
+        const name = parsePackageName(spec);
+        await runNpm(['install', '-g', spec]);
+        const { config, packages } = await readChannelPackages();
+        if (packages.includes(name)) {
+          console.log(`\n${name} is already in channelPackages — config unchanged.`);
+        } else {
+          await writeChannelPackages(config, [...packages, name]);
+          console.log(`\nAdded ${name} to channelPackages.`);
+        }
+        console.log('\nRestart the gateway for the change to take effect:');
+        console.log('  hermit gateway stop && hermit gateway start');
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  ch.command('uninstall <pkg>')
+    .alias('remove')
+    .description(
+      'Uninstall a channel plugin: removes it from the gateway `channelPackages` config and ' +
+      'runs `npm uninstall -g <pkg>`. Restart the gateway to drop it.',
+    )
+    .action(async (spec: string) => {
+      try {
+        const name = parsePackageName(spec);
+        const { config, packages } = await readChannelPackages();
+        const removed = packages.includes(name);
+        if (removed) {
+          await writeChannelPackages(config, packages.filter((p) => p !== name));
+        }
+        await runNpm(['uninstall', '-g', name]);
+        if (removed) {
+          console.log(`\nRemoved ${name} from channelPackages.`);
+        } else {
+          console.log(`\n${name} was not in channelPackages — config unchanged.`);
+        }
+        console.log('\nRestart the gateway for the change to take effect:');
+        console.log('  hermit gateway stop && hermit gateway start');
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  ch.command('list')
+    .alias('ls')
+    .description('List the npm packages currently registered as channel plugins.')
+    .action(async () => {
+      try {
+        const { packages } = await readChannelPackages();
+        if (packages.length === 0) {
+          console.log('No channel packages registered.');
+          console.log('Add one with: hermit channel install <pkg>');
+          return;
+        }
+        for (const p of packages) console.log(p);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+};

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -28,9 +28,17 @@ Newer adapters may exist (e.g., Signal); the *Manage → Channels* tab is the so
 
 ## 17.2 Managing Channels
 
-The current CLI does not include a `hermit channels` command. Configure channels in *Manage → Channels* or through the `/api/agents/<agent-id>/channels` API.
+Per-agent channel configuration (enabling Telegram, setting Discord bot tokens, issuing webhook tokens, etc.) lives in *Manage → Channels* or under the `/api/agents/<agent-id>/channels` API. The API lists configured channels, creates owner-issued external channels, patches existing channel config (`enabled`, secrets, and adapter options), and deletes channels. Built-in channels such as Telegram, Discord, and Slack are seeded as channel rows and are enabled by patching their config.
 
-The API lists configured channels, creates owner-issued external channels, patches existing channel config (`enabled`, secrets, and adapter options), and deletes channels. Built-in channels such as Telegram, Discord, and Slack are seeded as channel rows and are enabled by patching their config.
+To install or remove **gateway-wide channel plugins** (npm packages that contribute new channel types), use the `hermit channel` command:
+
+```bash
+hermit channel install <pkg>      # npm install -g <pkg> + append to channelPackages
+hermit channel uninstall <pkg>    # remove from channelPackages + npm uninstall -g <pkg>
+hermit channel list               # show registered channel packages
+```
+
+A gateway restart (`hermit gateway stop && hermit gateway start`) is required for plugin changes to take effect.
 
 ---
 

--- a/docs/manual/19-cli-cheatsheet.md
+++ b/docs/manual/19-cli-cheatsheet.md
@@ -93,7 +93,13 @@ hermit mcp disable <name> [--agent <id>|--all]
 
 ## 19.7 Channels
 
-There is no `hermit channels` command in the current CLI. Configure channels in *Manage → Channels* or through the `/api/agents/<id>/channels` API.
+```bash
+hermit channel install   <pkg>    # npm install -g <pkg> + add to channelPackages
+hermit channel uninstall <pkg>    # remove from channelPackages + npm uninstall -g <pkg>
+hermit channel list
+```
+
+Restart the gateway after install/uninstall. Per-agent channel config (enabling Telegram, issuing webhook tokens, etc.) lives in *Manage → Channels* or under `/api/agents/<id>/channels`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `hermit channel install <pkg>` — runs `npm install -g <pkg>` then appends the bare package name to the gateway's `channelPackages` config (deduped).
- Adds `hermit channel uninstall <pkg>` — removes the package from `channelPackages` first (so a partial `npm uninstall` leaves no phantom entry), then runs `npm uninstall -g <pkg>`.
- Adds `hermit channel list` to show the currently registered channel packages.
- Closes a gap from the channel-plugin design doc (`docs/channel-plugin-design.md:248`) — this command was planned for PR2 but never landed.
- Manual updated; the "no `hermit channels` command" note is gone.

## Test plan
- [x] `hermit channel --help` shows install / uninstall / list
- [x] `npm -w openhermit run typecheck` passes
- [ ] On test server (CLI 0.7.0 published or via `dev:cli`): `hermit channel install @openhermit/channel-wechat` adds it to config; `hermit channel uninstall @openhermit/channel-wechat` removes it
- [ ] Scoped + versioned spec like `@openhermit/channel-wechat@^0.1.0` adds the bare name (`@openhermit/channel-wechat`) to config
- [ ] `hermit channel list` matches `hermit gateway config get channelPackages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI commands to install, uninstall, and list gateway-wide channel plugins.
  * Gateway restart now required after plugin changes to take effect.

* **Documentation**
  * Updated channel configuration guide with CLI command instructions.
  * Updated CLI cheatsheet with new channel management commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->