### PR TITLE
feat(store): attachment metadata + AttachmentStorage with local provider

### DIFF
--- a/apps/agent/test/attachment-store.test.ts
+++ b/apps/agent/test/attachment-store.test.ts
@@ -59,9 +59,7 @@ test('DbAttachmentStore: create + get round-trips all fields', async (t) => {
   assert.equal(rec.mimeType, 'application/pdf');
   assert.equal(rec.sizeBytes, 1234);
   assert.equal(rec.materializationState, 'pending');
-  assert.equal(rec.descriptionState, 'pending');
   assert.equal(rec.sandboxPath, null);
-  assert.equal(rec.description, null);
 
   const fetched = await store.get(rec.id);
   assert.deepEqual(fetched, rec);
@@ -160,20 +158,6 @@ test('DbAttachmentStore: setMaterialization updates state, sandbox path, and err
   assert.equal(after?.materializationError, 'disk full');
 });
 
-test('DbAttachmentStore: setDescription updates content and state', async (t) => {
-  const store = await openStore(t);
-  const agentId = uniqueAgent();
-  const rec = await store.create(makeInput(agentId, 's1'));
-
-  await store.setDescription(rec.id, {
-    state: 'ready',
-    description: 'First page of a quarterly report.',
-  });
-  const after = await store.get(rec.id);
-  assert.equal(after?.descriptionState, 'ready');
-  assert.equal(after?.description, 'First page of a quarterly report.');
-});
-
 test('DbAttachmentStore: delete removes the row', async (t) => {
   const store = await openStore(t);
   const agentId = uniqueAgent();
@@ -181,6 +165,18 @@ test('DbAttachmentStore: delete removes the row', async (t) => {
 
   await store.delete(rec.id);
   assert.equal(await store.get(rec.id), undefined);
+});
+
+test('DbAttachmentStore: CHECK constraint rejects unknown materialization_state', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+  const rec = await store.create(makeInput(agentId, 's1'));
+
+  await assert.rejects(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => store.setMaterialization(rec.id, { state: 'bogus' as any }),
+    /materialization_state|check/i,
+  );
 });
 
 // ── LocalAttachmentStorage ──────────────────────────────────────────────
@@ -237,7 +233,7 @@ test('LocalAttachmentStorage: readStream + delete', async (t) => {
   assert.equal(Buffer.concat(chunks).toString('utf8'), 'hello attachments');
 
   await storage.delete(storageKey);
-  await assert.rejects(stat(path.join(root, storageKey)));
+  await assert.rejects(stat(path.join(root, storageKey)), { code: 'ENOENT' });
 });
 
 test('LocalAttachmentStorage: getSignedUrl returns null (no URL concept)', async (t) => {

--- a/apps/agent/test/attachment-store.test.ts
+++ b/apps/agent/test/attachment-store.test.ts
@@ -1,0 +1,266 @@
+import assert from 'node:assert/strict';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { test } from 'node:test';
+
+import {
+  DbAttachmentStore,
+  LocalAttachmentStorage,
+  type AttachmentRecord,
+} from '@openhermit/store';
+
+async function openStore(t: import('node:test').TestContext) {
+  const store = await DbAttachmentStore.open();
+  t.after(() => store.close());
+  return store;
+}
+
+function uniqueAgent(): string {
+  return `test-att-${randomUUID().slice(0, 8)}`;
+}
+
+function makeInput(
+  agentId: string,
+  sessionId: string,
+  overrides: Partial<Parameters<DbAttachmentStore['create']>[0]> = {},
+) {
+  return {
+    agentId,
+    sessionId,
+    originalName: 'report.pdf',
+    safeName: 'report.pdf',
+    mimeType: 'application/pdf',
+    sizeBytes: 1234,
+    sha256: 'a'.repeat(64),
+    storageProvider: 'local',
+    storageKey: `${agentId}/${sessionId}/att/report.pdf`,
+    ...overrides,
+  };
+}
+
+// ── DbAttachmentStore ───────────────────────────────────────────────────
+
+test('DbAttachmentStore: create + get round-trips all fields', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  const rec = await store.create(
+    makeInput(agentId, 's1', { uploaderUserId: 'usr-1' }),
+  );
+
+  assert.ok(rec.id.startsWith('att_'));
+  assert.equal(rec.agentId, agentId);
+  assert.equal(rec.sessionId, 's1');
+  assert.equal(rec.uploaderUserId, 'usr-1');
+  assert.equal(rec.originalName, 'report.pdf');
+  assert.equal(rec.mimeType, 'application/pdf');
+  assert.equal(rec.sizeBytes, 1234);
+  assert.equal(rec.materializationState, 'pending');
+  assert.equal(rec.descriptionState, 'pending');
+  assert.equal(rec.sandboxPath, null);
+  assert.equal(rec.description, null);
+
+  const fetched = await store.get(rec.id);
+  assert.deepEqual(fetched, rec);
+});
+
+test('DbAttachmentStore: list defaults to session scope', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  const a = await store.create(makeInput(agentId, 's1', { originalName: 'a.txt' }));
+  const b = await store.create(makeInput(agentId, 's1', { originalName: 'b.txt' }));
+  await store.create(makeInput(agentId, 's2', { originalName: 'other.txt' }));
+
+  const list = await store.list({ agentId }, 's1');
+  const ids = list.map((r: AttachmentRecord) => r.id).sort();
+  assert.deepEqual(ids, [a.id, b.id].sort());
+});
+
+test('DbAttachmentStore: list with scope=user spans sessions for the same user', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  const fromS1 = await store.create(
+    makeInput(agentId, 's1', { uploaderUserId: 'usr-1', originalName: 'one.txt' }),
+  );
+  const fromS2 = await store.create(
+    makeInput(agentId, 's2', { uploaderUserId: 'usr-1', originalName: 'two.txt' }),
+  );
+  // Different user — must not appear.
+  await store.create(
+    makeInput(agentId, 's1', { uploaderUserId: 'usr-2', originalName: 'other.txt' }),
+  );
+
+  const list = await store.list(
+    { agentId },
+    's1', // sessionId is ignored in user scope, kept for API symmetry
+    { scope: 'user', userId: 'usr-1' },
+  );
+  const ids = list.map((r: AttachmentRecord) => r.id).sort();
+  assert.deepEqual(ids, [fromS1.id, fromS2.id].sort());
+});
+
+test('DbAttachmentStore: list with scope=user requires userId', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  await assert.rejects(
+    () => store.list({ agentId }, 's1', { scope: 'user' }),
+    /requires options\.userId/,
+  );
+});
+
+test('DbAttachmentStore: list never leaks across agents', async (t) => {
+  const store = await openStore(t);
+  const agentA = uniqueAgent();
+  const agentB = uniqueAgent();
+
+  await store.create(makeInput(agentA, 's1', { uploaderUserId: 'usr-1' }));
+  await store.create(makeInput(agentB, 's1', { uploaderUserId: 'usr-1' }));
+
+  const listA = await store.list({ agentId: agentA }, 's1');
+  assert.equal(listA.length, 1);
+  assert.equal(listA[0]?.agentId, agentA);
+
+  const userScopedA = await store.list(
+    { agentId: agentA },
+    's1',
+    { scope: 'user', userId: 'usr-1' },
+  );
+  assert.equal(userScopedA.length, 1);
+  assert.equal(userScopedA[0]?.agentId, agentA);
+});
+
+test('DbAttachmentStore: setMaterialization updates state, sandbox path, and error', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+  const rec = await store.create(makeInput(agentId, 's1'));
+
+  await store.setMaterialization(rec.id, {
+    state: 'copied',
+    sandboxId: 'sbx-1',
+    sandboxPath: '/home/user/.openhermit/attachments/s1/x/report.pdf',
+  });
+  let after = await store.get(rec.id);
+  assert.equal(after?.materializationState, 'copied');
+  assert.equal(after?.sandboxId, 'sbx-1');
+  assert.equal(
+    after?.sandboxPath,
+    '/home/user/.openhermit/attachments/s1/x/report.pdf',
+  );
+  assert.equal(after?.materializationError, null);
+
+  await store.setMaterialization(rec.id, { state: 'failed', error: 'disk full' });
+  after = await store.get(rec.id);
+  assert.equal(after?.materializationState, 'failed');
+  assert.equal(after?.materializationError, 'disk full');
+});
+
+test('DbAttachmentStore: setDescription updates content and state', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+  const rec = await store.create(makeInput(agentId, 's1'));
+
+  await store.setDescription(rec.id, {
+    state: 'ready',
+    description: 'First page of a quarterly report.',
+  });
+  const after = await store.get(rec.id);
+  assert.equal(after?.descriptionState, 'ready');
+  assert.equal(after?.description, 'First page of a quarterly report.');
+});
+
+test('DbAttachmentStore: delete removes the row', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+  const rec = await store.create(makeInput(agentId, 's1'));
+
+  await store.delete(rec.id);
+  assert.equal(await store.get(rec.id), undefined);
+});
+
+// ── LocalAttachmentStorage ──────────────────────────────────────────────
+
+async function tempRoot(t: import('node:test').TestContext): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'openhermit-att-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+test('LocalAttachmentStorage: put stores bytes, returns size + sha256', async (t) => {
+  const root = await tempRoot(t);
+  const storage = new LocalAttachmentStorage({ root });
+
+  const body = randomBytes(2048);
+  const expectedSha = createHash('sha256').update(body).digest('hex');
+
+  const result = await storage.put({
+    agentId: 'agent-a',
+    sessionId: 's1',
+    attachmentId: 'att_xyz',
+    filename: 'report.pdf',
+    contentType: 'application/pdf',
+    body: Readable.from(body),
+  });
+
+  assert.equal(result.storageKey, 'agent-a/s1/att_xyz/report.pdf');
+  assert.equal(result.sizeBytes, body.length);
+  assert.equal(result.sha256, expectedSha);
+
+  const onDisk = await readFile(path.join(root, result.storageKey));
+  assert.deepEqual(onDisk, body);
+});
+
+test('LocalAttachmentStorage: readStream + delete', async (t) => {
+  const root = await tempRoot(t);
+  const storage = new LocalAttachmentStorage({ root });
+
+  const body = Buffer.from('hello attachments');
+  const { storageKey } = await storage.put({
+    agentId: 'agent-a',
+    sessionId: 's1',
+    attachmentId: 'att_1',
+    filename: 'note.txt',
+    contentType: 'text/plain',
+    body: Readable.from(body),
+  });
+
+  const chunks: Buffer[] = [];
+  const stream = await storage.readStream(storageKey);
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  assert.equal(Buffer.concat(chunks).toString('utf8'), 'hello attachments');
+
+  await storage.delete(storageKey);
+  await assert.rejects(stat(path.join(root, storageKey)));
+});
+
+test('LocalAttachmentStorage: getSignedUrl returns null (no URL concept)', async (t) => {
+  const root = await tempRoot(t);
+  const storage = new LocalAttachmentStorage({ root });
+  assert.equal(
+    await storage.getSignedUrl('agent-a/s1/att_1/note.txt', { expiresInSeconds: 60 }),
+    null,
+  );
+});
+
+test('LocalAttachmentStorage: rejects traversal in storage keys', async (t) => {
+  const root = await tempRoot(t);
+  const storage = new LocalAttachmentStorage({ root });
+  await assert.rejects(
+    () => storage.readStream('../etc/passwd'),
+    /traversal|escapes root/,
+  );
+});
+
+test('LocalAttachmentStorage: rejects non-absolute root', () => {
+  assert.throws(
+    () => new LocalAttachmentStorage({ root: 'relative/path' }),
+    /must be absolute/,
+  );
+});

