### PR TITLE
fix(agent): rescue thinking-only turns that claim stopReason=toolUse with no tool_use blocks

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2722,10 +2722,19 @@ export class AgentRunner implements SessionRuntime {
 
         const hasText = assistantText && hasMeaningfulAssistantText(assistantText);
         const hasThinking = thinkingText && thinkingText.length > 0;
+        const toolCallCount = assistantMessage.content.filter((c) => c.type === 'toolCall').length;
 
         // When model outputs only thinking with no text (e.g. DeepSeek R1 final answer),
         // promote thinking to assistant text if this is the final message (not a tool call).
-        const isFinalThinkingOnly = !hasText && hasThinking && assistantMessage.stopReason !== 'toolUse';
+        // `stopReason === 'toolUse'` with zero actual tool_use blocks (observed on
+        // moonshotai/kimi-k2.6 via OpenRouter) is treated as final-thinking-only — pi-ai's
+        // agent loop won't dispatch anything (no toolCall blocks), so without this rescue
+        // the turn would persist with empty content and the channel adapter would never see
+        // a text_final event, producing a phantom "interrupted reply".
+        const isFinalThinkingOnly =
+          !hasText
+          && hasThinking
+          && (assistantMessage.stopReason !== 'toolUse' || toolCallCount === 0);
         const effectiveText = isFinalThinkingOnly ? thinkingText : (assistantText || '');
         const effectiveThinking = isFinalThinkingOnly ? undefined : (hasThinking ? thinkingText : undefined);
 

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -130,6 +130,55 @@ const createToolCallResponseStream = (
   return stream;
 };
 
+/**
+ * Stream where the model emits only thinking and then claims `toolUse` as the
+ * stop reason — but never produces an actual `toolCall` block. Reproduces the
+ * moonshotai/kimi-k2.6-via-OpenRouter pattern where pi-ai has nothing to
+ * dispatch and the turn would otherwise persist with empty content and never
+ * publish a text_final event.
+ */
+const createThinkingOnlyToolUseStream = (thinking: string) => {
+  const stream = createAssistantMessageEventStream();
+  const message = createAssistantMessage(
+    [
+      {
+        type: 'thinking',
+        thinking,
+      },
+    ],
+    'toolUse',
+  );
+
+  stream.push({
+    type: 'start',
+    partial: createAssistantMessage([], 'toolUse'),
+  });
+  stream.push({
+    type: 'thinking_start',
+    contentIndex: 0,
+    partial: message,
+  });
+  stream.push({
+    type: 'thinking_delta',
+    contentIndex: 0,
+    delta: thinking,
+    partial: message,
+  });
+  stream.push({
+    type: 'thinking_end',
+    contentIndex: 0,
+    content: thinking,
+    partial: message,
+  });
+  stream.push({
+    type: 'done',
+    reason: 'toolUse',
+    message,
+  });
+
+  return stream;
+};
+
 const createSequentialStreamFn = (
   responders: Array<(context: Context) => ReturnType<typeof createAssistantMessageEventStream>>,
 ): StreamFn => {
@@ -655,6 +704,62 @@ test('AgentRunner ignores whitespace-only assistant messages emitted before tool
 
   assert.equal(assistantHistory.length, 1);
   assert.equal(assistantHistory[0]?.content, 'The fact is 42.');
+});
+
+test('AgentRunner promotes thinking to text when stopReason=toolUse but no tool_use blocks are emitted', async (t) => {
+  // Regression: moonshotai/kimi-k2.6 via OpenRouter has been observed to set
+  // stopReason="toolUse" while emitting only a thinking block and no actual
+  // toolCall blocks. pi-ai's agent loop has nothing to dispatch and exits, so
+  // without the rescue the runner would persist content="" and the channel
+  // adapter would never see a text_final — looking like an interrupted reply.
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: {
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+    },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () =>
+        createThinkingOnlyToolUseStream(
+          'The user is asking if `lit` is installed. Let me verify.',
+        ),
+    ]),
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:tooluse-empty-session',
+    source: {
+      kind: 'cli',
+      interactive: true,
+    },
+  });
+  await runner.postMessage('cli:tooluse-empty-session', {
+    text: 'lit 工具你已经安装了吗？',
+  });
+  await runner.waitForSessionIdle('cli:tooluse-empty-session');
+
+  const backlog = runner.events.getBacklog('cli:tooluse-empty-session');
+
+  // A text_final must be published carrying the thinking content so the
+  // channel adapter has something to deliver to the user. (The runner also
+  // double-publishes from agent_end on this path — same as DeepSeek R1's
+  // final-thinking-only behavior — so we assert ≥1, not exactly 1.)
+  const finalTextEvents = backlog.filter((entry) => entry.event.type === 'text_final');
+  assert.ok(finalTextEvents.length >= 1, 'expected at least one text_final event');
+  for (const entry of finalTextEvents) {
+    assert.match((entry.event as { text: string }).text, /lit/);
+  }
+
+  // The persisted assistant entry must carry the thinking text as content,
+  // not an empty string — otherwise resumed sessions show a phantom turn.
+  const sessionEntries = await readSessionLog(runner, 'cli:tooluse-empty-session');
+  const assistantEntries = sessionEntries.filter((entry) => entry.role === 'assistant');
+  assert.equal(assistantEntries.length, 1);
+  assert.match(String(assistantEntries[0]?.content ?? ''), /lit/);
 });
 
 test('AgentRunner surfaces a missing API key as an error event instead of crashing', async (t) => {


### PR DESCRIPTION
## Summary

- Widen the `isFinalThinkingOnly` guard in `apps/agent/src/agent-runner.ts` so that an assistant turn with `stopReason: "toolUse"`, thinking content, and **zero** actual `toolCall` blocks is treated as a final-thinking-only turn (same rescue path as DeepSeek R1's final-answer behavior).
- Add a regression test that drives a stream with thinking + `stopReason: "toolUse"` + no tool calls and asserts a `text_final` event is published and the assistant log carries the thinking text instead of an empty string.

## Why

Observed on session `amiko:cmoxp59j90002quryigfrjr3l` (model `moonshotai/kimi-k2.6` via OpenRouter): the model emitted only a thinking block (\"Let me verify by running \`lit --version\` via exec\") and then ended the turn with `stopReason="toolUse"` — but **never produced an actual `tool_use` block**.

- `pi-agent-core` filters message content for `type === 'toolCall'` to decide what to execute. With zero matches, `hasMoreToolCalls = false`, the inner loop exits, and `agent_end` fires immediately.
- `agent-runner`'s `message_end` handler had `isFinalThinkingOnly = !hasText && hasThinking && stopReason !== 'toolUse'`. Because the model **claimed** toolUse, this stayed false; `effectiveText = ''`. The assistant log entry was persisted with `content: ""` and no `text_final` ever published.
- From the channel's perspective: thinking streams in, then nothing — looks like an interrupted reply.

The fix matches the spirit of the existing DeepSeek rescue: if there are no real tools to dispatch and the model gave us thinking, surface the thinking as the reply rather than silently dropping the turn.

## Test plan

- [x] New unit test `apps/agent/test/agent-runner.test.ts` reproduces the empty-toolUse pattern via a hand-built stream and asserts `text_final` fires + assistant log content is non-empty.
- [x] Existing regression tests still pass: `executes built-in tools through pi-agent-core`, `ignores whitespace-only assistant messages emitted before tool use`, `publishes detailed tool failure messages`, `retains the assistant tool call when compaction keeps a trailing tool result`, `publishes SSE text events and writes minimal logs`.
- [x] `tsc -p apps/agent/tsconfig.json --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responses containing only model thinking without tool invocations, ensuring thinking content is properly displayed and persisted rather than stored as empty messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->