### PR TITLE
fix(ui): scope Usage drawer time tabs to the totals block

### DIFF
--- a/apps/gateway/ui/src/components/UsageDialog.tsx
+++ b/apps/gateway/ui/src/components/UsageDialog.tsx
@@ -61,45 +61,54 @@ export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: ()
 
         {detail && window && (
           <>
-            <div className="usage-window-tabs" role="tablist">
-              {(Object.keys(WINDOW_LABELS) as WindowKey[]).map((k) => (
-                <button
-                  key={k}
-                  role="tab"
-                  aria-selected={windowKey === k}
-                  className={`btn btn--sm${windowKey === k ? ' btn--primary' : ' btn--ghost'}`}
-                  onClick={() => setWindowKey(k)}
-                >
-                  {WINDOW_LABELS[k]}
-                </button>
-              ))}
-            </div>
+            <section className="usage-section usage-section--totals">
+              <header className="usage-section__head">
+                <h4 className="usage-section__title">Totals</h4>
+                <div className="usage-window-tabs" role="tablist" aria-label="Time range for totals">
+                  {(Object.keys(WINDOW_LABELS) as WindowKey[]).map((k) => (
+                    <button
+                      key={k}
+                      role="tab"
+                      aria-selected={windowKey === k}
+                      className={`btn btn--sm${windowKey === k ? ' btn--primary' : ' btn--ghost'}`}
+                      onClick={() => setWindowKey(k)}
+                    >
+                      {WINDOW_LABELS[k]}
+                    </button>
+                  ))}
+                </div>
+              </header>
 
-            <div className="usage-tiles">
-              <div className="usage-tile">
-                <div className="usage-tile__label">Input tokens</div>
-                <div className="usage-tile__value">{formatTokens(window.inputTokens)}</div>
+              <div className="usage-tiles">
+                <div className="usage-tile">
+                  <div className="usage-tile__label">Input tokens</div>
+                  <div className="usage-tile__value">{formatTokens(window.inputTokens)}</div>
+                </div>
+                <div className="usage-tile">
+                  <div className="usage-tile__label">Output tokens</div>
+                  <div className="usage-tile__value">{formatTokens(window.outputTokens)}</div>
+                </div>
+                <div className="usage-tile">
+                  <div className="usage-tile__label">Cache read</div>
+                  <div className="usage-tile__value">{formatTokens(window.cacheReadTokens)}</div>
+                </div>
+                <div className="usage-tile">
+                  <div className="usage-tile__label">Cache write</div>
+                  <div className="usage-tile__value">{formatTokens(window.cacheWriteTokens)}</div>
+                </div>
+                <div className="usage-tile usage-tile--cost">
+                  <div className="usage-tile__label">Total cost</div>
+                  <div className="usage-tile__value">{formatUsd(window.costUsd)}</div>
+                </div>
               </div>
-              <div className="usage-tile">
-                <div className="usage-tile__label">Output tokens</div>
-                <div className="usage-tile__value">{formatTokens(window.outputTokens)}</div>
-              </div>
-              <div className="usage-tile">
-                <div className="usage-tile__label">Cache read</div>
-                <div className="usage-tile__value">{formatTokens(window.cacheReadTokens)}</div>
-              </div>
-              <div className="usage-tile">
-                <div className="usage-tile__label">Cache write</div>
-                <div className="usage-tile__value">{formatTokens(window.cacheWriteTokens)}</div>
-              </div>
-              <div className="usage-tile usage-tile--cost">
-                <div className="usage-tile__label">Total cost</div>
-                <div className="usage-tile__value">{formatUsd(window.costUsd)}</div>
-              </div>
-            </div>
+            </section>
 
-            <h4 className="usage-section-heading">By model</h4>
-            {detail.byModel.length === 0 ? (
+            <section className="usage-section">
+              <header className="usage-section__head">
+                <h4 className="usage-section__title">By model</h4>
+                <span className="usage-section__range">All time</span>
+              </header>
+              {detail.byModel.length === 0 ? (
               <p className="secrets-empty">No assistant events yet.</p>
             ) : (
               <table className="usage-table">
@@ -132,29 +141,35 @@ export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: ()
                 </tbody>
               </table>
             )}
+            </section>
 
-            <h4 className="usage-section-heading">Daily (last 30 days)</h4>
-            {detail.daily.length === 0 ? (
-              <p className="secrets-empty">No activity in the last 30 days.</p>
-            ) : (
-              <div className="usage-daily">
-                {detail.daily.map((d) => (
-                  <div className="usage-daily__row" key={d.day}>
-                    <span className="usage-daily__day">{d.day}</span>
-                    <div className="usage-daily__bar-wrap">
-                      <div
-                        className="usage-daily__bar"
-                        style={{ width: `${Math.max(2, (d.costUsd / maxDailyCost) * 100)}%` }}
-                      />
+            <section className="usage-section">
+              <header className="usage-section__head">
+                <h4 className="usage-section__title">Daily</h4>
+                <span className="usage-section__range">Last 30 days</span>
+              </header>
+              {detail.daily.length === 0 ? (
+                <p className="secrets-empty">No activity in the last 30 days.</p>
+              ) : (
+                <div className="usage-daily">
+                  {detail.daily.map((d) => (
+                    <div className="usage-daily__row" key={d.day}>
+                      <span className="usage-daily__day">{d.day}</span>
+                      <div className="usage-daily__bar-wrap">
+                        <div
+                          className="usage-daily__bar"
+                          style={{ width: `${Math.max(2, (d.costUsd / maxDailyCost) * 100)}%` }}
+                        />
+                      </div>
+                      <span className="usage-daily__tokens">
+                        {formatTokens(d.inputTokens + d.outputTokens)}
+                      </span>
+                      <span className="usage-daily__cost">{formatUsd(d.costUsd)}</span>
                     </div>
-                    <span className="usage-daily__tokens">
-                      {formatTokens(d.inputTokens + d.outputTokens)}
-                    </span>
-                    <span className="usage-daily__cost">{formatUsd(d.costUsd)}</span>
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </div>
+              )}
+            </section>
           </>
         )}
 

--- a/apps/gateway/ui/src/styles.css
+++ b/apps/gateway/ui/src/styles.css
@@ -1064,17 +1064,53 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
 
 /* --- Usage dialog --- */
 
+.usage-section {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem 0.9rem;
+  background: var(--bg);
+  margin-bottom: 0.9rem;
+}
+
+.usage-section--totals {
+  background: var(--bg-surface);
+}
+
+.usage-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 0.6rem;
+}
+
+.usage-section__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.usage-section__range {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+}
+
 .usage-window-tabs {
   display: flex;
   gap: 6px;
-  margin-bottom: 0.5rem;
 }
 
 .usage-tiles {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 8px;
-  margin-bottom: 1rem;
 }
 
 .usage-tile {
@@ -1098,14 +1134,6 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
   font-size: 1.15rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-}
-
-.usage-section-heading {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  margin: 1rem 0 0.4rem;
 }
 
 .usage-table {


### PR DESCRIPTION
## Summary
The 24h / 7d / All-time tabs sat at the top of the Usage drawer, implying they filter every section. They don't — the **By model** table is always all-time and the **Daily** chart is always last-30-days.

Restructured into three labelled sections:
- **Totals** — owns the window tabs, only the five tiles react.
- **By model · All time** — fixed range, displayed as a chip.
- **Daily · Last 30 days** — fixed range, displayed as a chip.

## Test plan
- [ ] Open the Usage drawer for an agent; verify the window tabs are visually attached to "Totals".
- [ ] Click between 24h / 7d / All time — only the tile values change; By model + Daily stay the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the Usage Dialog layout into clearly organized sections with improved visual hierarchy. Time period controls and headers now display time ranges explicitly for better clarity.

* **Style**
  * Updated styling to support the new section-based structure with refined spacing and layout organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->