### PR TITLE
feat(skills): structured <available_skills> XML + anti-hallucination steer

### DIFF
--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -176,13 +176,25 @@ export const loadSkillIndex = async (
 export const formatSkillsPromptSection = (skills: SkillIndexEntry[]): string | undefined => {
   if (skills.length === 0) return undefined;
 
-  const lines = skills.map(
-    (s) => `- **${s.name}**: ${s.description} — \`file_read ${s.path}/SKILL.md\``,
-  );
+  const escapeXml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  const entries = skills
+    .map(
+      (s) =>
+        `  <skill>
+    <name>${escapeXml(s.name)}</name>
+    <description>${escapeXml(s.description)}</description>
+    <location>${s.path}/SKILL.md</location>
+  </skill>`,
+    )
+    .join('\n');
 
   return `## Skills
 
-The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with \`file_read\` (do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped).
+The following skills provide specialized instructions for specific tasks. Before replying, scan the <description> entries below. When one clearly matches the task, read its SKILL.md in full with \`file_read <location>\`. You MUST use the exact <location> value from <available_skills> — never guess, fabricate, or hard-code a skill file path. Do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped.
 
-${lines.join('\n')}`;
+<available_skills>
+${entries}
+</available_skills>`;
 };

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -158,17 +158,27 @@ test('formatSkillsPromptSection returns undefined for empty list', () => {
   assert.equal(formatSkillsPromptSection([]), undefined);
 });
 
-test('formatSkillsPromptSection formats skills as markdown', () => {
+test('formatSkillsPromptSection formats skills as available_skills XML', () => {
   const skills: SkillIndexEntry[] = [
     { id: 'test', name: 'Test', description: 'A test', path: '/skills/test', source: 'system' },
   ];
   const section = formatSkillsPromptSection(skills)!;
   assert.ok(section.includes('## Skills'));
-  assert.ok(section.includes('**Test**'));
-  // Steers the agent toward file_read (skill-aware: no truncation, no line
-  // numbers) instead of `exec cat`, which gets head+tail-previewed by
-  // agent-runner and is then unrecoverable across session resumes.
-  assert.ok(section.includes('file_read /skills/test/SKILL.md'));
+  // Structured <location> field — model copies path verbatim instead of
+  // reconstructing it from prose, which closes off path-hallucination.
+  assert.ok(section.includes('<available_skills>'));
+  assert.ok(section.includes('<name>Test</name>'));
+  assert.ok(section.includes('<description>A test</description>'));
+  assert.ok(section.includes('<location>/skills/test/SKILL.md</location>'));
+  // Anti-hallucination steer (borrowed from openclaw): the model must use
+  // the location value verbatim and not invent paths.
+  assert.ok(section.includes('never guess, fabricate, or hard-code'));
+  // Skill-aware read steering preserved from prior fix: `file_read` only,
+  // never `exec cat`, since cat output is head+tail-previewed and
+  // unrecoverable across session resumes. The anti-cat steer must appear
+  // in the prose, and there must be no per-skill `cat <path>` listing.
+  assert.ok(section.includes('file_read'));
+  assert.ok(section.includes('Do not use `exec cat`'));
   assert.ok(!section.includes('cat /skills/test/SKILL.md'));
 });
 
@@ -246,4 +256,13 @@ test('isSkillReadResult rejects malformed details', () => {
   assert.equal(isSkillReadResult('file_read', 'string-details', '/home/user'), false);
   assert.equal(isSkillReadResult('file_read', { path: 42 }, '/home/user'), false);
   assert.equal(isSkillReadResult('file_read', {}, '/home/user'), false);
+});
+
+test('formatSkillsPromptSection escapes XML special chars in name/description', () => {
+  const skills: SkillIndexEntry[] = [
+    { id: 'x', name: 'A & B', description: 'Has <angle> & chars', path: '/skills/x', source: 'system' },
+  ];
+  const section = formatSkillsPromptSection(skills)!;
+  assert.ok(section.includes('<name>A &amp; B</name>'));
+  assert.ok(section.includes('<description>Has &lt;angle&gt; &amp; chars</description>'));
 });


### PR DESCRIPTION
## Summary

Restructures the `## Skills` section of the system prompt, motivated by comparing our format with openclaw and pi-coding-agent. Stacked on top of #97 — review/merge that first.

**Two changes:**

1. **Structured `<available_skills>` XML** instead of a markdown bullet list. Each entry carries `<name>`, `<description>`, and `<location>` as separate fields. The model copies the location verbatim into `file_read <location>` rather than reconstructing the path out of prose around an inline backtick. Both openclaw and pi-coding-agent use this exact shape for the same reason.

2. **"Never guess, fabricate, or hard-code a skill file path"** steer, borrowed verbatim from openclaw's system prompt. Cheap defense against the model inventing skill paths once the index has scrolled past the prompt-cache window (a real failure mode on long sessions).

XML special characters in user-authored `name`/`description` frontmatter are escaped so a stray `<` or `&` can't break the block.

### Before / after

**Before (PR #97)**

```
## Skills

The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with `file_read` (do not use `exec cat`; `file_read` returns skill files verbatim and uncapped).

- **Amiko Channel Skill**: Use when interacting in the amiko channel. — `file_read /home/user/.openhermit/skills/system/amiko/SKILL.md`
- **WeChat Skill**: WeChat operations. — `file_read /home/user/.openhermit/skills/wechat/SKILL.md`
```

**After**

```
## Skills

The following skills provide specialized instructions for specific tasks. Before replying, scan the <description> entries below. When one clearly matches the task, read its SKILL.md in full with `file_read <location>`. You MUST use the exact <location> value from <available_skills> — never guess, fabricate, or hard-code a skill file path. Do not use `exec cat`; `file_read` returns skill files verbatim and uncapped.

<available_skills>
  <skill>
    <name>Amiko Channel Skill</name>
    <description>Use when interacting in the amiko channel.</description>
    <location>/home/user/.openhermit/skills/system/amiko/SKILL.md</location>
  </skill>
  <skill>
    <name>WeChat Skill</name>
    <description>WeChat operations.</description>
    <location>/home/user/.openhermit/skills/wechat/SKILL.md</location>
  </skill>
</available_skills>
```

## Test plan

- [x] `tsc -b` clean
- [x] 15/15 `skills.test.ts` pass, including:
  - new: `formatSkillsPromptSection formats skills as available_skills XML`
  - new: `formatSkillsPromptSection escapes XML special chars in name/description`
- [ ] Manual: deploy to test.openhermit.ai, exercise an agent with multiple skills, verify it picks the right `<location>` and reads via `file_read`

## Related

Stacked on #97 (skill-read no-truncate). The combined effect: model uses `file_read`, picks the path from a structured field, can't invent a path, and the result isn't truncated on resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)