### PR TITLE
feat(channels): public gateway URL, auto-start, persisted errors

### DIFF
--- a/apps/agent/test/channel-manifest-registry.test.ts
+++ b/apps/agent/test/channel-manifest-registry.test.ts
@@ -11,6 +11,7 @@ import {
 
 const dummyContext: ChannelContext = {
   agentBaseUrl: 'http://localhost:0',
+  publicAgentBaseUrl: 'http://localhost:0',
   agentTokens: {},
   logger: () => {},
 };

--- a/apps/channels/telegram/src/manifest.ts
+++ b/apps/channels/telegram/src/manifest.ts
@@ -42,9 +42,16 @@ const manifest: ChannelManifest = {
       logger: log,
     };
     if (mode === 'webhook') {
-      const derivedUrl =
-        config.webhook_url ||
-        `${context.agentBaseUrl}/channels/telegram/webhook`;
+      let derivedUrl: string;
+      if (config.webhook_url) {
+        derivedUrl = config.webhook_url;
+      } else if (context.publicAgentBaseUrl === context.agentBaseUrl) {
+        throw new Error(
+          'Telegram webhook mode needs a public URL. Either set OPENHERMIT_GATEWAY_PUBLIC_URL on the gateway or provide webhook_url in the channel config.',
+        );
+      } else {
+        derivedUrl = `${context.publicAgentBaseUrl}/channels/telegram/webhook`;
+      }
       botOptions.webhookUrl = derivedUrl;
       const secret = context.agentTokens['telegram'];
       if (secret) botOptions.webhookSecret = secret;

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2324,8 +2324,16 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         ? def.secretKeys.every((sk) => secretNames.includes(sk.key))
         : true;
       const runtime = runtimeStatuses.find((s) => s.name === row.channelType);
-      const status = !row.enabled ? 'disabled' : runtime?.status ?? 'unknown';
-      const error = runtime?.status === 'error' ? runtime.error : undefined;
+      // Prefer the live in-memory status (always current within this
+      // gateway process), but fall back to the persisted error so a
+      // failed-start that happened before the user's first GET (e.g. on
+      // a fresh gateway boot) is still visible.
+      const status = !row.enabled
+        ? 'disabled'
+        : runtime?.status ?? (row.lastError ? 'error' : 'unknown');
+      const error = runtime
+        ? runtime.status === 'error' ? runtime.error : undefined
+        : row.lastError ?? undefined;
       return {
         ...row,
         ...(def ? { label: row.label ?? def.label, secretKeys: def.secretKeys } : {}),
@@ -2419,6 +2427,21 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         ...(body.config ? { config: body.config } : {}),
         ...(typeof body.enabled === 'boolean' ? { enabled: body.enabled } : {}),
       });
+
+      // Auto-start the bridge so the user doesn't need a separate enable
+      // call. If start fails (e.g. webhook mode but no public URL),
+      // surface the error in the response — the row stays in DB so the
+      // user can fix config via PATCH.
+      if (created.enabled) {
+        const pool = instances.getChannelPool();
+        if (pool) {
+          const status = await pool.enableChannel(agentId, channelType);
+          return c.json(
+            { ...created, runtimeStatus: status.status, ...(status.error ? { error: status.error } : {}) },
+            201,
+          );
+        }
+      }
       return c.json(created, 201);
     }
 
@@ -2492,17 +2515,29 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     });
     if (!updated) throw new NotFoundError(`Channel ${channelId} not found.`);
 