--- a/packages/store/drizzle/0026_session_attachments.sql
+++ b/packages/store/drizzle/0026_session_attachments.sql
@@ -1,0 +1,35 @@
+-- Per-session uploaded files. Byte payload lives in an AttachmentStorage
+-- provider (local disk / s3 / supabase); this row is the metadata of
+-- record. See docs/file-attachments-design.md.
+
+CREATE TABLE "session_attachments" (
+  "id"                     TEXT PRIMARY KEY,
+  "agent_id"               TEXT NOT NULL,
+  "session_id"             TEXT NOT NULL,
+  "uploader_user_id"       TEXT,
+  "original_name"          TEXT NOT NULL,
+  "safe_name"              TEXT NOT NULL,
+  "mime_type"              TEXT NOT NULL,
+  "size_bytes"             INTEGER NOT NULL,
+  "sha256"                 TEXT NOT NULL,
+  "storage_provider"       TEXT NOT NULL,
+  "storage_key"            TEXT NOT NULL,
+  "sandbox_id"             TEXT,
+  "sandbox_path"           TEXT,
+  "materialization_state"  TEXT NOT NULL DEFAULT 'pending',
+  "materialization_error"  TEXT,
+  "description"            TEXT,
+  "description_state"      TEXT NOT NULL DEFAULT 'pending',
+  "created_at"             TEXT NOT NULL
+);
+
+CREATE INDEX "idx_session_attachments_session"
+  ON "session_attachments" ("agent_id", "session_id", "created_at");
+
+-- Powers `attachment_list` with `scope: 'user'` — every file a given
+-- user uploaded under this agent, newest first.
+CREATE INDEX "idx_session_attachments_user"
+  ON "session_attachments" ("agent_id", "uploader_user_id", "created_at");
+
+CREATE INDEX "idx_session_attachments_sha256"
+  ON "session_attachments" ("sha256");

