### PR TITLE
feat(fleet): token usage + cost views in Fleet and Stats panels

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2781,7 +2781,14 @@ export class AgentRunner implements SessionRuntime {
         // For large tool results, build an inline head+tail preview so we
         // don't bloat events or context.  The full output is persisted to
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
-        const truncation = resultText
+        // Skill-file reads opt out: SKILL.md is required reading and the
+        // head+tail preview would corrupt resumed sessions (DB-restored
+        // history would only ever see the truncated middle marker).
+        const isSkillRead =
+          typeof resultDetails === 'object'
+          && resultDetails !== null
+          && (resultDetails as { skillRead?: unknown }).skillRead === true;
+        const truncation = resultText && !isSkillRead
           ? buildToolResultPreview(event.toolCallId, resultText)
           : null;
         const publishText = truncation ? truncation.preview : resultText;

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2783,9 +2783,14 @@ export class AgentRunner implements SessionRuntime {
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
         // Skill-file reads opt out: SKILL.md is required reading and the
         // head+tail preview would corrupt resumed sessions (DB-restored
-        // history would only ever see the truncated middle marker).
+        // history would only ever see the truncated middle marker). The
+        // bypass is gated on the originating tool being `file_read` so
+        // any other tool that happens to set `skillRead` in its details
+        // (intentionally or by collision) cannot smuggle large output
+        // past truncation.
         const isSkillRead =
-          typeof resultDetails === 'object'
+          event.toolName === 'file_read'
+          && typeof resultDetails === 'object'
           && resultDetails !== null
           && (resultDetails as { skillRead?: unknown }).skillRead === true;
         const truncation = resultText && !isSkillRead

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -88,7 +88,7 @@ import {
 import { buildToolResultPreview, persistToolResult } from './agent-runner/tool-result-persistence.js';
 import { createWebProvider, type WebProvider } from './web/index.js';
 import { runIntrospection } from './introspection/index.js';
-import { loadSkillIndex } from './skills.js';
+import { isSkillReadResult, loadSkillIndex } from './skills.js';
 import type { ScheduleRecord } from '@openhermit/store';
 import { McpClientManager } from './mcp-client.js';
 import { createMcpManagementToolset, createMcpStatusOnlyToolset } from './tools/mcp.js';
@@ -2783,16 +2783,17 @@ export class AgentRunner implements SessionRuntime {
         // workspace/.openhermit/tool_results/<id>.json in the side-effect.
         // Skill-file reads opt out: SKILL.md is required reading and the
         // head+tail preview would corrupt resumed sessions (DB-restored
-        // history would only ever see the truncated middle marker). The
-        // bypass is gated on the originating tool being `file_read` so
-        // any other tool that happens to set `skillRead` in its details
-        // (intentionally or by collision) cannot smuggle large output
-        // past truncation.
-        const isSkillRead =
-          event.toolName === 'file_read'
-          && typeof resultDetails === 'object'
-          && resultDetails !== null
-          && (resultDetails as { skillRead?: unknown }).skillRead === true;
+        // history would only ever see the truncated middle marker).
+        //
+        // The classification is owned by the runner: only `file_read`
+        // returning a path under `<agentHome>/.openhermit/skills/`
+        // qualifies, and the determination is made here rather than
+        // trusting a flag from the tool's return value.
+        const isSkillRead = isSkillReadResult(
+          event.toolName,
+          resultDetails,
+          this.execBackendManager?.getDefault().agentHome,
+        );
         const truncation = resultText && !isSkillRead
           ? buildToolResultPreview(event.toolCallId, resultText)
           : null;

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -176,13 +176,25 @@ export const loadSkillIndex = async (
 export const formatSkillsPromptSection = (skills: SkillIndexEntry[]): string | undefined => {
   if (skills.length === 0) return undefined;
 
-  const lines = skills.map(
-    (s) => `- **${s.name}**: ${s.description} — \`file_read ${s.path}/SKILL.md\``,
-  );
+  const escapeXml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  const entries = skills
+    .map(
+      (s) =>
+        `  <skill>
+    <name>${escapeXml(s.name)}</name>
+    <description>${escapeXml(s.description)}</description>
+    <location>${s.path}/SKILL.md</location>
+  </skill>`,
+    )
+    .join('\n');
 
   return `## Skills
 
-The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with \`file_read\` (do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped).
+The following skills provide specialized instructions for specific tasks. Before replying, scan the <description> entries below. When one clearly matches the task, read its SKILL.md in full with \`file_read <location>\`. You MUST use the exact <location> value from <available_skills> — never guess, fabricate, or hard-code a skill file path. Do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped.
 
-${lines.join('\n')}`;
+<available_skills>
+${entries}
+</available_skills>`;
 };

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -16,6 +16,51 @@ export interface SkillIndexEntry {
   source: 'system' | 'workspace';
 }
 
+/**
+ * Classify an absolute path as living under the agent's skills directory.
+ *
+ * Skill files live at `<agentHome>/.openhermit/skills/`. Two downstream
+ * policies key off this: `file_read` returns skill content verbatim
+ * (no line numbers, no internal byte cap), and agent-runner skips the
+ * head+tail preview that would otherwise corrupt skill content across
+ * session resumes.
+ *
+ * Anchored to `agentHome` rather than substring-matched, so unrelated
+ * trees that happen to contain `.openhermit/skills/` don't silently
+ * inherit the bypass. `..` segments are rejected — paths flow through
+ * here without further sanitization, so traversal must be neutralized.
+ */
+export const isSkillPath = (filePath: string, agentHome: string): boolean => {
+  if (!path.posix.isAbsolute(filePath)) return false;
+  const normalized = path.posix.normalize(filePath);
+  if (normalized.split('/').includes('..')) return false;
+  const skillsRoot = `${agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
+  return normalized.startsWith(skillsRoot);
+};
+
+/**
+ * Decide — from a tool-execution-end event — whether a result represents
+ * a skill-file read that should bypass agent-runner's head+tail preview.
+ *
+ * Owned entirely by the runner side: classifies by the dispatched tool
+ * name (which the runner controls) plus the path the tool reports it
+ * read, re-checked against the agent's skills root. The tool's return
+ * value does not get to declare itself a skill read — only `file_read`
+ * is authorized, and only for paths that pass `isSkillPath`.
+ */
+export const isSkillReadResult = (
+  toolName: string,
+  details: unknown,
+  agentHome: string | undefined,
+): boolean => {
+  if (toolName !== 'file_read') return false;
+  if (!agentHome) return false;
+  if (typeof details !== 'object' || details === null) return false;
+  const filePath = (details as { path?: unknown }).path;
+  if (typeof filePath !== 'string') return false;
+  return isSkillPath(filePath, agentHome);
+};
+
 /** Parse YAML frontmatter from a SKILL.md file. */
 export const parseFrontmatter = (content: string): Record<string, string> => {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -132,12 +132,12 @@ export const formatSkillsPromptSection = (skills: SkillIndexEntry[]): string | u
   if (skills.length === 0) return undefined;
 
   const lines = skills.map(
-    (s) => `- **${s.name}**: ${s.description} — \`cat ${s.path}/SKILL.md\``,
+    (s) => `- **${s.name}**: ${s.description} — \`file_read ${s.path}/SKILL.md\``,
   );
 
   return `## Skills
 
-The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md for detailed instructions.
+The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with \`file_read\` (do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped).
 
 ${lines.join('\n')}`;
 };

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -187,7 +187,13 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         content: skillRead
           ? [{ type: 'text' as const, text: content }]
           : asTextContent(content),
-        details: { path: args.path, sandbox: backend.id, size: data.byteLength, encoding },
+        details: {
+          path: args.path,
+          sandbox: backend.id,
+          size: data.byteLength,
+          encoding,
+          ...(skillRead ? { skillRead: true } : {}),
+        },
       };
     }
 
@@ -217,6 +223,7 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         startLine: startIdx + 1,
         endLine: endIdx,
         encoding,
+        ...(skillRead ? { skillRead: true } : {}),
       },
     };
   },

--- a/apps/agent/src/tools/file.ts
+++ b/apps/agent/src/tools/file.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { Type, type Static } from '@mariozechner/pi-ai';
 import { ValidationError } from '@openhermit/shared';
 
@@ -19,6 +17,7 @@ import {
   evaluateAccess,
   resolveFilePathMatches,
 } from '../core/policy.js';
+import { isSkillPath } from '../skills.js';
 
 const SANDBOX_ARG = Type.Optional(
   Type.String({ description: 'Sandbox alias. Omit to use the default sandbox.' }),
@@ -96,25 +95,6 @@ type FileDeleteArgs = Static<typeof FileDeleteParams>;
 /** 5 MiB. Beyond this, results blow the model context budget. */
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 
-/**
- * Skill files live under `<agentHome>/.openhermit/skills/` and are required
- * reading for the agent to actually use a skill. Path-based file policies
- * commonly forbid reads under `~/.openhermit/`, so without an exception the
- * agent gets blocked and can't follow its own SKILL.md instructions.
- *
- * Anchor the check to the backend's agentHome rather than matching the
- * substring anywhere in the path — that way an unrelated path that happens
- * to contain `.openhermit/skills/` (e.g. a user-supplied workspace tree)
- * doesn't silently inherit the bypass.
- */
-const isSkillPath = (backend: ExecBackend, rawPath: string): boolean => {
-  if (!path.posix.isAbsolute(rawPath)) return false;
-  const normalized = path.posix.normalize(rawPath);
-  if (normalized.split('/').includes('..')) return false;
-  const skillsRoot = `${backend.agentHome.replace(/\/$/, '')}/.openhermit/skills/`;
-  return normalized.startsWith(skillsRoot);
-};
-
 const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
   if (!context.execBackendManager) {
     throw new ValidationError('File tools are unavailable: no execution backend configured for this agent.');
@@ -169,7 +149,12 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
   parameters: FileReadParams,
   execute: async (_id, args: FileReadArgs) => {
     const backend = resolveBackend(context, args.sandbox);
-    const skillRead = isSkillPath(backend, args.path);
+    // Skill-file reads bypass file-policy checks and content-shaping
+    // (line numbering, byte cap) because SKILL.md is required reading
+    // for the agent. The same classification is re-applied by
+    // agent-runner to skip the head+tail truncation preview — that
+    // decision lives in the runner, not in this tool's return shape.
+    const skillRead = isSkillPath(args.path, backend.agentHome);
     if (!skillRead) {
       await checkFilePath(context, backend.id, 'read', args.path, args);
     }
@@ -192,7 +177,6 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
           sandbox: backend.id,
           size: data.byteLength,
           encoding,
-          ...(skillRead ? { skillRead: true } : {}),
         },
       };
     }
@@ -223,7 +207,6 @@ export const createFileReadTool = (context: ToolContext): PolicyAwareTool<typeof
         startLine: startIdx + 1,
         endLine: endIdx,
         encoding,
-        ...(skillRead ? { skillRead: true } : {}),
       },
     };
   },

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -3,7 +3,14 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { parseFrontmatter, scanSkillDirectory, loadSkillIndex, formatSkillsPromptSection } from '../src/skills.js';
+import {
+  parseFrontmatter,
+  scanSkillDirectory,
+  loadSkillIndex,
+  formatSkillsPromptSection,
+  isSkillPath,
+  isSkillReadResult,
+} from '../src/skills.js';
 import type { SkillIndexEntry } from '../src/skills.js';
 import { createTempDir } from './helpers.js';
 
