### PR TITLE
chore(release): bump sdk 0.5.0 / cli 0.8.0

### DIFF
--- a/apps/channels/discord/package.json
+++ b/apps/channels/discord/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.5.0",
     "@openhermit/shared": "0.2.0",
     "discord.js": "^14.16.3"
   }

--- a/apps/channels/slack/package.json
+++ b/apps/channels/slack/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.5.0",
     "@openhermit/shared": "0.2.0",
     "@slack/web-api": "^7.9.1",
     "@slack/socket-mode": "^2.0.3"

--- a/apps/channels/telegram/package.json
+++ b/apps/channels/telegram/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.5.0",
     "@openhermit/shared": "0.2.0",
     "marked": "^15.0.12",
     "remend": "^1.3.0"

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -48,6 +48,6 @@
     "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "^0.4.0"
+    "@openhermit/sdk": "^0.5.0"
   }
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@openhermit/agent": "0.2.0",
     "@openhermit/gateway": "0.2.0",
-    "@openhermit/sdk": "0.4.0",
+    "@openhermit/sdk": "0.5.0",
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/web": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
       "name": "@openhermit/channel-discord",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.5.0",
         "@openhermit/shared": "0.2.0",
         "discord.js": "^14.16.3"
       }
@@ -58,7 +58,7 @@
       "name": "@openhermit/channel-slack",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.5.0",
         "@openhermit/shared": "0.2.0",
         "@slack/socket-mode": "^2.0.3",
         "@slack/web-api": "^7.9.1"
@@ -68,7 +68,7 @@
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
       "dependencies": {
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.5.0",
         "@openhermit/shared": "0.2.0",
         "marked": "^15.0.12",
         "remend": "^1.3.0"
@@ -79,7 +79,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@openhermit/sdk": "^0.4.0"
+        "@openhermit/sdk": "^0.5.0"
       },
       "engines": {
         "node": ">=20"
@@ -87,7 +87,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
@@ -120,7 +120,7 @@
       "devDependencies": {
         "@openhermit/agent": "0.2.0",
         "@openhermit/gateway": "0.2.0",
-        "@openhermit/sdk": "0.4.0",
+        "@openhermit/sdk": "0.5.0",
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/web": "0.2.0",
@@ -11211,7 +11211,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts a release for everything merged since the previous bump (b661581).

### SDK 0.4.0 → 0.5.0
- `GatewayClient.uploadAttachment / listAttachments / getAttachment` (#117)
- Trimmed `AttachmentMaterializationState` re-export — `'pending' | 'copied' | 'failed'`, with `'skipped'` removed in #118

### CLI 0.7.0 → 0.8.0
- \`hermit channel install / uninstall / list\` commands (#95)
- Picks up the SDK bump

Workspace \`@openhermit/sdk\` refs across channel apps (\`discord\`, \`slack\`, \`telegram\`, \`wechat\`) synced to 0.5.0.

## Test plan

- [x] \`npm install\` regenerates lockfile cleanly
- [x] \`npm run build\` is green across the workspace
- [ ] \`npm publish\` after merge (sdk first, then cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to version 0.5.0 across Discord, Slack, Telegram, and WeChat channel packages
  * Bumped CLI package version to 0.8.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->