--- a/packages/store/drizzle/0027_session_attachments_drop_description.sql
+++ b/packages/store/drizzle/0027_session_attachments_drop_description.sql
@@ -1,0 +1,19 @@
+-- Drop unused description columns from session_attachments and tighten
+-- materialization_state with a CHECK constraint.
+--
+-- Background: the original 0026 migration included a `description` /
+-- `description_state` pair intended for a server-side content preview
+-- the model would see in `attachment_list`. We landed multimodal
+-- inlining + sandbox materialization instead and never wrote the
+-- description extractor, so the columns only added free-text noise
+-- to every row.
+--
+-- The CHECK constraint guards against rogue writers; the app-side enum
+-- already restricts callers, but defence-in-depth is cheap here.
+
+ALTER TABLE "session_attachments" DROP COLUMN IF EXISTS "description";
+ALTER TABLE "session_attachments" DROP COLUMN IF EXISTS "description_state";
+
+ALTER TABLE "session_attachments"
+  ADD CONSTRAINT "session_attachments_materialization_state_check"
+  CHECK ("materialization_state" IN ('pending', 'copied', 'skipped', 'failed'));

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1779400000000,
       "tag": "0026_session_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1779500000000,
+      "tag": "0027_session_attachments_drop_description",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1779300000000,
       "tag": "0025_agent_channels_last_error",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1779400000000,
