### PR TITLE
docs(channels): refresh channel architecture + manual for plugin loading

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ PostgreSQL stores (Drizzle)
 | `apps/agent` | Agent loop, prompt assembly, tools, sessions, events, introspection, compaction, MCP client manager |
 | `apps/cli` | Setup, gateway lifecycle, agent management, chat TUI, config/secrets, schedules, logs/status |
 | `apps/web` | Standalone end-user chat web app |
-| `apps/channels/*` | Telegram, Discord, and Slack bridges |
+| `apps/channels/*` | Bundled bridges (Telegram, Discord, Slack) plus external plugins (e.g. `@openhermit/channel-wechat`) — all loaded uniformly through the `ChannelManifestRegistry` |
 | `packages/protocol` | Shared contracts and route builders |
 | `packages/sdk` | HTTP/SSE/WebSocket clients used by CLI/channels |
 | `packages/store` | Drizzle schema and PostgreSQL store implementations |
@@ -87,7 +87,7 @@ On startup, the gateway:
 3. opens PostgreSQL stores if `DATABASE_URL` is available
 4. scans and registers built-in skills from `skills/`
 5. starts the Hono server and WebSocket handler
-6. boots the channel pool — bridges (Telegram/Slack/Discord) attach to gateway HTTP routes; runners hydrate lazily on first inbound traffic
+6. loads the `ChannelManifestRegistry` — bundled defaults (Telegram/Slack/Discord) plus any plugin packages named in `gateway.config.channelPackages` (e.g. `@openhermit/channel-wechat`) — and boots the channel pool, attaching each adapter's webhook handler to gateway HTTP routes; runners hydrate lazily on first inbound traffic
 
 Agents hydrate on demand: the first request that targets an agent constructs its `AgentRunner`, syncs enabled skills into the sandbox via `runner.syncSkills`, attaches existing channel outbounds from the pool, and connects enabled MCP servers lazily through the runner. Schedules fire from a single gateway-level `CentralScheduler` that hydrates the target runner on demand at fire time. Idle runners are evicted by an LRU after `OPENHERMIT_EVICTION_TTL_MINUTES`; channel bridges in the pool stay alive across eviction.
 
@@ -143,7 +143,7 @@ Agent access can be `public`, `protected`, or `private`. `protected` requires th
 
 - **Tools:** built-in toolsets plus dynamically connected MCP tools
 - **Skills:** prompt instructions and supporting files, registered in DB and synced into each backend's sandbox via `runner.syncSkills`
-- **Channels:** Telegram, Discord, Slack built-ins plus channel-token support for external adapters
+- **Channels:** Telegram, Discord, Slack as bundled built-ins; additional adapters loaded as npm plugins via `channelPackages` (e.g. `@openhermit/channel-wechat`). All registered through the `ChannelManifestRegistry`. See [`channel-adapter.md`](channel-adapter.md) and [`channel-plugin-design.md`](channel-plugin-design.md).
 - **Schedules:** cron/once jobs that post prompts into dedicated or configured sessions
 - **Web providers:** Defuddle, Exa, Tavily
 

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -1,14 +1,28 @@
 # Channel Adapters
 
-OpenHermit includes built-in Telegram, Discord, and Slack adapters. At gateway boot the `ChannelPool` (`apps/gateway/src/channel-pool.ts`) starts every enabled adapter for every agent with `agents.status='active'` and registers scoped channel tokens so adapters can call back into `/api/agents/{agentId}/...`. Bridges are owned by the gateway, not by the per-agent runner — they stay alive across runner eviction and only tear down on gateway shutdown, agent disable, or explicit `disableChannel`. When an inbound message arrives, the gateway hydrates the runner on demand before dispatching.
+A **channel** is an npm package that default-exports a `ChannelManifest` (`packages/protocol/src/index.ts`) describing how to talk to an external messaging platform. At gateway boot, the `ChannelManifestRegistry` (`apps/gateway/src/channel-manifests.ts`) registers every manifest — bundled defaults plus any package named in `gateway.config.channelPackages` — and the `ChannelPool` (`apps/gateway/src/channel-pool.ts`) starts every enabled adapter for every agent with `agents.status='active'`, registering scoped channel tokens so adapters can call back into `/api/agents/{agentId}/...`. Bridges are owned by the gateway, not by the per-agent runner — they stay alive across runner eviction and only tear down on gateway shutdown, agent disable, or explicit `disableChannel`. When an inbound message arrives, the gateway hydrates the runner on demand before dispatching.
 