-    // Builtin channel runtime side-effects: enable → start, disable → stop.
-    if (existing.kind === 'builtin' && body.enabled !== undefined) {
+    // Builtin runtime side-effects:
+    //   enable=true              → start (or restart if already running)
+    //   enable=false             → stop
+    //   config changed, enabled  → restart so the new config takes effect
+    //                              (e.g. polling↔webhook mode switch)
+    if (existing.kind === 'builtin') {
       const pool = instances.getChannelPool();
       if (!pool) {
         throw new Error('channel pool not available');
       }
-      if (body.enabled) {
-        const status = await pool.enableChannel(agentId, existing.channelType);
-        return c.json({ ...updated, runtimeStatus: status.status, error: status.error });
-      } else {
+      const shouldDisable = body.enabled === false;
+      const shouldEnable =
+        body.enabled === true ||
+        (effectiveConfig !== undefined && updated.enabled);
+      if (shouldDisable) {
         await pool.disableChannel(agentId, existing.channelType);
+      } else if (shouldEnable) {
+        const status = await pool.enableChannel(agentId, existing.channelType);
+        return c.json({
+          ...updated,
+          runtimeStatus: status.status,
+          ...(status.error ? { error: status.error } : {}),
+        });
       }
     }
 

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -39,7 +39,15 @@ export interface ChannelPoolOptions {
   secretStore: SecretStore;
   channelRegistry: ChannelRegistry;
   manifestRegistry: ChannelManifestRegistry;
+  /** Internal URL the bridges use to call back into the gateway (loopback). */
   gatewayBaseUrl: string;
+  /**
+   * Public-facing URL of the gateway, used when a manifest registers a
+   * webhook URL with an external service (Telegram setWebhook etc.).
+   * Undefined when the operator has not configured a public URL — in
+   * that case webhook-mode channels should refuse to start.
+   */
+  publicGatewayBaseUrl?: string;
   /** Live-runner lookup so enable/disable can update the hot runner's outbounds. */
   getRunner: (agentId: string) => AgentRunner | undefined;
   log: (message: string) => void;
@@ -109,36 +117,43 @@ export class ChannelPool {
     return security;
   }
 
+  private agentBaseUrls(agentId: string): { agentBaseUrl: string; publicAgentBaseUrl: string } {
+    const segment = `/api/agents/${encodeURIComponent(agentId)}`;
+    const agentBaseUrl = `${this.opts.gatewayBaseUrl}${segment}`;
+    const publicAgentBaseUrl = this.opts.publicGatewayBaseUrl
+      ? `${this.opts.publicGatewayBaseUrl}${segment}`
+      : agentBaseUrl;
+    return { agentBaseUrl, publicAgentBaseUrl };
+  }
+
   private async startBuiltinsForAgent(
     agentId: string,
-    rows: Array<{ channelType: string; token: string; config: Record<string, unknown> }>,
+    rows: Array<{ id: string; channelType: string; token: string; config: Record<string, unknown> }>,
   ): Promise<void> {
     const security = await this.loadSecurity(agentId);
-    const agentBaseUrl = `${this.opts.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
+    const { agentBaseUrl, publicAgentBaseUrl } = this.agentBaseUrls(agentId);
     const startedHandles: ChannelHandle[] = [];
     const startedStatuses: ChannelStatus[] = [];
 
     for (const row of rows) {
       const manifest = this.opts.manifestRegistry.get(row.channelType);
       if (!manifest) {
-        this.opts.log(
-          `[${agentId}] [${row.channelType}] no manifest registered — skipping`,
-        );
-        startedStatuses.push({
-          name: row.channelType,
-          status: 'error',
-          error: `no manifest registered for channel "${row.channelType}"`,
-        });
+        const errMsg = `no manifest registered for channel "${row.channelType}"`;
+        this.opts.log(`[${agentId}] [${row.channelType}] ${errMsg} — skipping`);
+        startedStatuses.push({ name: row.channelType, status: 'error', error: errMsg });
+        await this.persistError(row.id, errMsg);
         continue;
       }
       const resolved = await security.expandSecrets({ ...row.config, enabled: true });
       const { handle, status } = await startSingleChannel(manifest, resolved, {
         agentBaseUrl,
+        publicAgentBaseUrl,
         agentTokens: { [manifest.key]: row.token },
         logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
       });
       if (handle) startedHandles.push(handle);
       startedStatuses.push(status);
+      await this.persistError(row.id, status.status === 'error' ? status.error ?? 'unknown error' : null);
     }
 
     if (startedHandles.length > 0) this.handles.set(agentId, startedHandles);
@@ -146,6 +161,16 @@ export class ChannelPool {
     if (startedHandles.length > 0) {
       this.opts.log(
         `[${agentId}] pool started ${startedHandles.length} channel(s): ${startedHandles.map((h) => h.name).join(', ')}`,
+      );
+    }
+  }
+
+  private async persistError(channelId: string, error: string | null): Promise<void> {
+    try {
+      await this.opts.channelStore.recordError(channelId, error);
+    } catch (err) {
+      this.opts.log(
+        `failed to persist channel error for ${channelId}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
@@ -237,15 +262,17 @@ export class ChannelPool {
       if (existingIdx !== -1) statuses[existingIdx] = errorStatus;
       else statuses.push(errorStatus);
       this.statuses.set(agentId, statuses);
+      await this.persistError(row.id, errorStatus.error ?? 'no manifest');
       return errorStatus;
     }
 
     const security = await this.loadSecurity(agentId);
     const resolved = await security.expandSecrets({ ...row.config, enabled: true });
-    const agentBaseUrl = `${this.opts.gatewayBaseUrl}/api/agents/${encodeURIComponent(agentId)}`;
+    const { agentBaseUrl, publicAgentBaseUrl } = this.agentBaseUrls(agentId);
 
     const { handle, status } = await startSingleChannel(manifest, resolved, {
       agentBaseUrl,
+      publicAgentBaseUrl,
       agentTokens: { [manifest.key]: loaded.token },
       logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
     });
@@ -264,6 +291,8 @@ export class ChannelPool {
     if (existingIdx !== -1) statuses[existingIdx] = status;
     else statuses.push(status);
     this.statuses.set(agentId, statuses);
+
+    await this.persistError(row.id, status.status === 'error' ? status.error ?? 'unknown error' : null);
 
     return status;
   }
@@ -297,6 +326,11 @@ export class ChannelPool {
     const sIdx = statuses.findIndex((s) => s.name === channelName);
     if (sIdx !== -1) statuses.splice(sIdx, 1);
     if (statuses.length === 0) this.statuses.delete(agentId);
+
+    // Disabling is a deliberate user action — clear the stale error so
+    // the UI doesn't keep showing it after the user has acknowledged it.
+    const row = await this.opts.channelStore.findBuiltin(agentId, channelName);
+    if (row) await this.persistError(row.id, null);
 
     this.opts.log(`[${agentId}] pool stopped channel: ${channelName}`);
   }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -417,6 +417,7 @@ export const main = async (): Promise<void> => {
   if (agentChannelStore && agentStore && configStore) {
     const secretStore = instances.getSecretStore();
     if (secretStore) {
+      const publicGatewayBaseUrl = process.env.OPENHERMIT_GATEWAY_PUBLIC_URL?.replace(/\/+$/, '');
       channelPool = new ChannelPool({
         agentStore,
         channelStore: agentChannelStore,
@@ -427,6 +428,7 @@ export const main = async (): Promise<void> => {
         // Channel adapters connect back from inside the host. Use
         // 127.0.0.1 even when the public listener is 0.0.0.0.
         gatewayBaseUrl: `http://127.0.0.1:${info.port}`,
+        ...(publicGatewayBaseUrl ? { publicGatewayBaseUrl } : {}),
         getRunner: (agentId) => instances.getRunner(agentId),
         log: logStartup,
       });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -274,6 +274,13 @@ export interface ChannelOutbound {
  */
 export interface ChannelContext {
   agentBaseUrl: string;
+  /**
+   * Public-facing equivalent of `agentBaseUrl`. Used by manifests that
+   * register a URL with an external service that must POST back over
+   * the public internet (e.g. Telegram `setWebhook`). Falls back to
+   * `agentBaseUrl` when the gateway has no public URL configured.
+   */
+  publicAgentBaseUrl: string;
   agentTokens: Record<string, string>;
   logger: (channel: string, message: string) => void;
 }

--- a/packages/store/drizzle/0025_agent_channels_last_error.sql
+++ b/packages/store/drizzle/0025_agent_channels_last_error.sql
@@ -1,0 +1,7 @@
+-- Persist the last channel-runtime error so it survives gateway restarts
+-- and is visible to the user in the channels list when a bridge fails to
+-- start (e.g. invalid bot token, revoked OAuth grant, webhook URL needed
+-- but not configured).
+ALTER TABLE "agent_channels"
+  ADD COLUMN IF NOT EXISTS "last_error" TEXT,
+  ADD COLUMN IF NOT EXISTS "last_error_at" TEXT;

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1779200000000,
       "tag": "0024_session_events_usage_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1779300000000,
+      "tag": "0025_agent_channels_last_error",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/db-agent-channel-store.ts
+++ b/packages/store/src/impl/db-agent-channel-store.ts
@@ -39,6 +39,8 @@ export interface AgentChannelRow {
   updatedAt: string;
   lastUsedAt: string | null;
   revokedAt: string | null;
+  lastError: string | null;
+  lastErrorAt: string | null;
 }
 
 export interface CreatedAgentChannel extends AgentChannelRow {
@@ -180,6 +182,8 @@ export class DbAgentChannelStore {
       updatedAt: now,
       lastUsedAt: null,
       revokedAt: null,
+      lastError: null,
+      lastErrorAt: null,
       token,
     };
   }
@@ -227,6 +231,20 @@ export class DbAgentChannelStore {
       .where(eq(agentChannels.id, id))
       .returning();
     return row ? rowToPublic(row) : undefined;
+  }
+
+  /**
+   * Record the last bridge-start error so it persists across gateway
+   * restarts and is visible in the channels list. Pass `null` to clear
+   * after a successful start.
+   */
+  async recordError(id: string, error: string | null): Promise<void> {
+    await this.db.update(agentChannels)
+      .set({
+        lastError: error,
+        lastErrorAt: error ? new Date().toISOString() : null,
+      })
+      .where(eq(agentChannels.id, id));
   }
 
   /** Soft-delete: mark revoked so it stops resolving. */
@@ -286,4 +304,6 @@ const rowToPublic = (row: typeof agentChannels.$inferSelect): AgentChannelRow =>
   updatedAt: row.updatedAt,
   lastUsedAt: row.lastUsedAt,
   revokedAt: row.revokedAt,
+  lastError: row.lastError,
+  lastErrorAt: row.lastErrorAt,
 });

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -116,6 +116,9 @@ export const agentChannels = pgTable('agent_channels', {
   updatedAt: text('updated_at').notNull(),
   lastUsedAt: text('last_used_at'),
   revokedAt: text('revoked_at'),
+  /** Last bridge-start error, surfaced in the channels list UI. */
+  lastError: text('last_error'),
+  lastErrorAt: text('last_error_at'),
 }, (table) => [
   index('idx_agent_channels_agent').on(table.agentId),
 ]);


### PR DESCRIPTION
## Summary

Four related improvements to the channel lifecycle.

- **Public URL config** — `OPENHERMIT_GATEWAY_PUBLIC_URL` is now read at gateway boot and threaded through to manifests as `ChannelContext.publicAgentBaseUrl`. Telegram webhook mode now derives its URL from this (falling back to `webhook_url` in config), and refuses to start with a clear error when neither is configured.
- **Auto-start on POST** — creating an enabled channel now starts the bridge automatically. Previously you had to PATCH `{enabled: true}` afterwards.
- **Restart on config change** — PATCH now restarts the bridge when config changes (not only on enable toggle), so polling↔webhook switches and bot-token rotations take effect immediately.
- **Persisted runtime errors** — added `agent_channels.last_error` + `last_error_at`. `ChannelPool` writes the latest start error (clearing on success) so failures survive gateway restarts and stay visible in the channels list even before the first GET hydrates in-memory status. Disable clears the error since it's a deliberate user action.

## Migration

`0025_agent_channels_last_error.sql` adds the two nullable text columns.

## Test plan

- [ ] On test.openhermit.ai: set `OPENHERMIT_GATEWAY_PUBLIC_URL=https://test.openhermit.ai`, switch telegram to webhook mode → bot calls `setWebhook` with the public URL.
- [ ] Without the env var set, switching to webhook mode shows the "needs a public URL" error in the channels list.
- [ ] Create a wechat channel without scanning the QR code → channel list shows the start error.
- [ ] Toggle telegram polling→webhook→polling via PATCH; bridge mode actually changes (`getWebhookInfo` reflects it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel runtime errors are now tracked and displayed, persisting across gateway restarts
  * Support for configuring public gateway URLs for external webhook callbacks
  * Automatic channel startup on creation and intelligent restart on configuration changes

* **Bug Fixes**
  * Enhanced webhook validation to ensure proper public URL accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->