+      "tag": "0026_session_attachments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/attachment-store.ts
+++ b/packages/store/src/impl/attachment-store.ts
@@ -7,8 +7,6 @@ import pg from 'pg';
 import type { AttachmentStore } from '../interfaces.js';
 import type {
   AttachmentCreateInput,
-  AttachmentDescriptionPatch,
-  AttachmentDescriptionState,
   AttachmentListOptions,
   AttachmentMaterializationPatch,
   AttachmentMaterializationState,
@@ -56,8 +54,6 @@ export class DbAttachmentStore implements AttachmentStore {
       sandboxPath: null,
       materializationState: 'pending' as const,
       materializationError: null,
-      description: null,
-      descriptionState: 'pending' as const,
       createdAt: new Date().toISOString(),
     };
     const [inserted] = await this.db.insert(sessionAttachments).values(row).returning();
@@ -125,20 +121,6 @@ export class DbAttachmentStore implements AttachmentStore {
       .where(eq(sessionAttachments.id, id));
   }
 
-  async setDescription(
-    id: string,
-    patch: AttachmentDescriptionPatch,
-  ): Promise<void> {
-    const update: Partial<typeof sessionAttachments.$inferInsert> = {
-      descriptionState: patch.state,
-    };
-    if (patch.description !== undefined) update.description = patch.description;
-    await this.db
-      .update(sessionAttachments)
-      .set(update)
-      .where(eq(sessionAttachments.id, id));
-  }
-
   async delete(id: string): Promise<void> {
     await this.db.delete(sessionAttachments).where(eq(sessionAttachments.id, id));
   }
@@ -161,8 +143,6 @@ function toRecord(row: typeof sessionAttachments.$inferSelect): AttachmentRecord
     sandboxPath: row.sandboxPath,
     materializationState: row.materializationState as AttachmentMaterializationState,
     materializationError: row.materializationError,
-    description: row.description,
-    descriptionState: row.descriptionState as AttachmentDescriptionState,
     createdAt: row.createdAt,
   };
 }

--- a/packages/store/src/impl/attachment-store.ts
+++ b/packages/store/src/impl/attachment-store.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto';
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { and, desc, eq } from 'drizzle-orm';
+import pg from 'pg';
+
+import type { AttachmentStore } from '../interfaces.js';
+import type {
+  AttachmentCreateInput,
+  AttachmentDescriptionPatch,
+  AttachmentDescriptionState,
+  AttachmentListOptions,
+  AttachmentMaterializationPatch,
+  AttachmentMaterializationState,
+  AttachmentRecord,
+  StoreScope,
+} from '../types.js';
+import * as schema from '../schema.js';
+import { sessionAttachments } from '../schema.js';
+import type { DrizzleDb } from './index.js';
+
+export class DbAttachmentStore implements AttachmentStore {
+  private pool?: pg.Pool;
+
+  constructor(private readonly db: DrizzleDb) {}
+
+  static async open(databaseUrl?: string): Promise<DbAttachmentStore> {
+    const url = databaseUrl ?? process.env.DATABASE_URL;
+    if (!url) throw new Error('DATABASE_URL environment variable is required');
+    const pool = new pg.Pool({ connectionString: url });
+    await pool.query('SELECT 1');
+    const db = drizzle(pool, { schema });
+    const store = new DbAttachmentStore(db);
+    store.pool = pool;
+    return store;
+  }
+
+  async close(): Promise<void> {
+    await this.pool?.end();
+  }
+
+  async create(input: AttachmentCreateInput): Promise<AttachmentRecord> {
+    const row = {
+      id: input.id ?? `att_${randomUUID()}`,
+      agentId: input.agentId,
+      sessionId: input.sessionId,
+      uploaderUserId: input.uploaderUserId ?? null,
+      originalName: input.originalName,
+      safeName: input.safeName,
+      mimeType: input.mimeType,
+      sizeBytes: input.sizeBytes,
+      sha256: input.sha256,
+      storageProvider: input.storageProvider,
+      storageKey: input.storageKey,
+      sandboxId: null,
+      sandboxPath: null,
+      materializationState: 'pending' as const,
+      materializationError: null,
+      description: null,
+      descriptionState: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    };
+    const [inserted] = await this.db.insert(sessionAttachments).values(row).returning();
+    if (!inserted) throw new Error('attachment insert returned no row');
+    return toRecord(inserted);
+  }
+
+  async get(id: string): Promise<AttachmentRecord | undefined> {
+    const rows = await this.db
+      .select()
+      .from(sessionAttachments)
+      .where(eq(sessionAttachments.id, id))
+      .limit(1);
+    return rows[0] ? toRecord(rows[0]) : undefined;
+  }
+
+  async list(
+    scope: StoreScope,
+    sessionId: string,
+    options: AttachmentListOptions = {},
+  ): Promise<AttachmentRecord[]> {
+    const scopeKind = options.scope ?? 'session';
+    const limit = options.limit ?? 100;
+
+    let where;
+    if (scopeKind === 'user') {
+      // User-scoped listing requires a user id; cross-user listing is
+      // never permitted, even within the same agent.
+      if (!options.userId) {
+        throw new Error('AttachmentStore.list with scope=user requires options.userId');
+      }
+      where = and(
+        eq(sessionAttachments.agentId, scope.agentId),
+        eq(sessionAttachments.uploaderUserId, options.userId),
+      );
+    } else {
+      where = and(
+        eq(sessionAttachments.agentId, scope.agentId),
+        eq(sessionAttachments.sessionId, sessionId),
+      );
+    }
+
+    const rows = await this.db
+      .select()
+      .from(sessionAttachments)
+      .where(where)
+      .orderBy(desc(sessionAttachments.createdAt))
+      .limit(limit);
+    return rows.map(toRecord);
+  }
+
+  async setMaterialization(
+    id: string,
+    patch: AttachmentMaterializationPatch,
+  ): Promise<void> {
+    const update: Partial<typeof sessionAttachments.$inferInsert> = {
+      materializationState: patch.state,
+    };
+    if (patch.sandboxId !== undefined) update.sandboxId = patch.sandboxId;
+    if (patch.sandboxPath !== undefined) update.sandboxPath = patch.sandboxPath;
+    if (patch.error !== undefined) update.materializationError = patch.error;
+    await this.db
+      .update(sessionAttachments)
+      .set(update)
+      .where(eq(sessionAttachments.id, id));
+  }
+
+  async setDescription(
+    id: string,
+    patch: AttachmentDescriptionPatch,
+  ): Promise<void> {
+    const update: Partial<typeof sessionAttachments.$inferInsert> = {
+      descriptionState: patch.state,
+    };
+    if (patch.description !== undefined) update.description = patch.description;
+    await this.db
+      .update(sessionAttachments)
+      .set(update)
+      .where(eq(sessionAttachments.id, id));
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.delete(sessionAttachments).where(eq(sessionAttachments.id, id));
+  }
+}
+
+function toRecord(row: typeof sessionAttachments.$inferSelect): AttachmentRecord {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    sessionId: row.sessionId,
+    uploaderUserId: row.uploaderUserId,
+    originalName: row.originalName,
+    safeName: row.safeName,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    sha256: row.sha256,
+    storageProvider: row.storageProvider,
+    storageKey: row.storageKey,
+    sandboxId: row.sandboxId,
+    sandboxPath: row.sandboxPath,
+    materializationState: row.materializationState as AttachmentMaterializationState,
+    materializationError: row.materializationError,
+    description: row.description,
+    descriptionState: row.descriptionState as AttachmentDescriptionState,
+    createdAt: row.createdAt,
+  };
+}