@@ -163,4 +170,80 @@ test('formatSkillsPromptSection formats skills as markdown', () => {
   // agent-runner and is then unrecoverable across session resumes.
   assert.ok(section.includes('file_read /skills/test/SKILL.md'));
   assert.ok(!section.includes('cat /skills/test/SKILL.md'));
+});
+
+// ── isSkillPath ──────────────────────────────────────────────────────────
+
+test('isSkillPath matches paths anchored under <agentHome>/.openhermit/skills/', () => {
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/system/demo/SKILL.md', '/home/user'), true);
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/wechat/SKILL.md', '/home/user'), true);
+});
+
+test('isSkillPath tolerates a trailing slash on agentHome', () => {
+  assert.equal(isSkillPath('/home/user/.openhermit/skills/x/SKILL.md', '/home/user/'), true);
+});
+
+test('isSkillPath rejects paths outside the skills root', () => {
+  assert.equal(isSkillPath('/home/user/notes.txt', '/home/user'), false);
+  assert.equal(isSkillPath('/etc/passwd', '/home/user'), false);
+});
+
+test('isSkillPath rejects paths with .. segments (no traversal bypass)', () => {
+  assert.equal(
+    isSkillPath('/home/user/.openhermit/skills/../../etc/passwd', '/home/user'),
+    false,
+  );
+});
+
+test('isSkillPath rejects relative paths', () => {
+  assert.equal(isSkillPath('.openhermit/skills/demo/SKILL.md', '/home/user'), false);
+});
+
+test('isSkillPath rejects paths that only superficially contain the skills prefix', () => {
+  // /home/userX/.openhermit/skills/... must NOT match agentHome=/home/user.
+  assert.equal(
+    isSkillPath('/home/userX/.openhermit/skills/demo/SKILL.md', '/home/user'),
+    false,
+  );
+});
+
+// ── isSkillReadResult ────────────────────────────────────────────────────
+
+test('isSkillReadResult: only file_read on a skill path qualifies', () => {
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(
+    isSkillReadResult('file_read', { path: skillPath }, '/home/user'),
+    true,
+  );
+});
+
+test('isSkillReadResult rejects non-file_read tools even with a skill path in details', () => {
+  // A different tool (or a future one) cannot smuggle a result past the
+  // head+tail preview by claiming to have read a skill file.
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(
+    isSkillReadResult('exec', { path: skillPath }, '/home/user'),
+    false,
+  );
+});
+
+test('isSkillReadResult rejects file_read on a non-skill path', () => {
+  assert.equal(
+    isSkillReadResult('file_read', { path: '/home/user/notes.txt' }, '/home/user'),
+    false,
+  );
+});
+
+test('isSkillReadResult rejects when agentHome is undefined', () => {
+  // Before any backend is initialized the runner can't classify — fail
+  // safe to the truncating path rather than silently bypassing.
+  const skillPath = '/home/user/.openhermit/skills/system/demo/SKILL.md';
+  assert.equal(isSkillReadResult('file_read', { path: skillPath }, undefined), false);
+});
+
+test('isSkillReadResult rejects malformed details', () => {
+  assert.equal(isSkillReadResult('file_read', null, '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', 'string-details', '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', { path: 42 }, '/home/user'), false);
+  assert.equal(isSkillReadResult('file_read', {}, '/home/user'), false);
 });

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -158,5 +158,9 @@ test('formatSkillsPromptSection formats skills as markdown', () => {
   const section = formatSkillsPromptSection(skills)!;
   assert.ok(section.includes('## Skills'));
   assert.ok(section.includes('**Test**'));
-  assert.ok(section.includes('cat /skills/test/SKILL.md'));
+  // Steers the agent toward file_read (skill-aware: no truncation, no line
+  // numbers) instead of `exec cat`, which gets head+tail-previewed by
+  // agent-runner and is then unrecoverable across session resumes.
+  assert.ok(section.includes('file_read /skills/test/SKILL.md'));
+  assert.ok(!section.includes('cat /skills/test/SKILL.md'));
 });

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -158,17 +158,27 @@ test('formatSkillsPromptSection returns undefined for empty list', () => {
   assert.equal(formatSkillsPromptSection([]), undefined);
 });
 