-## Implemented Adapters
+For the design rationale behind manifests, see [`channel-plugin-design.md`](channel-plugin-design.md).
+
+## Bundled Adapters
+
+These ship inside the CLI binary and are registered automatically:
 
 | Platform | Package | Connection |
 |----------|---------|------------|
 | Telegram | `@openhermit/channel-telegram` | polling or webhook |
 | Discord | `@openhermit/channel-discord` | Discord gateway via `discord.js` |
 | Slack | `@openhermit/channel-slack` | Slack Socket Mode |
+
+## External Plugin Adapters
+
+These are not bundled. Operators install them with `hermit channel install <pkg>` (or `npm install -g <pkg>` followed by adding to `channelPackages`); the gateway dynamic-imports each package at boot:
+
+| Platform | Package | Connection |
+|----------|---------|------------|
+| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
+
+External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
 
 ## Session Routing
 
@@ -48,7 +62,20 @@ Adapters register `ChannelOutbound` implementations. The `session_send` tool can
 
 ## Configuration
 
-Channels are stored in the `agent_channels` table (config + encrypted token columns) and managed through the admin UI, CLI (`hermit channels ...`), or the REST routes below. Tokens never live in `config.json`; they are encrypted at rest and decrypted only when an adapter starts.
+Channels are stored in the `agent_channels` table and managed through the admin UI (*Manage → Channels*) or the REST routes below. The row has two distinct credential slots:
+
+- **`config` (jsonb, plaintext)** — adapter-specific credentials the channel uses to reach the *upstream* platform (Telegram bot token, Slack bot/app tokens, WeChat `bot_token` + `base_url` from iLink, etc.). These are stored as plaintext jsonb today; treat the database itself as the security boundary.
+- **`token_ciphertext` (text, AES-256-GCM)** — the bearer token OpenHermit *issues* to that channel, used by webhook ingress (`POST /api/agents/.../channels/.../webhook`) and by adapters calling back into the gateway API. Encrypted at rest with `OPENHERMIT_SECRETS_KEY` and decrypted only when an adapter starts.
+
+To install or remove gateway-wide channel plugins (npm packages contributing new channel types), use:
+
+```bash
+hermit channel install   <pkg>    # npm install -g <pkg> + append to channelPackages
+hermit channel uninstall <pkg>    # remove from channelPackages + npm uninstall -g <pkg>
+hermit channel list
+```
+
+A gateway restart is required for plugin changes to take effect. The `channelPackages` array is also editable via `hermit gateway config set channelPackages '[...]'` or directly in *Admin → Gateway Config*.
 
 ## Runtime Management API
 
