### PR TITLE
feat(ui): split Usage modal into Overview / By model / Daily tabs

### DIFF
--- a/apps/gateway/ui/src/components/UsageDialog.tsx
+++ b/apps/gateway/ui/src/components/UsageDialog.tsx
@@ -25,6 +25,7 @@ interface AgentUsageDetail {
 }
 
 type WindowKey = 'window24h' | 'window7d' | 'allTime';
+type Tab = 'overview' | 'byModel' | 'daily';
 
 const WINDOW_LABELS: Record<WindowKey, string> = {
   window24h: 'Last 24h',
@@ -32,10 +33,17 @@ const WINDOW_LABELS: Record<WindowKey, string> = {
   allTime: 'All time',
 };
 
+const TAB_LABELS: Record<Tab, string> = {
+  overview: 'Overview',
+  byModel: 'By model',
+  daily: 'Daily',
+};
+
 export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: () => void }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [detail, setDetail] = useState<AgentUsageDetail | null>(null);
   const [error, setError] = useState('');
+  const [tab, setTab] = useState<Tab>('overview');
   const [windowKey, setWindowKey] = useState<WindowKey>('window24h');
 
   useEffect(() => { dialogRef.current?.showModal(); }, []);
@@ -46,7 +54,7 @@ export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: ()
       .catch((err) => setError((err as Error).message));
   }, [agentId]);
 
-  const window = detail?.totals[windowKey];
+  const win = detail?.totals[windowKey];
   const maxDailyCost = detail
     ? Math.max(0.0001, ...detail.daily.map((d) => d.costUsd))
     : 0.0001;
@@ -59,12 +67,25 @@ export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: ()
         {error && <p className="config-error">{error}</p>}
         {!detail && !error && <p className="secrets-empty">Loading…</p>}
 