-test('formatSkillsPromptSection formats skills as markdown', () => {
+test('formatSkillsPromptSection formats skills as available_skills XML', () => {
   const skills: SkillIndexEntry[] = [
     { id: 'test', name: 'Test', description: 'A test', path: '/skills/test', source: 'system' },
   ];
   const section = formatSkillsPromptSection(skills)!;
   assert.ok(section.includes('## Skills'));
-  assert.ok(section.includes('**Test**'));
-  // Steers the agent toward file_read (skill-aware: no truncation, no line
-  // numbers) instead of `exec cat`, which gets head+tail-previewed by
-  // agent-runner and is then unrecoverable across session resumes.
-  assert.ok(section.includes('file_read /skills/test/SKILL.md'));
+  // Structured <location> field — model copies path verbatim instead of
+  // reconstructing it from prose, which closes off path-hallucination.
+  assert.ok(section.includes('<available_skills>'));
+  assert.ok(section.includes('<name>Test</name>'));
+  assert.ok(section.includes('<description>A test</description>'));
+  assert.ok(section.includes('<location>/skills/test/SKILL.md</location>'));
+  // Anti-hallucination steer (borrowed from openclaw): the model must use
+  // the location value verbatim and not invent paths.
+  assert.ok(section.includes('never guess, fabricate, or hard-code'));
+  // Skill-aware read steering preserved from prior fix: `file_read` only,
+  // never `exec cat`, since cat output is head+tail-previewed and
+  // unrecoverable across session resumes. The anti-cat steer must appear
+  // in the prose, and there must be no per-skill `cat <path>` listing.
+  assert.ok(section.includes('file_read'));
+  assert.ok(section.includes('Do not use `exec cat`'));
   assert.ok(!section.includes('cat /skills/test/SKILL.md'));
 });
 
@@ -246,4 +256,13 @@ test('isSkillReadResult rejects malformed details', () => {
   assert.equal(isSkillReadResult('file_read', 'string-details', '/home/user'), false);
   assert.equal(isSkillReadResult('file_read', { path: 42 }, '/home/user'), false);
   assert.equal(isSkillReadResult('file_read', {}, '/home/user'), false);
+});
+
+test('formatSkillsPromptSection escapes XML special chars in name/description', () => {
+  const skills: SkillIndexEntry[] = [
+    { id: 'x', name: 'A & B', description: 'Has <angle> & chars', path: '/skills/x', source: 'system' },
+  ];
+  const section = formatSkillsPromptSection(skills)!;
+  assert.ok(section.includes('<name>A &amp; B</name>'));
+  assert.ok(section.includes('<description>Has &lt;angle&gt; &amp; chars</description>'));
 });

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -9,8 +9,11 @@ import { ValidationError } from '@openhermit/shared';
 
 import { DbInternalStateStore, standaloneScope } from '@openhermit/store';
 import { createBuiltInTools, withApproval } from '../src/tools.js';
+import { createFileReadTool } from '../src/tools/file.js';
 import { createSessionListTool, createSessionReadTool, createSessionSummaryTool } from '../src/tools/session.js';
 import { DefuddleWebProvider } from '../src/web/index.js';
+import { ExecBackendManager } from '../src/core/index.js';
+import type { ExecBackend } from '../src/core/index.js';
 import { createSecurityFixture, createTempDir } from './helpers.js';
 
 const defaultWebProvider = new DefuddleWebProvider();
@@ -640,4 +643,92 @@ test('session_summary denies access when user is not a participant', async (t) =
     (err: any) => err.message.includes('Access denied'),
     'should reject access for non-participant',
   );
+});
+
+// ── file_read: skill-path bypass ─────────────────────────────────────────
+
+const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): ExecBackend => ({
+  id: 'host',
+  type: 'host',
+  label: 'host',
+  username: 'tester',
+  agentHome,
+  ensure: async () => {},
+  exec: async () => ({ stdout: '', stderr: '', exitCode: 0, durationMs: 0 }),
+  syncSkills: async () => {},
+  shutdown: async () => {},
+  files: {
+    read: async (filePath: string) => {
+      const data = files.get(filePath);
+      if (!data) throw new Error(`fake backend: file not found: ${filePath}`);
+      return { data };
+    },
+    write: async () => { throw new Error('not used'); },
+    list: async () => [],
+    stat: async () => null,
+    delete: async () => { throw new Error('not used'); },
+  },
+});
+
+test('file_read flags skill-path reads and returns content verbatim (no line numbers)', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  const skillPath = `${agentHome}/.openhermit/skills/system/demo/SKILL.md`;
+  const skillBody = '---\nname: demo\ndescription: x\n---\n\nline one\nline two\nline three\n';
+  const backend = makeReadOnlyBackend(agentHome, new Map([[skillPath, Buffer.from(skillBody, 'utf8')]]));
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-skill', { path: skillPath });
+
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.equal(text, skillBody, 'skill files are returned without line-number prefixes');
+
+  const details = result.details as { skillRead?: boolean; path: string };
+  assert.equal(details.skillRead, true, 'details.skillRead is set so agent-runner can skip the head+tail preview');
+  assert.equal(details.path, skillPath);
+});
+
+test('file_read on a non-skill path numbers lines and does not set skillRead', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  const filePath = `${agentHome}/notes.txt`;
+  const body = 'alpha\nbeta\n';
+  const backend = makeReadOnlyBackend(agentHome, new Map([[filePath, Buffer.from(body, 'utf8')]]));
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-plain', { path: filePath });
+
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.ok(text.startsWith('1\talpha'), 'non-skill paths still get line-number prefixes');
+
+  const details = result.details as { skillRead?: boolean };
+  assert.equal(details.skillRead, undefined, 'skillRead flag is omitted for non-skill paths');
+});
+
+test('file_read does not bypass policy/numbering for paths only superficially matching skills root', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+
+  const agentHome = '/home/user';
+  // Path contains "/.openhermit/skills/" but resolves outside agentHome via "..".
+  // isSkillPath should reject — the bypass must not apply.
+  const escapingPath = `${agentHome}/.openhermit/skills/../../etc/passwd`;
+  const body = 'root:x:0:0\n';
+  const backend = makeReadOnlyBackend(
+    agentHome,
+    new Map([[escapingPath, Buffer.from(body, 'utf8')]]),
+  );
+  const execBackendManager = new ExecBackendManager([backend]);
+
+  const tool = createFileReadTool({ security, execBackendManager });
+  const result = await tool.execute('call-escape', { path: escapingPath });
+
+  const details = result.details as { skillRead?: boolean };
+  assert.equal(details.skillRead, undefined, 'paths with .. segments are not treated as skill paths');
 });

