### PR TITLE
fix(skills): keep skill-file reads verbatim across session resumes

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2781,7 +2781,14 @@ export class AgentRunner implements SessionRuntime {
         // For large tool results, build an inline head+tail preview so we
         // don't bloat events or context.  The full output is persisted to
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
-        const truncation = resultText
+        // Skill-file reads opt out: SKILL.md is required reading and the
+        // head+tail preview would corrupt resumed sessions (DB-restored
+        // history would only ever see the truncated middle marker).
+        const isSkillRead =
+          typeof resultDetails === 'object'
+          && resultDetails !== null
+          && (resultDetails as { skillRead?: unknown }).skillRead === true;
+        const truncation = resultText && !isSkillRead
           ? buildToolResultPreview(event.toolCallId, resultText)
           : null;
         const publishText = truncation ? truncation.preview : resultText;

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2783,9 +2783,14 @@ export class AgentRunner implements SessionRuntime {
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
         // Skill-file reads opt out: SKILL.md is required reading and the
         // head+tail preview would corrupt resumed sessions (DB-restored
-        // history would only ever see the truncated middle marker).
+        // history would only ever see the truncated middle marker). The
+        // bypass is gated on the originating tool being `file_read` so
+        // any other tool that happens to set `skillRead` in its details
+        // (intentionally or by collision) cannot smuggle large output
+        // past truncation.
         const isSkillRead =
-          typeof resultDetails === 'object'
+          event.toolName === 'file_read'
+          && typeof resultDetails === 'object'
           && resultDetails !== null
           && (resultDetails as { skillRead?: unknown }).skillRead === true;
         const truncation = resultText && !isSkillRead

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -88,7 +88,7 @@ import {
 import { buildToolResultPreview, persistToolResult } from './agent-runner/tool-result-persistence.js';
 import { createWebProvider, type WebProvider } from './web/index.js';
 import { runIntrospection } from './introspection/index.js';
-import { loadSkillIndex } from './skills.js';
+import { isSkillReadResult, loadSkillIndex } from './skills.js';
 import type { ScheduleRecord } from '@openhermit/store';
 import { McpClientManager } from './mcp-client.js';
 import { createMcpManagementToolset, createMcpStatusOnlyToolset } from './tools/mcp.js';
@@ -2783,16 +2783,17 @@ export class AgentRunner implements SessionRuntime {
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
         // Skill-file reads opt out: SKILL.md is required reading and the
         // head+tail preview would corrupt resumed sessions (DB-restored
-        // history would only ever see the truncated middle marker). The
-        // bypass is gated on the originating tool being `file_read` so
-        // any other tool that happens to set `skillRead` in its details
-        // (intentionally or by collision) cannot smuggle large output
-        // past truncation.
-        const isSkillRead =
-          event.toolName === 'file_read'
-          && typeof resultDetails === 'object'
-          && resultDetails !== null
-          && (resultDetails as { skillRead?: unknown }).skillRead === true;
+        // history would only ever see the truncated middle marker).
+        //
+        // The classification is owned by the runner: only `file_read`
+        // returning a path under `<agentHome>/.openhermit/skills/`
+        // qualifies, and the determination is made here rather than
+        // trusting a flag from the tool's return value.
+        const isSkillRead = isSkillReadResult(
+          event.toolName,
+          resultDetails,
+          this.execBackendManager?.getDefault().agentHome,
+        );
         const truncation = resultText && !isSkillRead
           ? buildToolResultPreview(event.toolCallId, resultText)
           : null;

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -16,6 +16,51 @@ export interface SkillIndexEntry {
   source: 'system' | 'workspace';
 }
 
+/**
+ * Classify an absolute path as living under the agent's skills directory.
+ *
+ * Skill files live at `<agentHome>/.openhermit/skills/`. Two downstream
+ * policies key off this: `file_read` returns skill content verbatim
+ * (no line numbers, no internal byte cap), and agent-runner skips the
+ * head+tail preview that would otherwise corrupt skill content across
+ * session resumes.
+ *
+ * Anchored to `agentHome` rather than substring-matched, so unrelated
+ * trees that happen to contain `.openhermit/skills/` don't silently
+ * inherit the bypass. `..` segments are rejected — paths flow through
+ * here without further sanitization, so traversal must be neutralized.
+ */
+export const isSkillPath = (filePath: string, agentHome: string): boolean => {
+  if (!path.posix.isAbsolute(filePath)) return false;
+  const normalized = path.posix.normalize(filePath);
+  if (normalized.split('/').includes('..')) return false;
+  const skillsRoot = `${agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
+  return normalized.startsWith(skillsRoot);
+};
+
+/**
+ * Decide — from a tool-execution-end event — whether a result represents
+ * a skill-file read that should bypass agent-runner's head+tail preview.
+ *
+ * Owned entirely by the runner side: classifies by the dispatched tool
+ * name (which the runner controls) plus the path the tool reports it
+ * read, re-checked against the agent's skills root. The tool's return
+ * value does not get to declare itself a skill read — only `file_read`
+ * is authorized, and only for paths that pass `isSkillPath`.
+ */
+export const isSkillReadResult = (
+  toolName: string,
+  details: unknown,
+  agentHome: string | undefined,
+): boolean => {
+  if (toolName !== 'file_read') return false;
+  if (!agentHome) return false;
+  if (typeof details !== 'object' || details === null) return false;
+  const filePath = (details as { path?: unknown }).path;
+  if (typeof filePath !== 'string') return false;
+  return isSkillPath(filePath, agentHome);
+};
+
 /** Parse YAML frontmatter from a SKILL.md file. */
 export const parseFrontmatter = (content: string): Record<string, string> => {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -132,12 +132,12 @@ export const formatSkillsPromptSection = (skills: SkillIndexEntry[]): string | u
   if (skills.length === 0) return undefined;
 
   const lines = skills.map(
-    (s) => `- **${s.name}**: ${s.description} — \`cat ${s.path}/SKILL.md\``,
+    (s) => `- **${s.name}**: ${s.description} — \`file_read ${s.path}/SKILL.md\``,
   );
 
   return `## Skills
 
-The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md for detailed instructions.
+The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with \`file_read\` (do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped).
 
 ${lines.join('\n')}`;
 };

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -187,7 +187,13 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         content: skillRead
           ? [{ type: 'text' as const, text: content }]
           : asTextContent(content),
-        details: { path: args.path, sandbox: backend.id, size: data.byteLength, encoding },
+        details: {
+          path: args.path,
+          sandbox: backend.id,
+          size: data.byteLength,
+          encoding,
+          ...(skillRead ? { skillRead: true } : {}),
+        },
       };
     }
 
@@ -217,6 +223,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         startLine: startIdx + 1,
         endLine: endIdx,
         encoding,
+        ...(skillRead ? { skillRead: true } : {}),
       },
     };
   },

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { Type, type Static } from '@mariozechner/pi-ai';
 import { ValidationError } from '@openhermit/shared';
 