@@ -62,7 +89,27 @@ Channels are stored in the `agent_channels` table (config + encrypted token colu
 
 These routes require owner or admin auth.
 
-## Webhook Ingress
+## Interactive Setup (QR Scan, OAuth Device Flow)
+
+Token-paste channels (Telegram, Discord, Slack) start with a known `config` — the operator pastes a bot token and saves the row. Channels whose credentials are only obtainable after an external action — WeChat QR scan, Signal device-link, OAuth device flow — implement the optional `ChannelManifest.setup` state machine. The contract lives in `packages/protocol/src/index.ts` (`ChannelSetup`, `ChannelSetupState`) and is wrapped by four gateway routes:
+
+```
+POST   /api/agents/:id/channels/:type/setup/begin              -> { sessionId, state }
+GET    /api/agents/:id/channels/:type/setup/:sessionId         -> { sessionId, state }   (poll)
+POST   /api/agents/:id/channels/:type/setup/:sessionId         -> { sessionId, state }   (submit)
+DELETE /api/agents/:id/channels/:type/setup/:sessionId         -> { ok: true }            (cancel)
+```
+
+The UI switch-renders on `state.kind`:
+
+- `awaiting_user_input` — form (e.g. phone number for Signal)
+- `awaiting_external` — render `qrText` as a QR code, or surface `redirectUrl` as a button; poll every `pollIntervalMs`
+- `done` — the UI takes `state.config` and POSTs / PATCHes it onto the channel row via the existing CRUD API (the setup contract itself does **not** write to the DB)
+- `error` — display `message` verbatim
+
+Session state lives in-process inside the plugin (`Map<sessionId, ...>`); the gateway is stateless. Sessions are bounded by a plugin-chosen TTL (WeChat: 5 min; Signal: 10 min). On gateway restart, in-flight setup sessions are lost — the UI restarts the wizard. **Completed setups survive restart** because the durable credentials live on the channel row, not in the setup session: WeChat's `bot_token` (and any equivalent long-lived credential a setup flow produces) is reloaded from `agent_channels.config` and used to re-establish the upstream connection without re-scanning.
+
+
 
 For platforms that push updates over HTTPS (e.g. Telegram in webhook
 mode, Slack Events API, Discord Interactions), the gateway exposes a
@@ -121,3 +168,10 @@ Slack:
 - channel, DM, and thread metadata
 - deduplicates paired message/app-mention events
 - optional `allowed_channel_ids`
+
+WeChat (external plugin):
+
+- iLink long-poll loop on `bot_token` — no per-message webhook
+- QR-link setup wizard exchanges scan+confirmation for `bot_token` + IDC-pinned `base_url`; both persist on the channel row
+- text-only v0 (no media, no group filtering)
+- `errcode === -14` from `getUpdates` is treated as long-poll cursor reset, **not** auth failure

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -1,6 +1,6 @@
-# Channel Plugin Architecture (Design Draft)
+# Channel Plugin Architecture
 
-> Status: draft — partially implemented. The manifest contract and `ChannelManifestRegistry` have landed in `@openhermit/protocol`; nothing consumes the registry yet (see migration plan below). Supersedes the "External Channel Adapter API" open question in `pending-decisions.md`.
+> Status: shipped. Manifest contract, `ChannelManifestRegistry`, the `channelPackages` config field, the setup contract, and the first external plugin (`@openhermit/channel-wechat`) have all landed. The migration plan below is kept for historical context; everything in it is done. Supersedes the "External Channel Adapter API" open question in `pending-decisions.md`. For day-to-day operational reference, see [`channel-adapter.md`](channel-adapter.md).
 
 ## Why
 
@@ -29,7 +29,7 @@ Goal: make channels first-class npm-installable plugins. The CLI still bundles a
 │                                                                     │
 │  ┌──────────────────────────┐  ┌─────────────────────────────────┐  │
 │  │ ChannelManifestRegistry  │← │ PluginLoader                    │  │
-│  │ (runtime)                │  │  • read channel_packages config │  │
+│  │ (runtime)                │  │  • read channelPackages config │  │
 │  └──────────────────────────┘  │  • dynamic-import each manifest │  │
 │         ▲                      │  • register {key, namespace,    │  │
 │         │                      │     parseConfig, start}         │  │
@@ -190,12 +190,14 @@ Key design choices:
 Plugins are loaded from two sources, in order:
 
 1. **CLI-bundled defaults.** Manifests imported directly in `apps/cli/src/cli.ts` (or a dedicated `default-channels.ts`) and registered before reading external config. These are bundled by `tsup` and always available.
-2. **External packages listed in config.** Read from `config.yaml`:
+2. **External packages listed in config.** Read from `gateway.config.channelPackages`:
 
-   ```yaml
-   channel_packages:
-     - '@heyamiko/channel-signal'
-     - '@heyamiko/channel-weixin'
+   ```json
+   {
+     "channelPackages": [
+       "@openhermit/channel-wechat"
+     ]
+   }
    ```
 
    At gateway boot, each name is passed to `await import(name)`. Node's module resolution finds the package in the same `node_modules` tree the CLI itself lives in.
@@ -210,31 +212,29 @@ v1 supports npm-installed CLI only — pnpm, bun, homebrew, and standalone-binar
 
 ## CLI Bundling Policy
 
-| Channel | Bundled in CLI? | Loaded via |
-|---|---|---|
-| `@openhermit/channel-telegram` | yes (default) | static import + manifest registration |
-| `@openhermit/channel-slack` | yes (default) | static import + manifest registration |
-| `@openhermit/channel-discord` | yes (default) | static import + manifest registration |
-| `@openhermit/channel-signal` | no | global `node_modules` + `channel_packages` config |
-| `@heyamiko/channel-weixin` | no | global `node_modules` + `channel_packages` config |
-| `@heyamiko/channel-debox` | no | global `node_modules` + `channel_packages` config |
+| Channel | Package | Published to npm? | Bundled in CLI? | Loaded via |
+|---|---|---|---|---|
+| Telegram | `@openhermit/channel-telegram` | no (`private: true`) | yes — `tsup noExternal` | static import + manifest registration |
+| Slack | `@openhermit/channel-slack` | no (`private: true`) | yes — `tsup noExternal` | static import + manifest registration |
+| Discord | `@openhermit/channel-discord` | no (`private: true`) | yes — `tsup noExternal` | static import + manifest registration |
+| WeChat | `@openhermit/channel-wechat` | yes (`0.1.0`) | no | global `node_modules` + `channelPackages` config |
+| Signal (planned) | `@openhermit/channel-signal` | no (in review on PR #92) | no | global `node_modules` + `channelPackages` config |
 
-This honors "default-bundle the three established channels so `hermit` is usable out-of-box" while keeping the loading path uniform — both bundled and external go through the same manifest registration, so there is no special-case code for the built-ins.
-
-`apps/cli/tsup.config.ts` needs no new entries beyond what's there today; the three default channels keep their `noExternal` treatment (slack and discord need to be added; only telegram is listed currently).
+This honors "default-bundle the three established channels so `hermit` is usable out-of-box" while keeping the loading path uniform — both bundled and external go through the same manifest registration, so there is no special-case code for the built-ins. Bundled channels keep `private: true` because the CLI binary is the only consumer; only channels meant for `hermit channel install` are published.
 
 ## Migration Plan
 
-Sequenced so each step is independently shippable:
+The plan below is preserved as the historical record of how the rollout was sequenced. Everything is shipped.
 
-1. **Manifest contract.** Add `ChannelManifest` type and `ChannelManifestRegistry` runtime class in `packages/protocol` and `apps/gateway`. No behavioral change yet — `BUILTIN_CHANNELS` becomes a thin wrapper that constructs three manifests internally.
-2. **Refactor built-ins to export manifests.** `@openhermit/channel-telegram`, `-slack`, `-discord` add `export default manifest`. The CLI imports and registers them explicitly at boot.
-3. **Add `channel_packages` config.** Gateway reads the list, dynamic-imports each, registers. Empty list = no-op, fully backwards compatible.
-4. **Delete `BUILTIN_CHANNELS` constant.** All consumers (`channels.ts` `starters` map, admin UI registry, backfill) now read from the runtime registry. Backfill becomes: "for each manifest registered at boot, ensure an `agent_channels` row exists per active agent."
-5. **Ship Signal as the first external-default channel.** PR #81 rebased: drop from `BUILTIN_CHANNELS`, drop from `tsup` `noExternal`, add `export default manifest`. Operators add `@openhermit/channel-signal` to `channel_packages` to enable.
-6. **Admin UI registry.** `/api/channels/available` returns the runtime registry instead of a hardcoded list. Form rendering uses each manifest's `parseConfig` (or a richer descriptor we add later — `parseConfig` is opaque by design, so the UI may eventually want an explicit JSON-Schema or Zod field for form generation).
+1. **Manifest contract.** ✅ `ChannelManifest` type and `ChannelManifestRegistry` runtime class — landed in PR #87 (`packages/protocol`, `apps/gateway/src/channel-manifests.ts`).
+2. **Refactor built-ins to export manifests.** ✅ Telegram, Slack, Discord now default-export their `ChannelManifest` and register via the registry — landed in PR #88.
+3. **Add `channelPackages` config.** ✅ Gateway config carries a `channelPackages: string[]` field; each entry is dynamic-imported at boot — landed in PR #88 alongside step 2. Empty list = no-op.
+4. **Delete `BUILTIN_CHANNELS` constant.** ✅ All consumers read from the runtime registry; admin UI registry derives from registered manifests — folded into PR #88.
+5. **Interactive setup contract.** ✅ `ChannelSetup` / `ChannelSetupState` plus the four `/setup/*` gateway routes — landed in PR #90.
+6. **First external-plugin channel.** ✅ `@openhermit/channel-wechat@0.1.0` published — landed in PR #94 (manifest) and the corresponding workspace package. Operators add it via `hermit channel install @openhermit/channel-wechat`.
+7. **CLI ergonomics.** ✅ `hermit channel install/uninstall/list` — landed in PR #95.
 
-Steps 1–4 are pure infrastructure with no user-visible change. Step 5 is the first user-visible delivery; step 6 polishes the admin UX.
+Signal (PR #81 / PR #92) is the next external-default channel candidate, awaiting contributor fixes to packaging. It lands as the second published external plugin and requires no further gateway changes.
 
 ## Scope Decisions
 
@@ -243,11 +243,11 @@ Steps 1–4 are pure infrastructure with no user-visible change. Step 5 is the f
 - **No pnpm or bun global resolution.** Their global layouts use symlink trees that Node's default upward resolution from the CLI's location does not traverse. Supporting them is feasible (custom `createRequire` paths, `PNPM_HOME`-aware loader) but each adds a code path that must be maintained. Operators wanting pnpm/bun can install the CLI and channel packages into a project-local `node_modules` and point the gateway at it via env var — but this is unsupported in v1.
 - **No homebrew / `curl | sh` / standalone-binary distributions.** Those install the CLI outside any `node_modules` tree, so a sibling-resolution model doesn't apply. v1 is `npm install -g @openhermit/cli` only. Other distribution channels are a future-work item.
 
-These constraints are documented in the operator-facing channel install docs (added in PR2 alongside the `hermit channel install` command) so users picking pnpm/bun/brew aren't surprised.
+These constraints are documented in [`channel-adapter.md`](channel-adapter.md) so users picking pnpm/bun/brew aren't surprised.
 
-### `hermit channel install` ships in PR2
+### `hermit channel install` (shipped, PR #95)
 
-A thin wrapper around `npm install -g <pkg>` that also appends the package to `channel_packages` in the gateway config. Without it, operators have to run npm directly and edit the config file by hand — workable but not first-class. PR2 includes it as part of the user-visible delivery.
+A thin wrapper around `npm install -g <pkg>` that also appends the package to `channelPackages` in the gateway config. The install does the npm step first so a failed npm install leaves no phantom entry in config; the uninstall writes the config first so a failed npm uninstall doesn't leave the gateway pointing at a package it can't load. A gateway restart is required for changes to take effect.
 
 ### Supply-chain trust is the operator's responsibility
 

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -14,11 +14,17 @@ A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, 
 
 ## 17.1 The Channels You Get
 
+**Bundled with the CLI** (always available once `openhermit` is installed):
+
 - **CLI** — `hermit chat`. Always available if you have the CLI installed.
 - **Web** — `https://<your-gateway>/chat/<agent>`. Always available once the gateway is reachable.
 - **Telegram** — bot you create via BotFather, registered with the agent.
 - **Discord** — bot application registered with the agent.
 - **Slack** — Slack app installed into your workspace, registered with the agent.
+
+**Installable as npm packages** (add via `hermit channel install`):
+
+- **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text-only v0.
 
 Each non-CLI channel needs a credential (a bot token or app secret). Credentials are stored as secrets — see [Chapter 18](18-secrets.md).
 
@@ -60,6 +66,13 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Slack apps are workspace-scoped. Install per workspace, register per agent.
 - Threading: the adapter creates a thread for each session by default. Quote-reply to continue an existing one.
 - File attachments supported.
+
+### WeChat (external plugin)
+
+- Install with `hermit channel install @openhermit/channel-wechat`, then restart the gateway.
+- Pair the bot through *Manage → Channels → Add channel → WeChat*: the UI renders a QR code that you scan with the WeChat mobile app and confirm. The setup wizard exchanges the scan + confirmation for a long-lived `bot_token` and IDC-pinned `base_url`, which the gateway stores on the channel row.
+- Restarts preserve the login: the gateway reloads `bot_token` from the channel row and resumes the iLink long-poll without re-scanning. You only need to re-pair if you unlink the bot from inside the WeChat client.
+- Text-only in v0 — no attachments, no group filtering.
 
 ### Web / CLI
 
@@ -114,6 +127,24 @@ Channels are interchangeable surfaces over the same agent. Disable Telegram, ena
 ### 17.6.3 Run one bot for two agents
 
 Not supported on the same channel handle. Use two distinct bot tokens / apps, one per agent.
+
+---
+
+### 17.6.4 Install a plugin channel (WeChat)
+
+```bash
+hermit channel install @openhermit/channel-wechat
+hermit gateway stop && hermit gateway start
+```
+
+Then open *Manage → Channels → Add channel → WeChat*, scan the QR with your phone, confirm the login, and save the channel. To remove it later:
+
+```bash
+hermit channel uninstall @openhermit/channel-wechat
+hermit gateway stop && hermit gateway start
+```
+
+`hermit channel list` shows what's currently registered.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`docs/channel-adapter.md`** — split adapter table into **Bundled** (Telegram/Discord/Slack) vs **External Plugin** (WeChat); document `hermit channel install/uninstall/list`; clarify plaintext `config` jsonb vs encrypted `token_ciphertext`; add the interactive-setup section (4 routes, session lifetime, restart behavior) and WeChat platform notes.
- **`docs/channel-plugin-design.md`** — flip status from draft to shipped, mark migration plan steps with their landing PRs (#87 / #88 / #90 / #94 / #95), refresh the bundling-policy table with a "published to npm?" column showing that only `@openhermit/channel-wechat@0.1.0` is published — bundled channels stay `private: true`.
- **`docs/manual/17-channels.md`** — list WeChat as the first installable plugin, add `17.6.4 Install a plugin channel (WeChat)` recipe.
- **`docs/architecture.md`** — mention `ChannelManifestRegistry` + `channelPackages` in the `apps/channels` row, boot sequence, and extension surfaces.

## Test plan

- [ ] Render the manual locally and verify §17 reads cleanly with the new WeChat blocks
- [ ] Verify cross-doc links (`channel-adapter.md` ↔ `channel-plugin-design.md` ↔ `manual/17-channels.md`)
- [ ] Sanity-check that no doc still refers to a hardcoded `BUILTIN_CHANNELS` constant or the snake-case `channel_packages` config field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect plugin-driven channel system with bundled and external adapters.
  * Added WeChat as an available external channel plugin with installation and setup instructions.
  * Documented interactive setup workflows for channels with credential management.
  * Enhanced channel adapter and configuration guides with credential handling and platform-specific notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/96)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->