--- a/apps/agent/test/tools.test.ts
+++ b/apps/agent/test/tools.test.ts
@@ -670,7 +670,7 @@ const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): Exe
   },
 });
 
-test('file_read flags skill-path reads and returns content verbatim (no line numbers)', async (t) => {
+test('file_read returns skill-path content verbatim (no line numbers)', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -683,15 +683,18 @@ test('file_read flags skill-path reads and returns content verbatim (no line num
   const tool = createFileReadTool({ security, execBackendManager });
   const result = await tool.execute('call-skill', { path: skillPath });
 
+  // Content shape is the observable signal that the tool classified this
+  // as a skill read internally (skipped line numbering + byte cap). The
+  // truncation-bypass decision is owned by agent-runner; covered by
+  // `isSkillReadResult` tests in skills.test.ts.
   const text = (result.content[0] as { type: string; text: string }).text;
   assert.equal(text, skillBody, 'skill files are returned without line-number prefixes');
 
-  const details = result.details as { skillRead?: boolean; path: string };
-  assert.equal(details.skillRead, true, 'details.skillRead is set so agent-runner can skip the head+tail preview');
+  const details = result.details as { path: string };
   assert.equal(details.path, skillPath);
 });
 
-test('file_read on a non-skill path numbers lines and does not set skillRead', async (t) => {
+test('file_read on a non-skill path numbers lines', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -706,12 +709,9 @@ test('file_read on a non-skill path numbers lines and does not set skillRead', a
 
   const text = (result.content[0] as { type: string; text: string }).text;
   assert.ok(text.startsWith('1\talpha'), 'non-skill paths still get line-number prefixes');
-
-  const details = result.details as { skillRead?: boolean };
-  assert.equal(details.skillRead, undefined, 'skillRead flag is omitted for non-skill paths');
 });
 
-test('file_read does not bypass policy/numbering for paths only superficially matching skills root', async (t) => {
+test('file_read does not bypass numbering for paths only superficially matching skills root', async (t) => {
   const { security } = await createSecurityFixture(t);
   await security.load();
 
@@ -729,6 +729,6 @@ test('file_read does not bypass policy/numbering for paths only superficially ma
   const tool = createFileReadTool({ security, execBackendManager });
   const result = await tool.execute('call-escape', { path: escapingPath });
 
-  const details = result.details as { skillRead?: boolean };
-  assert.equal(details.skillRead, undefined, 'paths with .. segments are not treated as skill paths');
+  const text = (result.content[0] as { type: string; text: string }).text;
+  assert.ok(text.startsWith('1\troot:x:0:0'), 'paths with .. segments are treated as non-skill — line numbers applied');
 });

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1467,12 +1467,22 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const records = await agentStore.list();
     const agentIds = records.map((r) => r.agentId);
     const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    const stats = await agentStore.fleetStats(agentIds, since);
+    const [stats, usage] = await Promise.all([
+      agentStore.fleetStats(agentIds, since),
+      agentStore.fleetUsage(agentIds),
+    ]);
+
+    const emptyUsage = {
+      window24h: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+      window7d:  { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+      allTime:   { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+    };
 
     const fleet = await Promise.all(records.map(async (record) => {
       const stat = stats.get(record.agentId) ?? {
         sessions24h: 0, errors24h: 0, skillsCount: 0, mcpCount: 0,
       };
+      const u = usage.get(record.agentId) ?? emptyUsage;
       const channelStatuses = instances.getChannelPool()?.getStatuses(record.agentId) ?? [];
       const channelsEnabled = channelStatuses
         .filter((s) => s.status === 'connected')
@@ -1487,9 +1497,19 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         channels: channelsEnabled,
         skillsCount: stat.skillsCount,
         mcpCount: stat.mcpCount,
+        usage: u,
       };
     }));
     return c.json(fleet);
+  });
+
+  app.get('/api/admin/agents/:agentId/usage', async (c) => {
+    requireAdmin(c.req.header('authorization'));
+    if (!agentStore) {
+      return c.json({ error: { code: 'not_configured', message: 'Agent store not configured.' } }, 500);
+    }
+    const detail = await agentStore.agentUsageDetail(c.req.param('agentId'));
+    return c.json(detail);
   });
 
   app.get('/api/admin/sandboxes', async (c) => {
@@ -1584,7 +1604,15 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
   app.get('/api/admin/stats', async (c) => {
     requireAdmin(c.req.header('authorization'));
     const memoryUsage = process.memoryUsage();
-    const counts = agentStore ? await agentStore.counts() : { users: 0, sessions: 0, sessionEvents: 0 };
+    const [counts, usage] = agentStore
+      ? await Promise.all([agentStore.counts(), agentStore.usageTotals()])
+      : [
+          { users: 0, sessions: 0, sessionEvents: 0 },
+          {
+            window24h: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+            allTime:   { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+          },
+        ];
     return c.json({
       uptime: process.uptime(),
       memory: {
@@ -1596,6 +1624,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         running: instances.listRunnerIds().length,
       },
       counts,
+      usage,
     });
   });
 

--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -4,6 +4,21 @@ import { api } from '../api';
 import { SecretsDialog } from './SecretsDialog';
 import { SecurityDialog } from './SecurityDialog';
 import { ConfigDialog } from './ConfigDialog';
+import { UsageDialog } from './UsageDialog';
+
+export interface UsageWindow {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  costUsd: number;
+}
+
+export interface FleetUsage {
+  window24h: UsageWindow;
+  window7d: UsageWindow;
+  allTime: UsageWindow;
+}
 
 interface FleetAgent {
   agentId: string;
@@ -15,6 +30,7 @@ interface FleetAgent {
   channels: string[];
   skillsCount: number;
   mcpCount: number;
+  usage: FleetUsage;
 }
 
 interface SkillInfo {
@@ -50,6 +66,20 @@ const formatRelative = (iso?: string): string => {
   return `${Math.floor(ms / 86_400_000)}d ago`;
 };
 
+export const formatTokens = (n: number): string => {
+  if (n < 1_000) return n.toString();
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 2 : 1)}M`;
+};
+
+export const formatUsd = (n: number): string => {
+  if (!Number.isFinite(n) || n === 0) return '$0';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  if (n < 100) return `$${n.toFixed(2)}`;
+  return `$${Math.round(n).toLocaleString()}`;
+};
+
 export function FleetPanel() {
   const [fleet, setFleet] = useState<FleetAgent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -63,6 +93,7 @@ export function FleetPanel() {
   const [securityAgent, setSecurityAgent] = useState<string | null>(null);
   const [skillsAgent, setSkillsAgent] = useState<string | null>(null);
   const [mcpAgent, setMcpAgent] = useState<string | null>(null);
+  const [usageAgent, setUsageAgent] = useState<string | null>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   const load = useCallback(async () => {
@@ -204,6 +235,8 @@ export function FleetPanel() {
               <th>Last activity</th>
               <th className="fleet-table__num">Sessions 24h</th>
               <th className="fleet-table__num">Errors 24h</th>
+              <th className="fleet-table__num">Tokens 24h</th>
+              <th className="fleet-table__num">USD 24h</th>
               <th className="fleet-table__actions"></th>
             </tr>
           </thead>
@@ -232,6 +265,10 @@ export function FleetPanel() {
                 <td className={`fleet-table__num${a.errors24h > 0 ? ' fleet-cell-error' : ''}`}>
                   {a.errors24h}
                 </td>
+                <td className="fleet-table__num">
+                  {formatTokens(a.usage.window24h.inputTokens + a.usage.window24h.outputTokens)}
+                </td>
+                <td className="fleet-table__num">{formatUsd(a.usage.window24h.costUsd)}</td>
                 <td className="fleet-table__actions">
                   <div className="fleet-actions">
                     <button
@@ -314,6 +351,14 @@ export function FleetPanel() {
                   <dt>Errors 24h</dt>
                   <dd className={a.errors24h > 0 ? 'fleet-cell-error' : ''}>{a.errors24h}</dd>
                 </div>
+                <div>
+                  <dt>Tokens 24h</dt>
+                  <dd>{formatTokens(a.usage.window24h.inputTokens + a.usage.window24h.outputTokens)}</dd>
+                </div>
+                <div>
+                  <dt>USD 24h</dt>
+                  <dd>{formatUsd(a.usage.window24h.costUsd)}</dd>
+                </div>
               </dl>
             </div>
           ))}
@@ -344,6 +389,7 @@ export function FleetPanel() {
           onMcp={(id) => { setOpenMenu(null); setMcpAgent(id); }}
           onSecrets={(id) => { setOpenMenu(null); setSecretsAgent(id); }}
           onSecurity={(id) => { setOpenMenu(null); setSecurityAgent(id); }}
+          onUsage={(id) => { setOpenMenu(null); setUsageAgent(id); }}
         />,
         document.body,
       )}
@@ -354,6 +400,7 @@ export function FleetPanel() {
       {configAgent && <ConfigDialog agentId={configAgent} onClose={() => setConfigAgent(null)} />}
       {skillsAgent && <AgentSkillsDialog agentId={skillsAgent} onClose={() => setSkillsAgent(null)} />}
       {mcpAgent && <AgentMcpDialog agentId={mcpAgent} onClose={() => setMcpAgent(null)} />}
+      {usageAgent && <UsageDialog agentId={usageAgent} onClose={() => setUsageAgent(null)} />}
     </div>
   );
 }
@@ -368,6 +415,7 @@ function FleetActionsMenu({
   onMcp,
   onSecrets,
   onSecurity,
+  onUsage,
 }: {
   agent: FleetAgent | undefined;
   top: number;
@@ -378,6 +426,7 @@ function FleetActionsMenu({
   onMcp: (agentId: string) => void;
   onSecrets: (agentId: string) => void;
   onSecurity: (agentId: string) => void;
+  onUsage: (agentId: string) => void;
 }) {
   if (!agent) return null;
   return (
@@ -401,6 +450,7 @@ function FleetActionsMenu({
       <button role="menuitem" onClick={() => onMcp(agent.agentId)}>MCP</button>
       <button role="menuitem" onClick={() => onSecrets(agent.agentId)}>Secrets</button>
       <button role="menuitem" onClick={() => onSecurity(agent.agentId)}>Security</button>
+      <button role="menuitem" onClick={() => onUsage(agent.agentId)}>Usage…</button>
       {agent.status === 'disabled' && (
         <>
           <div className="fleet-actions__divider" />

--- a/apps/gateway/ui/src/components/StatsPanel.tsx
+++ b/apps/gateway/ui/src/components/StatsPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import { formatTokens, formatUsd, type UsageWindow } from './FleetPanel';
 
 interface Stats {
   uptime: number;
   memory: { rss: number; heapUsed: number; heapTotal: number };
   agents: { running: number };
   counts?: { users?: number; sessions?: number; sessionEvents?: number };
+  usage?: { window24h: UsageWindow; allTime: UsageWindow };
 }
 
 function formatBytes(bytes: number): string {
@@ -74,6 +76,23 @@ export function StatsPanel() {
             <StatCard label="Session Events" value={c.sessionEvents ?? 0} />
           </div>
         </div>
+        {stats.usage && (
+          <div className="stats-section">
+            <h3 className="stats-section__title">Token Usage</h3>
+            <div className="stats-row">
+              <StatCard
+                label="Tokens 24h"
+                value={formatTokens(stats.usage.window24h.inputTokens + stats.usage.window24h.outputTokens)}
+              />
+              <StatCard label="Cost 24h" value={formatUsd(stats.usage.window24h.costUsd)} />
+              <StatCard
+                label="Tokens all-time"
+                value={formatTokens(stats.usage.allTime.inputTokens + stats.usage.allTime.outputTokens)}
+              />
+              <StatCard label="Cost all-time" value={formatUsd(stats.usage.allTime.costUsd)} />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/gateway/ui/src/components/UsageDialog.tsx
+++ b/apps/gateway/ui/src/components/UsageDialog.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../api';
+import { formatTokens, formatUsd, type UsageWindow } from './FleetPanel';
+
+interface AgentUsageDetail {
+  totals: {
+    window24h: UsageWindow;
+    window7d: UsageWindow;
+    allTime: UsageWindow;
+  };
+  byModel: Array<{
+    model: string;
+    provider?: string;
+    calls: number;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+  }>;
+  daily: Array<{
+    day: string;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+  }>;
+}
+
+type WindowKey = 'window24h' | 'window7d' | 'allTime';
+
+const WINDOW_LABELS: Record<WindowKey, string> = {
+  window24h: 'Last 24h',
+  window7d: 'Last 7 days',
+  allTime: 'All time',
+};
+
+export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: () => void }) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [detail, setDetail] = useState<AgentUsageDetail | null>(null);
+  const [error, setError] = useState('');
+  const [windowKey, setWindowKey] = useState<WindowKey>('window24h');
+
+  useEffect(() => { dialogRef.current?.showModal(); }, []);
+
+  useEffect(() => {
+    api<AgentUsageDetail>(`/api/admin/agents/${encodeURIComponent(agentId)}/usage`)
+      .then(setDetail)
+      .catch((err) => setError((err as Error).message));
+  }, [agentId]);
+
+  const window = detail?.totals[windowKey];
+  const maxDailyCost = detail
+    ? Math.max(0.0001, ...detail.daily.map((d) => d.costUsd))
+    : 0.0001;
+
+  return (
+    <dialog ref={dialogRef} className="dialog dialog--wide" onClose={onClose}>
+      <div className="dialog__form">
+        <h3>Usage — {agentId}</h3>
+
+        {error && <p className="config-error">{error}</p>}
+        {!detail && !error && <p className="secrets-empty">Loading…</p>}
+
+        {detail && window && (
+          <>
+            <div className="usage-window-tabs" role="tablist">
+              {(Object.keys(WINDOW_LABELS) as WindowKey[]).map((k) => (
+                <button
+                  key={k}
+                  role="tab"
+                  aria-selected={windowKey === k}
+                  className={`btn btn--sm${windowKey === k ? ' btn--primary' : ' btn--ghost'}`}
+                  onClick={() => setWindowKey(k)}
+                >
+                  {WINDOW_LABELS[k]}
+                </button>
+              ))}
+            </div>
+
+            <div className="usage-tiles">
+              <div className="usage-tile">
+                <div className="usage-tile__label">Input tokens</div>
+                <div className="usage-tile__value">{formatTokens(window.inputTokens)}</div>
+              </div>
+              <div className="usage-tile">
+                <div className="usage-tile__label">Output tokens</div>
+                <div className="usage-tile__value">{formatTokens(window.outputTokens)}</div>
+              </div>
+              <div className="usage-tile">
+                <div className="usage-tile__label">Cache read</div>
+                <div className="usage-tile__value">{formatTokens(window.cacheReadTokens)}</div>
+              </div>
+              <div className="usage-tile">
+                <div className="usage-tile__label">Cache write</div>
+                <div className="usage-tile__value">{formatTokens(window.cacheWriteTokens)}</div>
+              </div>
+              <div className="usage-tile usage-tile--cost">
+                <div className="usage-tile__label">Total cost</div>
+                <div className="usage-tile__value">{formatUsd(window.costUsd)}</div>
+              </div>
+            </div>
+
+            <h4 className="usage-section-heading">By model</h4>
+            {detail.byModel.length === 0 ? (
+              <p className="secrets-empty">No assistant events yet.</p>
+            ) : (
+              <table className="usage-table">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th className="fleet-table__num">Calls</th>
+                    <th className="fleet-table__num">Input</th>
+                    <th className="fleet-table__num">Output</th>
+                    <th className="fleet-table__num">USD</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.byModel.map((m, i) => (
+                    <tr key={`${m.model}-${m.provider ?? ''}-${i}`}>
+                      <td>
+                        <div className="usage-model-cell">
+                          <span className="usage-model-cell__name">{m.model}</span>
+                          {m.provider && (
+                            <span className="usage-model-cell__provider">{m.provider}</span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="fleet-table__num">{m.calls.toLocaleString()}</td>
+                      <td className="fleet-table__num">{formatTokens(m.inputTokens)}</td>
+                      <td className="fleet-table__num">{formatTokens(m.outputTokens)}</td>
+                      <td className="fleet-table__num">{formatUsd(m.costUsd)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+
+            <h4 className="usage-section-heading">Daily (last 30 days)</h4>
+            {detail.daily.length === 0 ? (
+              <p className="secrets-empty">No activity in the last 30 days.</p>
+            ) : (
+              <div className="usage-daily">
+                {detail.daily.map((d) => (
+                  <div className="usage-daily__row" key={d.day}>
+                    <span className="usage-daily__day">{d.day}</span>
+                    <div className="usage-daily__bar-wrap">
+                      <div
+                        className="usage-daily__bar"
+                        style={{ width: `${Math.max(2, (d.costUsd / maxDailyCost) * 100)}%` }}
+                      />
+                    </div>
+                    <span className="usage-daily__tokens">
+                      {formatTokens(d.inputTokens + d.outputTokens)}
+                    </span>
+                    <span className="usage-daily__cost">{formatUsd(d.costUsd)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="dialog__actions">
+          <button className="btn btn--ghost" type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/apps/gateway/ui/src/styles.css
+++ b/apps/gateway/ui/src/styles.css
@@ -1061,3 +1061,102 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
 .users-role--owner { background: rgba(238, 92, 44, 0.12); color: var(--brand); }
 .users-role--user { background: rgba(22, 163, 74, 0.1); color: var(--green); }
 .users-role--guest { background: var(--bg-hover); color: var(--text-muted); }
+
+/* --- Usage dialog --- */
+
+.usage-window-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.usage-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin-bottom: 1rem;
+}
+
+.usage-tile {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-surface);
+}
+
+.usage-tile--cost { border-color: var(--brand); }
+
+.usage-tile__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.usage-tile__value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-section-heading {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 1rem 0 0.4rem;
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.usage-table th,
+.usage-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+
+.usage-model-cell { display: flex; flex-direction: column; gap: 1px; }
+.usage-model-cell__name { font-family: var(--mono); }
+.usage-model-cell__provider { font-size: 0.7rem; color: var(--text-muted); }
+
+.usage-daily {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.8rem;
+}
+
+.usage-daily__row {
+  display: grid;
+  grid-template-columns: 90px 1fr 70px 70px;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.usage-daily__day { font-family: var(--mono); color: var(--text-muted); }
+
+.usage-daily__bar-wrap {
+  background: var(--bg-surface);
+  border-radius: 3px;
+  height: 8px;
+  overflow: hidden;
+}
+
+.usage-daily__bar {
+  background: var(--brand);
+  height: 100%;
+  min-width: 2px;
+}
+
+.usage-daily__tokens,
+.usage-daily__cost {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/store/src/impl/agent-store.ts
+++ b/packages/store/src/impl/agent-store.ts
@@ -4,6 +4,33 @@ import pg from 'pg';
 
 import type { AgentStore } from '../interfaces.js';
 import type { AgentRecord, AgentStatus } from '../types.js';
+
+export interface UsageWindow {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  costUsd: number;
+}
+
+export interface FleetUsageEntry {
+  window24h: UsageWindow;
+  window7d: UsageWindow;
+  allTime: UsageWindow;
+}
+
+export interface AgentUsageDetail {
+  totals: FleetUsageEntry;
+  byModel: Array<{
+    model: string;
+    provider?: string;
+    calls: number;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+  }>;
+  daily: Array<{ day: string; inputTokens: number; outputTokens: number; costUsd: number }>;
+}
 import * as schema from '../schema.js';
 import {
   agents,
@@ -255,6 +282,223 @@ export class DbAgentStore implements AgentStore {
       this.db.select({ count: sql<number>`count(*)::int` }).from(sessionEvents),
     ]);
     return { users: u!.count, sessions: s!.count, sessionEvents: e!.count };
+  }
+
+  /**
+   * Per-agent token + cost aggregates across three windows: 24h, 7d, all-time.
+   * Sums the `usage` block stored on every `assistant` event payload
+   * (input / output / cacheRead / cacheWrite tokens + pre-computed
+   * `cost.total` USD). Returns a Map keyed by agentId; agents absent from
+   * the result had no billable activity in any window.
+   */
+  async fleetUsage(agentIds: string[]): Promise<Map<string, FleetUsageEntry>> {
+    const result = new Map<string, FleetUsageEntry>();
+    if (agentIds.length === 0) return result;
+
+    const now = new Date();
+    const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    const since7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const rows = await this.db.execute<{
+      agent_id: string;
+      window: string;
+      input_tokens: string | null;
+      output_tokens: string | null;
+      cache_read_tokens: string | null;
+      cache_write_tokens: string | null;
+      usd_total: number | null;
+    }>(sql`
+      WITH usage AS (
+        SELECT agent_id, ts, payload
+        FROM ${sessionEvents}
+        WHERE event_type = 'assistant'
+          AND payload ? 'usage'
+          AND agent_id = ANY(${agentIds}::text[])
+      ),
+      buckets AS (
+        SELECT agent_id, 'window24h' AS window, payload FROM usage WHERE ts > ${since24h}
+        UNION ALL
+        SELECT agent_id, 'window7d'  AS window, payload FROM usage WHERE ts > ${since7d}
+        UNION ALL
+        SELECT agent_id, 'allTime'   AS window, payload FROM usage
+      )
+      SELECT
+        agent_id,
+        window,
+        SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text       AS input_tokens,
+        SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text      AS output_tokens,
+        SUM(COALESCE((payload->'usage'->>'cacheRead')::bigint, 0))::text   AS cache_read_tokens,
+        SUM(COALESCE((payload->'usage'->>'cacheWrite')::bigint, 0))::text  AS cache_write_tokens,
+        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+      FROM buckets
+      GROUP BY agent_id, window
+    `);
+
+    const empty = (): UsageWindow => ({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      costUsd: 0,
+    });
+    const ensure = (id: string): FleetUsageEntry => {
+      let entry = result.get(id);
+      if (!entry) {
+        entry = { window24h: empty(), window7d: empty(), allTime: empty() };
+        result.set(id, entry);
+      }
+      return entry;
+    };
+    for (const row of rows.rows) {
+      const entry = ensure(row.agent_id);
+      const bucket: UsageWindow = {
+        inputTokens: Number(row.input_tokens ?? 0),
+        outputTokens: Number(row.output_tokens ?? 0),
+        cacheReadTokens: Number(row.cache_read_tokens ?? 0),
+        cacheWriteTokens: Number(row.cache_write_tokens ?? 0),
+        costUsd: Number(row.usd_total ?? 0),
+      };
+      if (row.window === 'window24h') entry.window24h = bucket;
+      else if (row.window === 'window7d') entry.window7d = bucket;
+      else entry.allTime = bucket;
+    }
+    return result;
+  }
+
+  /**
+   * Gateway-wide token + cost totals for the system stats panel.
+   * Two windows: last 24h and all-time.
+   */
+  async usageTotals(): Promise<{ window24h: UsageWindow; allTime: UsageWindow }> {
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const rows = await this.db.execute<{
+      window: string;
+      input_tokens: string | null;
+      output_tokens: string | null;
+      cache_read_tokens: string | null;
+      cache_write_tokens: string | null;
+      usd_total: number | null;
+    }>(sql`
+      WITH buckets AS (
+        SELECT 'window24h' AS window, payload
+          FROM ${sessionEvents}
+          WHERE event_type = 'assistant' AND payload ? 'usage' AND ts > ${since24h}
+        UNION ALL
+        SELECT 'allTime' AS window, payload
+          FROM ${sessionEvents}
+          WHERE event_type = 'assistant' AND payload ? 'usage'
+      )
+      SELECT
+        window,
+        SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text       AS input_tokens,
+        SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text      AS output_tokens,
+        SUM(COALESCE((payload->'usage'->>'cacheRead')::bigint, 0))::text   AS cache_read_tokens,
+        SUM(COALESCE((payload->'usage'->>'cacheWrite')::bigint, 0))::text  AS cache_write_tokens,
+        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+      FROM buckets
+      GROUP BY window
+    `);
+
+    const empty: UsageWindow = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      costUsd: 0,
+    };
+    const out = { window24h: { ...empty }, allTime: { ...empty } };
+    for (const row of rows.rows) {
+      const bucket: UsageWindow = {
+        inputTokens: Number(row.input_tokens ?? 0),
+        outputTokens: Number(row.output_tokens ?? 0),
+        cacheReadTokens: Number(row.cache_read_tokens ?? 0),
+        cacheWriteTokens: Number(row.cache_write_tokens ?? 0),
+        costUsd: Number(row.usd_total ?? 0),
+      };
+      if (row.window === 'window24h') out.window24h = bucket;
+      else out.allTime = bucket;
+    }
+    return out;
+  }
+
+  /**
+   * Per-agent drilldown: token + cost totals plus a per-model breakdown
+   * and a daily series for the last 30 days. Drives the "Usage" drawer in
+   * the admin Fleet UI.
+   */
+  async agentUsageDetail(agentId: string): Promise<AgentUsageDetail> {
+    const now = new Date();
+    const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    const since7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const since30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    const [totals] = await Promise.all([this.fleetUsage([agentId])]);
+    const totalsEntry = totals.get(agentId) ?? {
+      window24h: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+      window7d:  { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+      allTime:   { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+    };
+
+    const modelRows = await this.db.execute<{
+      model: string | null;
+      provider: string | null;
+      calls: string | null;
+      input_tokens: string | null;
+      output_tokens: string | null;
+      usd_total: number | null;
+    }>(sql`
+      SELECT
+        payload->>'model'    AS model,
+        payload->>'provider' AS provider,
+        COUNT(*)::text       AS calls,
+        SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text  AS input_tokens,
+        SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text AS output_tokens,
+        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+      FROM ${sessionEvents}
+      WHERE event_type = 'assistant'
+        AND payload ? 'usage'
+        AND agent_id = ${agentId}
+      GROUP BY model, provider
+      ORDER BY usd_total DESC NULLS LAST
+    `);
+
+    const dailyRows = await this.db.execute<{
+      day: string;
+      input_tokens: string | null;
+      output_tokens: string | null;
+      usd_total: number | null;
+    }>(sql`
+      SELECT
+        to_char(date_trunc('day', ts::timestamptz), 'YYYY-MM-DD') AS day,
+        SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text  AS input_tokens,
+        SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text AS output_tokens,
+        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+      FROM ${sessionEvents}
+      WHERE event_type = 'assistant'
+        AND payload ? 'usage'
+        AND agent_id = ${agentId}
+        AND ts > ${since30d}
+      GROUP BY day
+      ORDER BY day ASC
+    `);
+
+    return {
+      totals: totalsEntry,
+      byModel: modelRows.rows.map((r) => ({
+        model: r.model ?? '(unknown)',
+        ...(r.provider ? { provider: r.provider } : {}),
+        calls: Number(r.calls ?? 0),
+        inputTokens: Number(r.input_tokens ?? 0),
+        outputTokens: Number(r.output_tokens ?? 0),
+        costUsd: Number(r.usd_total ?? 0),
+      })),
+      daily: dailyRows.rows.map((r) => ({
+        day: r.day,
+        inputTokens: Number(r.input_tokens ?? 0),
+        outputTokens: Number(r.output_tokens ?? 0),
+        costUsd: Number(r.usd_total ?? 0),
+      })),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Surface per-agent token usage and cost on the admin Fleet view, with a drawer showing 24h/7d/all-time totals, per-model breakdown, and a 30-day cost timeline.
- Add 24h + all-time token/cost tiles to the gateway StatsPanel.
- Aggregate from `session_events.payload.usage` (pre-computed cost.total) via three new `DbAgentStore` methods: `fleetUsage`, `usageTotals`, `agentUsageDetail`, exposed through `/api/admin/agents/fleet`, `/api/admin/stats`, and a new `GET /api/admin/agents/:agentId/usage` route.

## Test plan
- [ ] `npm run typecheck -w @openhermit/gateway` and `-w @openhermit/store` are clean (already verified locally; pre-existing failures in `apps/agent/test/user-store.test.ts` are unrelated).
- [ ] `vite build apps/gateway/ui` succeeds.
- [ ] Smoke-test in the admin UI: Fleet table shows Tokens 24h / USD 24h columns, action menu "Usage…" opens the drawer, time-window tabs work, StatsPanel shows the new "Token Usage" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage and cost tracking with 24h, 7d, and all-time windows
  * New Usage Dialog displaying daily breakdown and per-model costs
  * Fleet panel now shows per-agent token and USD metrics for the last 24 hours

* **Improvements**
  * Enhanced skill file detection and handling
  * Updated skill prompt formatting for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->