### PR TITLE
perf(store): partial index on session_events for usage aggregation

### DIFF
--- a/packages/store/drizzle/0024_session_events_usage_idx.sql
+++ b/packages/store/drizzle/0024_session_events_usage_idx.sql
@@ -1,0 +1,8 @@
+-- Partial index on session_events to accelerate the usage aggregation
+-- queries (fleetUsage / usageTotals / agentUsageDetail). Filters to only
+-- the rows that the aggregator scans (assistant events carrying a usage
+-- payload) and leads with (agent_id, ts) so per-agent time-windowed
+-- SUMs can index-scan instead of seq-scanning session_events.
+CREATE INDEX IF NOT EXISTS "idx_session_events_assistant_usage"
+  ON "session_events" ("agent_id", "ts")
+  WHERE event_type = 'assistant' AND payload ? 'usage';

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1779100000000,
       "tag": "0023_session_events_message_id_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1779200000000,
+      "tag": "0024_session_events_usage_idx",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds migration `0024_session_events_usage_idx.sql`: a partial index on `(agent_id, ts)` filtered to `event_type='assistant' AND payload ? 'usage'` — exactly the rows scanned by `fleetUsage` / `usageTotals` / `agentUsageDetail`.
- Before: the all-time + per-agent SUMs in the Fleet poll (every 10s) had to seq-scan `session_events`.
- After: PG can range-scan only assistant events that carry a usage payload.

## Test plan
- [ ] After deploy, the migration applies on gateway start (`migrations applied` log line).
- [ ] `EXPLAIN ANALYZE` on the usage CTE on test shows an Index Scan instead of a Seq Scan.
- [ ] `/api/admin/agents/fleet` response time drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database performance for agent usage reporting and aggregation through optimized indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->