--- a/packages/store/src/impl/index.ts
+++ b/packages/store/src/impl/index.ts
@@ -67,6 +67,11 @@ export { DbAgentConfigStore } from './agent-config-store.js';
 export { DbSandboxStore } from './sandbox-store.js';
 export { DbPolicyStore } from './policy-store.js';
 export { DbApprovalRequestStore } from './approval-request-store.js';
+export { DbAttachmentStore } from './attachment-store.js';
+export {
+  LocalAttachmentStorage,
+  type LocalAttachmentStorageOptions,
+} from './local-attachment-storage.js';
 export { FileSecretStore, type ConfigDirResolver } from './file-secret-store.js';
 export { DbSecretStore, generateSecretsKey } from './db-secret-store.js';
 export {

--- a/packages/store/src/impl/local-attachment-storage.ts
+++ b/packages/store/src/impl/local-attachment-storage.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import type { AttachmentStorage } from '../interfaces.js';
+
+export interface LocalAttachmentStorageOptions {
+  /**
+   * Absolute root directory under which attachments are stored, e.g.
+   * `~/.openhermit/attachments`. Created on demand. Object keys are
+   * relative to this root.
+   */
+  root: string;
+}
+
+/**
+ * Disk-backed `AttachmentStorage`. Lays files out as
+ * `<root>/<agentId>/<sessionId>/<attachmentId>/<safeName>` so an
+ * operator can `ls` the directory and reason about session ownership.
+ * Signed URLs are not meaningful for local disk — `getSignedUrl`
+ * returns `null` so callers fall back to streaming.
+ */
+export class LocalAttachmentStorage implements AttachmentStorage {
+  readonly name = 'local';
+
+  constructor(private readonly options: LocalAttachmentStorageOptions) {
+    if (!path.isAbsolute(options.root)) {
+      throw new Error(`LocalAttachmentStorage root must be absolute: ${options.root}`);
+    }
+  }
+
+  async put(input: {
+    agentId: string;
+    sessionId: string;
+    attachmentId: string;
+    filename: string;
+    contentType: string;
+    body: NodeJS.ReadableStream;
+  }): Promise<{ storageKey: string; sizeBytes: number; sha256: string }> {
+    const storageKey = path.posix.join(
+      input.agentId,
+      input.sessionId,
+      input.attachmentId,
+      input.filename,
+    );
+    const target = this.resolveKey(storageKey);
+    await mkdir(path.dirname(target), { recursive: true });
+
+    const hasher = createHash('sha256');
+    let bytesSeen = 0;
+    input.body.on('data', (chunk: Buffer | string) => {
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      hasher.update(buf);
+      bytesSeen += buf.length;
+    });
+
+    await pipeline(input.body, createWriteStream(target));
+    const stats = await stat(target);
+    // Prefer the on-disk size; bytesSeen is a sanity check.
+    if (stats.size !== bytesSeen) {
+      throw new Error(
+        `LocalAttachmentStorage size mismatch for ${storageKey}: streamed ${bytesSeen} but wrote ${stats.size}`,
+      );
+    }
+    return {
+      storageKey,
+      sizeBytes: stats.size,
+      sha256: hasher.digest('hex'),
+    };
+  }
+
+  async readStream(storageKey: string): Promise<NodeJS.ReadableStream> {
+    return createReadStream(this.resolveKey(storageKey));
+  }
+
+  async getSignedUrl(): Promise<string | null> {
+    return null;
+  }
+
+  async delete(storageKey: string): Promise<void> {
+    await rm(this.resolveKey(storageKey), { force: true });
+  }
+
+  private resolveKey(storageKey: string): string {
+    // Defence in depth: storage keys are server-generated, but reject
+    // any traversal in case a future caller plumbs a user value
+    // through.
+    if (storageKey.includes('..')) {
+      throw new Error(`LocalAttachmentStorage rejects key with traversal: ${storageKey}`);
+    }
+    const resolved = path.resolve(this.options.root, storageKey);
+    const rootResolved = path.resolve(this.options.root);
+    if (resolved !== rootResolved && !resolved.startsWith(rootResolved + path.sep)) {
+      throw new Error(`LocalAttachmentStorage key escapes root: ${storageKey}`);
+    }
+    return resolved;
+  }
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -14,6 +14,8 @@ export type {
   SandboxStore,
   PolicyStore,
   ApprovalRequestStore,
+  AttachmentStore,
+  AttachmentStorage,
 } from './interfaces.js';
 
 export type {
@@ -54,6 +56,14 @@ export type {
   ApprovalResolution,
   ApprovalRequestRecord,
   ApprovalRequestCreateInput,
+  AttachmentRecord,
+  AttachmentCreateInput,
+  AttachmentListOptions,
+  AttachmentMaterializationPatch,
+  AttachmentMaterializationState,
+  AttachmentDescriptionPatch,
+  AttachmentDescriptionState,
+  AttachmentStorageProvider,
 } from './types.js';
 
 export { STANDALONE_AGENT_ID, standaloneScope } from './types.js';
@@ -97,6 +107,9 @@ export {
   DbSandboxStore,
   DbPolicyStore,
   DbApprovalRequestStore,
+  DbAttachmentStore,
+  LocalAttachmentStorage,
+  type LocalAttachmentStorageOptions,
   DbMetaStore,
   generateSecretsKey,
   runMigrations,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -61,8 +61,6 @@ export type {
   AttachmentListOptions,
   AttachmentMaterializationPatch,
   AttachmentMaterializationState,
-  AttachmentDescriptionPatch,
-  AttachmentDescriptionState,
   AttachmentStorageProvider,
 } from './types.js';
 

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -10,7 +10,6 @@ import type {
   ApprovalResolution,
   ApprovalStatus,
   AttachmentCreateInput,
-  AttachmentDescriptionPatch,
   AttachmentListOptions,
   AttachmentMaterializationPatch,
   AttachmentRecord,
@@ -343,7 +342,6 @@ export interface AttachmentStore {
   /** Scoped lookup for tool calls — defaults to session scope. */
   list(scope: StoreScope, sessionId: string, options?: AttachmentListOptions): Promise<AttachmentRecord[]>;
   setMaterialization(id: string, patch: AttachmentMaterializationPatch): Promise<void>;
-  setDescription(id: string, patch: AttachmentDescriptionPatch): Promise<void>;
   delete(id: string): Promise<void>;
 }
 

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -9,6 +9,11 @@ import type {
   ApprovalRequestRecord,
   ApprovalResolution,
   ApprovalStatus,
+  AttachmentCreateInput,
+  AttachmentDescriptionPatch,
+  AttachmentListOptions,
+  AttachmentMaterializationPatch,
+  AttachmentRecord,
   McpServerRecord,
   MessageRow,
   InstructionEntry,
@@ -321,6 +326,50 @@ export interface ApprovalRequestStore {
     reason?: string,
   ): Promise<ApprovalRequestRecord>;
   expireOld(): Promise<number>;
+}
+
+/**
+ * Metadata store for uploaded files. Byte payloads live behind an
+ * `AttachmentStorage` provider; this interface is only the row-of-record
+ * for "what file IDs exist and what do we know about them."
+ *
+ * Cross-user listing is never permitted. `list` with `scope: 'user'`
+ * requires `userId` and filters on `uploader_user_id` in addition to
+ * `agentId`.
+ */
+export interface AttachmentStore {
+  create(input: AttachmentCreateInput): Promise<AttachmentRecord>;
+  get(id: string): Promise<AttachmentRecord | undefined>;
+  /** Scoped lookup for tool calls — defaults to session scope. */
+  list(scope: StoreScope, sessionId: string, options?: AttachmentListOptions): Promise<AttachmentRecord[]>;
+  setMaterialization(id: string, patch: AttachmentMaterializationPatch): Promise<void>;
+  setDescription(id: string, patch: AttachmentDescriptionPatch): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+/**
+ * Byte-storage provider for attachments. Independent of the metadata
+ * store so the same provider impl (local disk / s3 / supabase) can be
+ * reused across deployments without leaking storage details to the
+ * gateway or to tools.
+ */
+export interface AttachmentStorage {
+  readonly name: string;
+  put(input: {
+    agentId: string;
+    sessionId: string;
+    attachmentId: string;
+    filename: string;
+    contentType: string;
+    body: NodeJS.ReadableStream;
+  }): Promise<{ storageKey: string; sizeBytes: number; sha256: string }>;
+  readStream(storageKey: string): Promise<NodeJS.ReadableStream>;
+  /** Returns null when the provider has no signed-URL concept (e.g. local disk). */
+  getSignedUrl(
+    storageKey: string,
+    options: { expiresInSeconds: number },
+  ): Promise<string | null>;
+  delete(storageKey: string): Promise<void>;
 }
 
 export interface InternalStateStore {

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -340,9 +340,9 @@ export const schedules = pgTable('schedules', {
  *
  * `materialization_state` tracks whether the file is currently mirrored
  * into the agent's sandbox as a regular file (so `file_read` / `exec`
- * can see it directly); `description_state` tracks the bounded
- * server-side content preview surfaced to the model in
- * `attachment_list`.
+ * can see it directly). Multimodal user prompts inline small images
+ * directly into the model context; everything else is referenced by
+ * its sandbox path or fetched via `attachment_fetch`.
  */
 export const sessionAttachments = pgTable('session_attachments', {
   id: text('id').primaryKey(),
@@ -365,13 +365,9 @@ export const sessionAttachments = pgTable('session_attachments', {
   sandboxId: text('sandbox_id'),
   /** Agent-visible path inside the sandbox, if materialized. */
   sandboxPath: text('sandbox_path'),
-  /** 'pending' | 'copied' | 'skipped' | 'failed' */
+  /** 'pending' | 'copied' | 'skipped' | 'failed' — guarded by a CHECK constraint. */
   materializationState: text('materialization_state').default('pending').notNull(),
   materializationError: text('materialization_error'),
-  /** Short server-generated content preview (e.g., PDF first page, text head). */
-  description: text('description'),
-  /** 'pending' | 'ready' | 'skipped' | 'failed' */
-  descriptionState: text('description_state').default('pending').notNull(),
   createdAt: text('created_at').notNull(),
 }, (table) => [
   index('idx_session_attachments_session').on(table.agentId, table.sessionId, table.createdAt),

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -333,6 +333,54 @@ export const schedules = pgTable('schedules', {
   index('idx_schedules_next_run').on(table.agentId, table.nextRunAt),
 ]);
 
+/**
+ * Per-session uploaded files. The byte payload lives in an
+ * `AttachmentStorage` provider (local disk / s3 / supabase); this row is
+ * the metadata of record. See `docs/file-attachments-design.md`.
+ *
+ * `materialization_state` tracks whether the file is currently mirrored
+ * into the agent's sandbox as a regular file (so `file_read` / `exec`
+ * can see it directly); `description_state` tracks the bounded
+ * server-side content preview surfaced to the model in
+ * `attachment_list`.
+ */
+export const sessionAttachments = pgTable('session_attachments', {
+  id: text('id').primaryKey(),
+  agentId: text('agent_id').notNull(),
+  sessionId: text('session_id').notNull(),
+  /** Authenticated user who uploaded the file, when known. */
+  uploaderUserId: text('uploader_user_id'),
+  /** Original client-supplied filename, preserved for display. */
+  originalName: text('original_name').notNull(),
+  /** Sanitized filename used in sandbox paths. */
+  safeName: text('safe_name').notNull(),
+  mimeType: text('mime_type').notNull(),
+  sizeBytes: integer('size_bytes').notNull(),
+  sha256: text('sha256').notNull(),
+  /** 'local' | 's3' | 'supabase' (future) */
+  storageProvider: text('storage_provider').notNull(),
+  /** Provider-internal object key — never exposed to the model. */
+  storageKey: text('storage_key').notNull(),
+  /** Sandbox that currently has a materialized copy, if any. */
+  sandboxId: text('sandbox_id'),
+  /** Agent-visible path inside the sandbox, if materialized. */
+  sandboxPath: text('sandbox_path'),
+  /** 'pending' | 'copied' | 'skipped' | 'failed' */
+  materializationState: text('materialization_state').default('pending').notNull(),
+  materializationError: text('materialization_error'),
+  /** Short server-generated content preview (e.g., PDF first page, text head). */
+  description: text('description'),
+  /** 'pending' | 'ready' | 'skipped' | 'failed' */
+  descriptionState: text('description_state').default('pending').notNull(),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  index('idx_session_attachments_session').on(table.agentId, table.sessionId, table.createdAt),
+  // Powers `attachment_list` with `scope: 'user'` — every file a given
+  // user uploaded under this agent, newest first.
+  index('idx_session_attachments_user').on(table.agentId, table.uploaderUserId, table.createdAt),
+  index('idx_session_attachments_sha256').on(table.sha256),
+]);
+
 export const scheduleRuns = pgTable('schedule_runs', {
   id: serial('id').primaryKey(),
   agentId: text('agent_id').notNull(),

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -98,6 +98,76 @@ export interface ApprovalRequestCreateInput {
   ttlMinutes?: number;
 }
 
+export type AttachmentMaterializationState =
+  | 'pending'
+  | 'copied'
+  | 'skipped'
+  | 'failed';
+
+export type AttachmentDescriptionState =
+  | 'pending'
+  | 'ready'
+  | 'skipped'
+  | 'failed';
+
+/** 'local' | 's3' | 'supabase' — open string so providers can be added without a schema bump. */
+export type AttachmentStorageProvider = string;
+
+export interface AttachmentRecord {
+  id: string;
+  agentId: string;
+  sessionId: string;
+  uploaderUserId: string | null;
+  originalName: string;
+  safeName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageProvider: AttachmentStorageProvider;
+  storageKey: string;
+  sandboxId: string | null;
+  sandboxPath: string | null;
+  materializationState: AttachmentMaterializationState;
+  materializationError: string | null;
+  description: string | null;
+  descriptionState: AttachmentDescriptionState;
+  createdAt: string;
+}
+
+export interface AttachmentCreateInput {
+  id?: string;
+  agentId: string;
+  sessionId: string;
+  uploaderUserId?: string | null;
+  originalName: string;
+  safeName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageProvider: AttachmentStorageProvider;
+  storageKey: string;
+}
+
+export interface AttachmentListOptions {
+  /** Defaults to 'session'. */
+  scope?: 'session' | 'user';
+  /** Required when `scope` is 'user' — never permit cross-user listing. */
+  userId?: string;
+  limit?: number;
+}
+
+export interface AttachmentMaterializationPatch {
+  sandboxId?: string | null;
+  sandboxPath?: string | null;
+  state: AttachmentMaterializationState;
+  error?: string | null;
+}
+
+export interface AttachmentDescriptionPatch {
+  description?: string | null;
+  state: AttachmentDescriptionState;
+}
+
 export interface SandboxCreateInput {
   id?: string;
   agentId: string;

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -104,12 +104,6 @@ export type AttachmentMaterializationState =
   | 'skipped'
   | 'failed';
 
-export type AttachmentDescriptionState =
-  | 'pending'
-  | 'ready'
-  | 'skipped'
-  | 'failed';
-
 /** 'local' | 's3' | 'supabase' — open string so providers can be added without a schema bump. */
 export type AttachmentStorageProvider = string;
 
@@ -129,8 +123,6 @@ export interface AttachmentRecord {
   sandboxPath: string | null;
   materializationState: AttachmentMaterializationState;
   materializationError: string | null;
-  description: string | null;
-  descriptionState: AttachmentDescriptionState;
   createdAt: string;
 }
 
@@ -161,11 +153,6 @@ export interface AttachmentMaterializationPatch {
   sandboxPath?: string | null;
   state: AttachmentMaterializationState;
   error?: string | null;
-}
-
-export interface AttachmentDescriptionPatch {
-  description?: string | null;
-  state: AttachmentDescriptionState;
 }
 
 export interface SandboxCreateInput {


### PR DESCRIPTION
## Summary

Phase 1, steps 1-2 of [docs/file-attachments-design.md](https://github.com/HCF-STUDIOS/openhermit/blob/codex/file-attachments-plan/docs/file-attachments-design.md) (proposed in #99). This is the foundation: the metadata table, the storage abstraction, and a local disk provider. No HTTP route, no sandbox materialization, no description extractor yet — those come in follow-up PRs.

- `session_attachments` table (migration `0026_session_attachments.sql`) — the row-of-record for every uploaded file: storage provider+key, sha256, MIME, sandbox path, plus separate `materialization_state` and `description_state` lifecycles.
- `AttachmentStore` interface + `DbAttachmentStore`. `list` defaults to session scope; passing `scope: 'user'` returns every file the same `uploader_user_id` uploaded under this agent, across sessions. Cross-user listing is rejected at the store boundary as defense-in-depth on top of the eventual HTTP-level user-id enforcement.
- `AttachmentStorage` interface + `LocalAttachmentStorage`. Disk-backed; layout mirrors sandbox paths (`agentId/sessionId/attachmentId/safeName`) so an operator can `ls` and reason about ownership. Hashes the stream on `put`. `getSignedUrl` returns `null` — local has no URL concept; callers fall back to streaming.

## Test plan

- [x] `npm run typecheck` clean across the repo
- [x] 13 new tests in `apps/agent/test/attachment-store.test.ts` pass:
  - create + get round-trip, session-scope list, user-scope list (cross-session, same user)
  - cross-agent isolation, cross-user isolation, scope='user' requires `userId`
  - `setMaterialization` / `setDescription` lifecycle patches, `delete`
  - LocalAttachmentStorage put → sha256/size; readStream + delete; signed URL returns null; traversal rejected; non-absolute root rejected
- [ ] Migration is registered in `_journal.json` (idx 26) so drizzle picks it up — confirmed locally by applying against the test DB before running new tests

Refs #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment storage and management: create, retrieve, list, and delete attachments with session- and user-scoped views.
  * Persistent database-backed storage plus local-disk storage option.
  * Automatic metadata tracking: file size, SHA‑256, MIME type, storage key, and materialization state.

* **Database**
  * New table and indexes for session attachments; added materialization-state constraint.

* **Tests**
  * Comprehensive tests covering DB and local storage behavior, validation, tenant isolation, and path-safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->