@@ -19,6 +17,7 @@ import {
   evaluateAccess,
   resolveFilePathMatches,
 } from '../core/policy.js';
+import { isSkillPath } from '../skills.js';
 
 const SANDBOX_ARG = Type.Optional(
   Type.String({ description: 'Sandbox alias. Omit to use the default sandbox.' }),
@@ -96,25 +95,6 @@ type FileDeleteArgs = Static<typeof FileDeleteParams>;
 /** 5 MiB. Beyond this, results blow the model context budget. */
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 
-/**
- * Skill files live under `<agentHome>/.openhermit/skills/` and are required
- * reading for the agent to actually use a skill. Path-based file policies
- * commonly forbid reads under `~/.openhermit/`, so without an exception the
- * agent gets blocked and can't follow its own SKILL.md instructions.
- *
- * Anchor the check to the backend's agentHome rather than matching the
- * substring anywhere in the path — that way an unrelated path that happens
- * to contain `.openhermit/skills/` (e.g. a user-supplied workspace tree)
- * doesn't silently inherit the bypass.
- */
-const isSkillPath = (backend: ExecBackend, rawPath: string): boolean => {
-  if (!path.posix.isAbsolute(rawPath)) return false;
-  const normalized = path.posix.normalize(rawPath);
-  if (normalized.split('/').includes('..')) return false;
-  const skillsRoot = `${backend.agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
-  return normalized.startsWith(skillsRoot);
-};
-
 const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
   if (!context.execBackendManager) {
     throw new ValidationError('File tools are unavailable: no execution backend configured for this agent.');
@@ -169,7 +149,12 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    const skillRead = isSkillPath(backend, args.path);
+    // Skill-file reads bypass file-policy checks and content-shaping
+    // (line numbering, byte cap) because SKILL.md is required reading
+    // for the agent. The same classification is re-applied by
+    // agent-runner to skip the head+tail truncation preview — that
+    // decision lives in the runner, not in this tool's return shape.
+    const skillRead = isSkillPath(args.path, backend.agentHome);
     if (!skillRead) {
       await checkFilePath(context, backend.id, 'read', args.path, args);
     }
@@ -192,7 +177,6 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
           sandbox: backend.id,
           size: data.byteLength,
           encoding,
-          ...(skillRead ? { skillRead: true } : {}),
         },
       };
     }
@@ -223,7 +207,6 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         startLine: startIdx + 1,
         endLine: endIdx,
         encoding,
-        ...(skillRead ? { skillRead: true } : {}),
       },
     };
   },

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -3,7 +3,14 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { parseFrontmatter, scanSkillDirectory, loadSkillIndex, formatSkillsPromptSection } from '../src/skills.js';
+import {
+  parseFrontmatter,
+  scanSkillDirectory,
+  loadSkillIndex,
+  formatSkillsPromptSection,
+  isSkillPath,
+  isSkillReadResult,
+} from '../src/skills.js';
 import type { SkillIndexEntry } from '../src/skills.js';
 import { createTempDir } from './helpers.js';
 
@@ -163,4 +170,80 @@ test('formatSkillsPromptSection formats skills as markdown', () => {
   // agent-runner and is then unrecoverable across session resumes.
   assert.ok(section.includes('file_read /skills/test/SKILL.md'));
   assert.ok(!section.includes('cat /skills/test/SKILL.md'));
+});
+
+// ── isSkillPath ──────────────────────────────────────────────────────────
+
+test('isSkillPath matches paths anchored under <agentHome>/.openhermit/skills/', () => {
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/system/demo/SKILL.md', '/home/user'), true);
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/wechat/SKILL.md', '/home/user'), true);
+});
+
+test('isSkillPath tolerates a trailing slash on agentHome', () => {
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/x/SKILL.md', '/home/user/'), true);
+});
+
+test('isSkillPath rejects paths outside the skills root', () => {
+  assert.equal(isSkillPath('/home/user/notes.txt', '/home/user'), false);
+  assert.equal(isSkillPath('/etc/passwd', '/home/user'), false);
+});
+
+test('isSkillPath rejects paths with .. segments (no traversal bypass)', () => {
+  assert.equal(
+    isSkillPath('/home/user/.openhermit/skills/../../etc/passwd', '/home/user'),
+    false,
+  );
+});
+
+test('isSkillPath rejects relative paths', () => {
+  assert.equal(isSkillPath('.openhermit/skills/demo/SKILL.md', '/home/user'), false);
+});
+
+test('isSkillPath rejects paths that only superficially contain the skills prefix', () => {
+  // /home/userX/.openhermit/skills/... must NOT match agentHome=/home/user.
+  assert.equal(
+    isSkillPath('/home/userX/.openhermit/skills/demo/SKILL.md', '/home/user'),
+    false,
+  );
+});
+
+// ── isSkillReadResult ────────────────────────────────────────────────────
+
+test('isSkillReadResult: only file_read on a skill path qualifies', () => {
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(
+    isSkillReadResult('file_read', { path: skillPath }, '/home/user'),
+    true,
+  );
+});
+
+test('isSkillReadResult rejects non-file_read tools even with a skill path in details', () => {
+  // A different tool (or a future one) cannot smuggle a result past the
+  // head+tail preview by claiming to have read a skill file.
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(
+    isSkillReadResult('exec', { path: skillPath }, '/home/user'),
+    false,
+  );
+});
+
+test('isSkillReadResult rejects file_read on a non-skill path', () => {
+  assert.equal(
+    isSkillReadResult('file_read', { path: '/home/user/notes.txt' }, '/home/user'),
+    false,
+  );
+});
+
+test('isSkillReadResult rejects when agentHome is undefined', () => {
+  // Before any backend is initialized the runner can't classify — fail
+  // safe to the truncating path rather than silently bypassing.
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(isSkillReadResult('file_read', { path: skillPath }, undefined), false);
+});
+
+test('isSkillReadResult rejects malformed details', () => {
+  assert.equal(isSkillReadResult('file_read', null, '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', 'string-details', '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', { path: 42 }, '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', {}, '/home/user'), false);
 });

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -158,5 +158,9 @@ test('formatSkillsPromptSection formats skills as markdown', () => {
   const section = formatSkillsPromptSection(skills)!;
   assert.ok(section.includes('## Skills'));
   assert.ok(section.includes('**Test**'));
-  assert.ok(section.includes('cat /skills/test/SKILL.md'));
+  // Steers the agent toward file_read (skill-aware: no truncation, no line
+  // numbers) instead of `exec cat`, which gets head+tail-previewed by
+  // agent-runner and is then unrecoverable across session resumes.
+  assert.ok(section.includes('file_read /skills/test/SKILL.md'));
+  assert.ok(!section.includes('cat /skills/test/SKILL.md'));
 });

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -9,8 +9,11 @@ import { ValidationError } from '@openhermit/shared';
 
 import { DbInternalStateStore, standaloneScope } from '@openhermit/store';
 import { createBuiltInTools, withApproval } from '../src/tools.js';
+import { createFileReadTool } from '../src/tools/file.js';
 import { createSessionListTool, createSessionReadTool, createSessionSummaryTool } from '../src/tools/session.js';
 import { DefuddleWebProvider } from '../src/web/index.js';
+import { ExecBackendManager } from '../src/core/index.js';
+import type { ExecBackend } from '../src/core/index.js';
 import { createSecurityFixture, createTempDir } from './helpers.js';
 
 const defaultWebProvider = new DefuddleWebProvider();
@@ -640,4 +643,92 @@ test('session_summary denies access when user is not a participant', async (t) =
     (err: any) => err.message.includes('Access denied'),
     'should reject access for non-participant',
   );
+});
+
+// ── file_read: skill-path bypass ─────────────────────────────────────────
+
+const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): ExecBackend => ({
+  id: 'host',
+  type: 'host',
+  label: 'host',
+  username: 'tester',
+  agentHome,
+  ensure: async () => {},
+  exec: async () => ({ stdout: '', stderr: '', exitCode: 0, durationMs: 0 }),
+  syncSkills: async () => {},
+  shutdown: async () => {},
+  files: {
+    read: async (filePath: string) => {
+      const data = files.get(filePath);
+      if (!data) throw new Error(`fake backend: file not found: ${filePath}`);
+      return { data };
+    },
+    write: async () => { throw new Error('not used'); },
+    list: async () => [],
+    stat: async () => null,
+    delete: async () => { throw new Error('not used'); },
+  },
+});
+
+test('file_read flags skill-path reads and returns content verbatim (no line numbers)', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  const skillPath = `${agentHome}/.openhermit/skills/system/demo/SKILL.md`;
+  const skillBody = '---\nname: demo\ndescription: x\n---\n\nline one\nline two\nline three\n';
+  const backend = makeReadOnlyBackend(agentHome, new Map([[skillPath, Buffer.from(skillBody, 'utf8')]]));
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-skill', { path: skillPath });
+
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.equal(text, skillBody, 'skill files are returned without line-number prefixes');
+
+  const details = result.details as { skillRead?: boolean; path: string };
+  assert.equal(details.skillRead, true, 'details.skillRead is set so agent-runner can skip the head+tail preview');
+  assert.equal(details.path, skillPath);
+});
+
+test('file_read on a non-skill path numbers lines and does not set skillRead', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  const filePath = `${agentHome}/notes.txt`;
+  const body = 'alpha\nbeta\n';
+  const backend = makeReadOnlyBackend(agentHome, new Map([[filePath, Buffer.from(body, 'utf8')]]));
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-plain', { path: filePath });
+
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.ok(text.startsWith('1\talpha'), 'non-skill paths still get line-number prefixes');
+
+  const details = result.details as { skillRead?: boolean };
+  assert.equal(details.skillRead, undefined, 'skillRead flag is omitted for non-skill paths');
+});
+
+test('file_read does not bypass policy/numbering for paths only superficially matching skills root', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  // Path contains "/.openhermit/skills/" but resolves outside agentHome via "..".
+  // isSkillPath should reject — the bypass must not apply.
+  const escapingPath = `${agentHome}/.openhermit/skills/../../etc/passwd`;
+  const body = 'root:x:0:0\n';
+  const backend = makeReadOnlyBackend(
+    agentHome,
+    new Map([[escapingPath, Buffer.from(body, 'utf8')]]),
+  );
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-escape', { path: escapingPath });
+
+  const details = result.details as { skillRead?: boolean };
+  assert.equal(details.skillRead, undefined, 'paths with .. segments are not treated as skill paths');
 });

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -670,7 +670,7 @@ const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): Exe
   },
 });
 
-test('file_read flags skill-path reads and returns content verbatim (no line numbers)', async (t) => {
+test('file_read returns skill-path content verbatim (no line numbers)', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -683,15 +683,18 @@ test('file_read flags skill-path reads and returns content verbatim (no line num
   const tool = createFileReadTool({ security, execBackendManager });
   const result = await tool.execute('call-skill', { path: skillPath });
 
+  // Content shape is the observable signal that the tool classified this
+  // as a skill read internally (skipped line numbering + byte cap). The
+  // truncation-bypass decision is owned by agent-runner; covered by
+  // `isSkillReadResult` tests in skills.test.ts.
   const text = (result.content[0] as { type: string; text: string }).text;
   assert.equal(text, skillBody, 'skill files are returned without line-number prefixes');
 
-  const details = result.details as { skillRead?: boolean; path: string };
-  assert.equal(details.skillRead, true, 'details.skillRead is set so agent-runner can skip the head+tail preview');
+  const details = result.details as { path: string };
   assert.equal(details.path, skillPath);
 });
 
-test('file_read on a non-skill path numbers lines and does not set skillRead', async (t) => {
+test('file_read on a non-skill path numbers lines', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -706,12 +709,9 @@ test('file_read on a non-skill path numbers lines and does not set skillRead', a
 
   const text = (result.content[0] as { type: string; text: string }).text;
   assert.ok(text.startsWith('1\talpha'), 'non-skill paths still get line-number prefixes');
-
-  const details = result.details as { skillRead?: boolean };
-  assert.equal(details.skillRead, undefined, 'skillRead flag is omitted for non-skill paths');
 });
 
-test('file_read does not bypass policy/numbering for paths only superficially matching skills root', async (t) => {
+test('file_read does not bypass numbering for paths only superficially matching skills root', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -729,6 +729,6 @@ test('file_read does not bypass policy/numbering for paths only superficially ma
   const tool = createFileReadTool({ security, execBackendManager });
   const result = await tool.execute('call-escape', { path: escapingPath });
 
-  const details = result.details as { skillRead?: boolean };
-  assert.equal(details.skillRead, undefined, 'paths with .. segments are not treated as skill paths');
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.ok(text.startsWith('1\troot:x:0:0'), 'paths with .. segments are treated as non-skill — line numbers applied');
 });


### PR DESCRIPTION
## Summary

Two-part fix for SKILL.md reads showing up truncated to the agent after a gateway restart, surfaced on the deployed `amiko:cmoxp59j90002quryigfrjr3l` session where the agent read its skill via `exec cat` and then, even after switching to `file_read`, only saw a head+tail-elided version.

- **Prompt steers toward `file_read`.** `formatSkillsPromptSection` used to render each skill as `\`cat <path>/SKILL.md\``, which is exactly what the agent did. `exec cat` output flows through the agent-runner head+tail preview pipeline and is unrecoverable on resume. The prompt now uses `\`file_read ...\`` and explicitly tells the agent to avoid `exec cat` for skill files.
- **Skill-file `file_read` opts out of the downstream preview.** PR #57 made `file_read` itself return SKILL.md uncapped, but `buildToolResultPreview` in `agent-runner.ts` still truncated any tool result over 8KB before persisting + emitting events. After a gateway restart the resumed session rebuilt its history from the DB-persisted preview — so the agent only ever saw `[... N characters omitted ...]` in the middle of its own skill. `file_read` now sets `details.skillRead: true` for paths anchored under `<agentHome>/.openhermit/skills/`, and agent-runner skips `buildToolResultPreview` when that flag is set.

The skill-path detection reuses the existing `isSkillPath` helper (posix-normalized, rejects `..`, anchored to `backend.agentHome`).

## Test plan

- [x] `apps/agent` builds cleanly (`tsc -b`)
- [x] New targeted tests pass:
  - `formatSkillsPromptSection` emits `file_read` and not `cat`
  - `file_read` flags skill-path reads with `details.skillRead === true` and returns content verbatim (no line numbers)
  - `file_read` on a non-skill path still numbers lines and does not set `skillRead`
  - `file_read` does not bypass numbering for paths only superficially matching the skills root (e.g. `.../skills/../../etc/passwd`)
- [ ] Manual: redeploy gateway, send a fresh session, restart gateway mid-conversation, confirm the agent still sees full SKILL.md after resume

## Related

Follow-up to #57 — that PR fixed `file_read`'s internal truncation; this one closes the downstream gap in agent-runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool result previews for skill documentation are no longer truncated—full contents are shown for skill-file reads.

* **Improvements**
  * Agent prompt now instructs using file_read .../SKILL.md for each skill.
  * Skill-file reads are reliably detected so their content is returned verbatim without line-number prefixes and previews reflect the full text.

* **Tests**
  * Added/updated tests to verify skill-path classification, file_read behavior, and preview formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->