-        {detail && window && (
+        {detail && (
           <>
-            <section className="usage-section usage-section--totals">
-              <header className="usage-section__head">
-                <h4 className="usage-section__title">Totals</h4>
-                <div className="usage-window-tabs" role="tablist" aria-label="Time range for totals">
+            <div className="usage-main-tabs" role="tablist" aria-label="Usage view">
+              {(Object.keys(TAB_LABELS) as Tab[]).map((k) => (
+                <button
+                  key={k}
+                  role="tab"
+                  aria-selected={tab === k}
+                  className={`usage-main-tab${tab === k ? ' usage-main-tab--active' : ''}`}
+                  onClick={() => setTab(k)}
+                >
+                  {TAB_LABELS[k]}
+                </button>
+              ))}
+            </div>
+
+            {tab === 'overview' && win && (
+              <div className="usage-tab-panel" role="tabpanel">
+                <div className="usage-window-tabs" role="tablist" aria-label="Time range">
                   {(Object.keys(WINDOW_LABELS) as WindowKey[]).map((k) => (
                     <button
                       key={k}
@@ -77,99 +98,97 @@ export function UsageDialog({ agentId, onClose }: { agentId: string; onClose: ()
                     </button>
                   ))}
                 </div>
-              </header>
 
-              <div className="usage-tiles">
-                <div className="usage-tile">
-                  <div className="usage-tile__label">Input tokens</div>
-                  <div className="usage-tile__value">{formatTokens(window.inputTokens)}</div>
-                </div>
-                <div className="usage-tile">
-                  <div className="usage-tile__label">Output tokens</div>
-                  <div className="usage-tile__value">{formatTokens(window.outputTokens)}</div>
-                </div>
-                <div className="usage-tile">
-                  <div className="usage-tile__label">Cache read</div>
-                  <div className="usage-tile__value">{formatTokens(window.cacheReadTokens)}</div>
-                </div>
-                <div className="usage-tile">
-                  <div className="usage-tile__label">Cache write</div>
-                  <div className="usage-tile__value">{formatTokens(window.cacheWriteTokens)}</div>
-                </div>
-                <div className="usage-tile usage-tile--cost">
-                  <div className="usage-tile__label">Total cost</div>
-                  <div className="usage-tile__value">{formatUsd(window.costUsd)}</div>
+                <div className="usage-tiles">
+                  <div className="usage-tile">
+                    <div className="usage-tile__label">Input tokens</div>
+                    <div className="usage-tile__value">{formatTokens(win.inputTokens)}</div>
+                  </div>
+                  <div className="usage-tile">
+                    <div className="usage-tile__label">Output tokens</div>
+                    <div className="usage-tile__value">{formatTokens(win.outputTokens)}</div>
+                  </div>
+                  <div className="usage-tile">
+                    <div className="usage-tile__label">Cache read</div>
+                    <div className="usage-tile__value">{formatTokens(win.cacheReadTokens)}</div>
+                  </div>
+                  <div className="usage-tile">
+                    <div className="usage-tile__label">Cache write</div>
+                    <div className="usage-tile__value">{formatTokens(win.cacheWriteTokens)}</div>
+                  </div>
+                  <div className="usage-tile usage-tile--cost">
+                    <div className="usage-tile__label">Total cost</div>
+                    <div className="usage-tile__value">{formatUsd(win.costUsd)}</div>
+                  </div>
                 </div>
               </div>
-            </section>
-
-            <section className="usage-section">
-              <header className="usage-section__head">
-                <h4 className="usage-section__title">By model</h4>
-                <span className="usage-section__range">All time</span>
-              </header>
-              {detail.byModel.length === 0 ? (
-              <p className="secrets-empty">No assistant events yet.</p>
-            ) : (
-              <table className="usage-table">
-                <thead>
-                  <tr>
-                    <th>Model</th>
-                    <th className="fleet-table__num">Calls</th>
-                    <th className="fleet-table__num">Input</th>
-                    <th className="fleet-table__num">Output</th>
-                    <th className="fleet-table__num">USD</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {detail.byModel.map((m, i) => (
-                    <tr key={`${m.model}-${m.provider ?? ''}-${i}`}>
-                      <td>
-                        <div className="usage-model-cell">
-                          <span className="usage-model-cell__name">{m.model}</span>
-                          {m.provider && (
-                            <span className="usage-model-cell__provider">{m.provider}</span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="fleet-table__num">{m.calls.toLocaleString()}</td>
-                      <td className="fleet-table__num">{formatTokens(m.inputTokens)}</td>
-                      <td className="fleet-table__num">{formatTokens(m.outputTokens)}</td>
-                      <td className="fleet-table__num">{formatUsd(m.costUsd)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
             )}
-            </section>
 
-            <section className="usage-section">
-              <header className="usage-section__head">
-                <h4 className="usage-section__title">Daily</h4>
-                <span className="usage-section__range">Last 30 days</span>
-              </header>
-              {detail.daily.length === 0 ? (
-                <p className="secrets-empty">No activity in the last 30 days.</p>
-              ) : (
-                <div className="usage-daily">
-                  {detail.daily.map((d) => (
-                    <div className="usage-daily__row" key={d.day}>
-                      <span className="usage-daily__day">{d.day}</span>
-                      <div className="usage-daily__bar-wrap">
-                        <div
-                          className="usage-daily__bar"
-                          style={{ width: `${Math.max(2, (d.costUsd / maxDailyCost) * 100)}%` }}
-                        />
+            {tab === 'byModel' && (
+              <div className="usage-tab-panel" role="tabpanel">
+                <p className="usage-tab-note">All time</p>
+                {detail.byModel.length === 0 ? (
+                  <p className="secrets-empty">No assistant events yet.</p>
+                ) : (
+                  <table className="usage-table">
+                    <thead>
+                      <tr>
+                        <th>Model</th>
+                        <th className="fleet-table__num">Calls</th>
+                        <th className="fleet-table__num">Input</th>
+                        <th className="fleet-table__num">Output</th>
+                        <th className="fleet-table__num">USD</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detail.byModel.map((m, i) => (
+                        <tr key={`${m.model}-${m.provider ?? ''}-${i}`}>
+                          <td>
+                            <div className="usage-model-cell">
+                              <span className="usage-model-cell__name">{m.model}</span>
+                              {m.provider && (
+                                <span className="usage-model-cell__provider">{m.provider}</span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="fleet-table__num">{m.calls.toLocaleString()}</td>
+                          <td className="fleet-table__num">{formatTokens(m.inputTokens)}</td>
+                          <td className="fleet-table__num">{formatTokens(m.outputTokens)}</td>
+                          <td className="fleet-table__num">{formatUsd(m.costUsd)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            )}
+
+            {tab === 'daily' && (
+              <div className="usage-tab-panel" role="tabpanel">
+                <p className="usage-tab-note">Last 30 days</p>
+                {detail.daily.length === 0 ? (
+                  <p className="secrets-empty">No activity in the last 30 days.</p>
+                ) : (
+                  <div className="usage-daily">
+                    {detail.daily.map((d) => (
+                      <div className="usage-daily__row" key={d.day}>
+                        <span className="usage-daily__day">{d.day}</span>
+                        <div className="usage-daily__bar-wrap">
+                          <div
+                            className="usage-daily__bar"
+                            style={{ width: `${Math.max(2, (d.costUsd / maxDailyCost) * 100)}%` }}
+                          />
+                        </div>
+                        <span className="usage-daily__tokens">
+                          {formatTokens(d.inputTokens + d.outputTokens)}
+                        </span>
+                        <span className="usage-daily__cost">{formatUsd(d.costUsd)}</span>
                       </div>
-                      <span className="usage-daily__tokens">
-                        {formatTokens(d.inputTokens + d.outputTokens)}
-                      </span>
-                      <span className="usage-daily__cost">{formatUsd(d.costUsd)}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </section>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </>
         )}
 

--- a/apps/gateway/ui/src/styles.css
+++ b/apps/gateway/ui/src/styles.css
@@ -1064,42 +1064,47 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
 
 /* --- Usage dialog --- */
 
-.usage-section {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.75rem 0.9rem 0.9rem;
-  background: var(--bg);
-  margin-bottom: 0.9rem;
-}
-
-.usage-section--totals {
-  background: var(--bg-surface);
-}
-
-.usage-section__head {
+.usage-main-tabs {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-bottom: 0.6rem;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
 }
 
-.usage-section__title {
-  font-size: 0.95rem;
-  font-weight: 600;
+.usage-main-tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.usage-main-tab:hover {
+  color: var(--text);
+}
+
+.usage-main-tab--active {
+  color: var(--text);
+  border-bottom-color: var(--brand);
+}
+
+.usage-tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.usage-tab-note {
   margin: 0;
-}
-
-.usage-section__range {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
 }
 
 .usage-window-tabs {


### PR DESCRIPTION
## Summary
- Replaces the long scrolling Usage modal with three top-level tabs: **Overview**, **By model**, **Daily**.
- **Overview** owns the 24h / 7d / All-time time-range tabs and the five totals tiles.
- **By model** shows the per-model table with an "All time" subtitle.
- **Daily** shows the last-30-days bars with a "Last 30 days" subtitle.

## Test plan
- [ ] Open the Usage drawer; verify the three top-level tabs render with an underline-style active indicator.
- [ ] Click Overview and toggle 24h/7d/All time — the tiles update.
- [ ] Click By model and Daily — each shows its own data with the fixed-range subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Usage Dialog with intuitive tabbed interface for improved organization
  * Overview tab: Displays comprehensive usage summary including token counts, cache metrics, and total costs
  * By Model tab: View detailed usage breakdown organized by model and provider with call counts and costs
  * Daily tab: Track daily usage patterns and costs with visual representation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->