### PR TITLE
fix(agent): don't duplicate new user message on first turn after resume

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2481,10 +2481,14 @@ export class AgentRunner implements SessionRuntime {
       });
     }
 
-    // Prepend restored history from DB so it's treated identically to
-    // messages that accumulated in memory during a live session.
+    // When we restored from DB, drop the in-memory `messages`: the current
+    // turn's user input was persisted by `postMessage` before `agent.prompt`
+    // was queued, so it's already at the tail of `restoredMessages`. Keeping
+    // both lists would duplicate the latest user message (observed on the
+    // first turn after channel-driven session resume — e.g. one "hi" arriving
+    // as "hi\n\nhi" to the model).
     const allMessages = restoredMessages.length > 0
-      ? [...restoredMessages, ...messages]
+      ? restoredMessages
       : messages;
 
     // Truncate oversized tool results before compaction so that a single

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -890,6 +890,80 @@ test('AgentRunner injects session resumption context when reopening a persisted 
   );
 });
 
+test('AgentRunner does not duplicate the new user message on the first turn after resume', async (t) => {
+  // Regression: when a channel-driven session resumes (e.g. Telegram receives
+  // a message for an existing chat), the new user message was previously
+  // appearing twice in the LLM context. The DB-restore path and the
+  // in-memory `messages` list both included it, and they were concatenated.
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: {
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () => createTextResponseStream('first reply'),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:dup-check-session',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:dup-check-session', {
+    text: 'original turn',
+  });
+  await runner.waitForSessionIdle('cli:dup-check-session');
+
+  let capturedMessages: Context['messages'] = [];
+  const restoredRunner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      (context) => {
+        capturedMessages = context.messages;
+        return createTextResponseStream('resumed reply');
+      },
+    ]),
+  });
+
+  await restoredRunner.openSession({
+    sessionId: 'cli:dup-check-session',
+    source: { kind: 'cli', interactive: true },
+  });
+  await restoredRunner.postMessage('cli:dup-check-session', {
+    text: 'hi',
+  });
+  await restoredRunner.waitForSessionIdle('cli:dup-check-session');
+
+  // Look at user messages and count the ones whose visible text is exactly
+  // the new turn input. Content may be a string or an array of parts; the
+  // resumption context block is a long "Session resumption context: ..."
+  // string and won't be miscounted.
+  const userTexts = capturedMessages
+    .filter((msg) => msg.role === 'user')
+    .map((msg) => {
+      if (typeof msg.content === 'string') return msg.content.trim();
+      if (Array.isArray(msg.content)) {
+        return msg.content
+          .map((c) => (typeof c === 'object' && c && 'text' in c ? String((c as { text: unknown }).text) : ''))
+          .join('')
+          .trim();
+      }
+      return '';
+    });
+  const hiUserCount = userTexts.filter((t) => t === 'hi').length;
+  assert.equal(
+    hiUserCount,
+    1,
+    `new user message "hi" must appear exactly once in the LLM context (got ${hiUserCount})`,
+  );
+});
+
 test('AgentRunner emits Langfuse traces for LLM steps', async (t) => {
   const { workspace, security } = await createSecurityFixture(t, {
     secrets: {


### PR DESCRIPTION
## Summary
- The model was seeing the user's latest turn doubled (e.g. one \`hi\` arriving as \`hi\n\nhi\`) on the first turn after a channel-driven session resume.
- Root cause: \`postMessage\` persists the user text to DB **before** queueing \`agent.prompt\`. Then \`transformContext\` sees \`session.resumed && messages.length <= 1\`, rebuilds the message list from DB (which already includes the new turn), and concatenated the in-memory list on top — producing two copies.
- Fix: when we restore from DB, drop the in-memory \`messages\`; they're a strict subset of \`restoredMessages\` at that point.

## Test plan
- [x] Added regression test \`AgentRunner does not duplicate the new user message on the first turn after resume\` — verified it fails without the fix (\`got 2\`) and passes with it (\`got 1\`).
- [x] Verified the 5 pre-existing failures in \`agent-runner.test.ts\` are unrelated and present on \`main\` without this change.
- [ ] After merge, observe gateway log on test.openhermit.ai for a Telegram \"hi\" turn — model should not "joke about double greeting".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where resuming a persisted session would duplicate the latest user message in the conversation context, ensuring accurate message history when reopening sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->