### PR TITLE
fix(telegram): pass channelUserId on realtime approval review

### DIFF
--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -577,10 +577,12 @@ export class TelegramBridge implements ChannelOutbound {
     this.pendingApprovals.delete(id);
 
     try {
-      await this.client.submitApproval(pending.sessionId, {
+      const approvalReq: Parameters<typeof this.client.submitApproval>[1] = {
         toolCallId: pending.toolCallId,
         approved,
-      });
+      };
+      if (query.from?.id) approvalReq.channelUserId = String(query.from.id);
+      await this.client.submitApproval(pending.sessionId, approvalReq);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.log(`approval submission failed: ${msg}`);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -101,9 +101,11 @@ export class AgentLocalClient {
 
   async submitApproval(
     sessionId: string,
-    request: ToolApprovalRequest,
+    request: ToolApprovalRequest & { channelUserId?: string },
   ): Promise<{ resolved: boolean }> {
-    return this.postJson(agentLocalRoutes.sessionApprove(sessionId), request);
+    const { channelUserId, ...body } = request;
+    const headers = channelUserId ? { 'x-channel-user-id': channelUserId } : undefined;
+    return this.postJson(agentLocalRoutes.sessionApprove(sessionId), body, headers);
   }
 
   async checkpointSession(


### PR DESCRIPTION
## Summary
- Bridge's `handleRealtimeApproval` now forwards `query.from.id` as `channelUserId` when calling `submitApproval`, matching the async path already does.
- SDK's `submitApproval` accepts an optional `channelUserId` and sends it via `x-channel-user-id` (same shape as `reviewApprovalRequest`).

## Root cause
Clicking the Approve/Reject button on a realtime approval (e.g. `memory_add`) was failing with "Session not found".

The gateway route `POST /api/agents/:agentId/sessions/:sessionId/approve` runs `requireSessionAccessHttp` for channel-mode callers. That function calls `resolveCallerUserId({ channel, channelUserId })` and throws `NotFoundError('Session not found: ...')` when no user can be resolved. The bridge wasn't sending the telegram user's id, so the lookup silently returned undefined.

The async approval path (`handleAsyncApproval` → `reviewApprovalRequestByShortId`) already attached `channelUserId`, so persistent approvals were unaffected — only the realtime (in-flight) path was broken.

## Test plan
- [ ] On a telegram-connected agent, trigger a realtime approval (e.g. attempt `memory_add` from a chat session) and click ✅ Approve.
- [ ] Verify Telegram shows "Approved" (not "Failed: Session not found").
- [ ] Verify the agent run proceeds.
- [ ] Re-run the async approval flow to make sure it still works (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved approval submission handling to better track user identification across channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->