### PR TITLE
fix(store): use inArray() instead of ANY() for fleetUsage agentIds

### DIFF
--- a/packages/store/src/impl/agent-store.ts
+++ b/packages/store/src/impl/agent-store.ts
@@ -313,7 +313,7 @@ export class DbAgentStore implements AgentStore {
         FROM ${sessionEvents}
         WHERE event_type = 'assistant'
           AND payload ? 'usage'
-          AND agent_id = ANY(${agentIds}::text[])
+          AND ${inArray(sessionEvents.agentId, agentIds)}
       ),
       buckets AS (
         SELECT agent_id, 'window24h' AS bucket, payload FROM usage WHERE ts > ${since24h}


### PR DESCRIPTION
## Summary
- Drizzle expands an array interpolation `${agentIds}` as `($1, $2, ...)` — a parenthesised positional list, not a Postgres array literal. Casting that to `text[]` failed at runtime (PG error 42846 / `transformTypeCast`).
- Switch to the `inArray()` helper so the array is bound via a proper `IN (…)` clause.

Follow-up to #101. Discovered on test.openhermit.ai while exercising `/api/admin/agents/fleet`.

## Test plan
- [ ] `npm run typecheck -w @openhermit/store` clean.
- [ ] After deploy, `/api/admin/agents/fleet` returns 200 with `usage` fields populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal database query logic for agent usage data retrieval to improve compatibility with the data access framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->