### PR TITLE
feat(channels): auto-reactivate inactive sessions on inbound message

### DIFF
--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -64,6 +64,7 @@ export class DiscordBridge implements ChannelOutbound {
         channel: 'discord',
         metadata: { discord_channel_id: channelId },
         limit: 1,
+        includeInactive: true,
       });
       if (sessions.length > 0) {
         const sessionId = sessions[0]!.sessionId;
@@ -126,6 +127,18 @@ export class DiscordBridge implements ChannelOutbound {
 
     const newSessionId = DiscordBridge.generateSessionId();
     this.channelSessions.set(channelId, newSessionId);
+
+    // Persist the new session row eagerly so a gateway restart between
+    // `/new` and the next message doesn't cause the resolver to
+    // reactivate the just-checkpointed old session.
+    try {
+      await this.client.openSession({
+        sessionId: newSessionId,
+        source: { kind: 'channel', interactive: true, platform: 'discord' },
+        metadata: { discord_channel_id: channelId },
+      });
+    } catch { /* ignore */ }
+
     await this.discord.sendMessage(channelId, 'New conversation started.');
   }
 

--- a/apps/channels/slack/src/bridge.ts
+++ b/apps/channels/slack/src/bridge.ts
@@ -70,6 +70,7 @@ export class SlackBridge implements ChannelOutbound {
         channel: 'slack',
         metadata,
         limit: 1,
+        includeInactive: true,
       });
       if (sessions.length > 0) {
         const sessionId = sessions[0]!.sessionId;
@@ -112,6 +113,20 @@ export class SlackBridge implements ChannelOutbound {
 
     const newSessionId = SlackBridge.generateSessionId();
     this.channelSessions.set(key, newSessionId);
+
+    // Persist the new session row eagerly so a gateway restart between
+    // `/new` and the next message doesn't cause the resolver to
+    // reactivate the just-checkpointed old session.
+    const metadata: Record<string, string> = { slack_channel_id: channelId };
+    if (threadTs) metadata.slack_thread_ts = threadTs;
+    try {
+      await this.client.openSession({
+        sessionId: newSessionId,
+        source: { kind: 'channel', interactive: true, platform: 'slack' },
+        metadata,
+      });
+    } catch { /* ignore */ }
+
     await this.slack.sendMessage(channelId, 'New conversation started.', ...(threadTs ? [{ threadTs }] : []));
   }
 

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -153,17 +153,24 @@ export class TelegramBridge implements ChannelOutbound {
     return `telegram:${new Date().toISOString().slice(0, 10)}-${randomUUID().slice(0, 8)}`;
   }
 
-  /** Get or create the current sessionId for a chat. */
+  /**
+   * Resolve the current sessionId for a chat. Prefers an in-memory cache,
+   * then the most recent persisted session for this chat — including ones
+   * marked `inactive` (by `/new` or the 3-day stale-marker), so a reply
+   * after a long pause stays in the same thread instead of forking a new
+   * session and splitting history. The session is auto-reactivated on the
+   * next `ensureSession` (openSession reopens with `status: 'idle'`).
+   */
   private async getSessionId(chatId: number): Promise<string> {
     const cached = this.chatSessions.get(chatId);
     if (cached) return cached;
 
-    // Try to recover the most recent session for this chat from the server.
     try {
       const sessions = await this.client.listSessions({
         channel: 'telegram',
         metadata: { telegram_chat_id: String(chatId) },
         limit: 1,
+        includeInactive: true,
       });
       if (sessions.length > 0) {
         const sessionId = sessions[0]!.sessionId;
@@ -244,9 +251,27 @@ export class TelegramBridge implements ChannelOutbound {
     }
     this.lastEventIds.delete(oldSessionId);
 
-    // Generate a fresh sessionId for this chat.
     const newSessionId = TelegramBridge.generateSessionId();
     this.chatSessions.set(chatId, newSessionId);
+
+    // Persist the new session row eagerly so a gateway restart between
+    // `/new` and the user's first follow-up message doesn't cause the
+    // resolver to reactivate the just-checkpointed old session (its
+    // `lastActivityAt` would otherwise still win the limit:1 lookup).
+    try {
+      await this.client.openSession({
+        sessionId: newSessionId,
+        source: {
+          kind: 'channel',
+          interactive: true,
+          platform: 'telegram',
+        },
+        metadata: { telegram_chat_id: chatId },
+      });
+    } catch {
+      // Server unavailable — old session will resurrect on next message,
+      // which is the same outcome as if `/new` had never been issued.
+    }
 
     await this.telegram.sendMessage(chatId, 'New conversation started.');
   }

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -181,6 +181,7 @@ export class WechatBridge implements ChannelOutbound {
         channel: 'wechat',
         metadata: { [isGroup ? 'wechat_group_id' : 'wechat_peer_id']: peer },
         limit: 1,
+        includeInactive: true,
       });
       if (sessions.length > 0) {
         const sessionId = sessions[0]!.sessionId;

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -160,6 +160,13 @@ const parseSessionListQuery = (request: Request): SessionListQuery => {
     if (observe !== undefined) query.observe = observe;
   }
 
+  if (url.searchParams.has('includeInactive')) {
+    const includeInactive = parseBooleanQuery(
+      url.searchParams.get('includeInactive') ?? undefined,
+    );
+    if (includeInactive !== undefined) query.includeInactive = includeInactive;
+  }
+
   return query;
 };
 

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -240,6 +240,7 @@ const handleRequest = async (
         if (typeof p.channel === 'string') query.channel = p.channel;
         if (p.metadata && typeof p.metadata === 'object') query.metadata = p.metadata as Record<string, string>;
         if (typeof p.observe === 'boolean') query.observe = p.observe;
+        if (typeof p.includeInactive === 'boolean') query.includeInactive = p.includeInactive;
         // Routes through the same helper as the HTTP endpoint so any
         // future change to the auth-mode → visibility rules takes
         // effect on both transports at once.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -68,6 +68,10 @@ export class AgentLocalClient {
       searchParams.set('channel', query.channel);
     }
 
+    if (query.includeInactive) {
+      searchParams.set('includeInactive', 'true');
+    }
+
     if (query.metadata) {
       for (const [key, value] of Object.entries(query.metadata)) {
         searchParams.set(`metadata.${key}`, value);


### PR DESCRIPTION
## Summary

- Channel resolvers (`getSessionId` in telegram/slack/discord/wechat) now find inactive sessions via `listSessions({ includeInactive: true })` instead of forking a new session. `ensureSession` → `openSession` flips status back to `idle` on the next message, so a reply after a `/new` or 3-day idle stays in the same thread.
- `/new` flows in telegram/slack/discord eagerly persist the new session via `openSession`, so a gateway restart between `/new` and the user's next message won't resurrect the just-checkpointed old session (the new row's fresher `lastActivityAt` wins the `limit:1` lookup).
- The 24h `markStaleInactive` background timer is retained as-is.

## Changes

- `packages/sdk`: `listSessions` forwards `includeInactive` as a query param
- `apps/gateway/src/app.ts`: HTTP `parseSessionListQuery` parses `includeInactive`
- `apps/gateway/src/ws-handler.ts`: WS `session.list` honours `includeInactive`
- `apps/channels/{telegram,slack,discord,wechat}/src/bridge.ts`: pass `includeInactive: true` in `getSessionId`
- `apps/channels/{telegram,slack,discord}/src/bridge.ts`: eagerly `openSession` the new sessionId inside `handleNew` / `handleNewSession`

## Test plan

- [ ] In a channel session, run `/new`, then restart gateway before sending another message — next message goes to the new (empty) session, not the old one.
- [ ] In a channel session, wait until the 24h stale-marker flips the session to `inactive` (or manually update the DB row), then send a message — the same session is reused (history preserved).
- [ ] Default `listSessions()` calls (with no `includeInactive` flag) still filter inactive — the agent web UI / CLI list does not regress.
- [ ] Build is clean across all packages (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session listings across Discord, Slack, Telegram, and WeChat now include inactive sessions, enabling reuse of previous conversation contexts after pauses.
  * New conversations are now eagerly persisted to the system, improving reliability against restarts and preventing duplicate session creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->