### PR TITLE
feat(sessions): remove auto-stale-inactive timer; only /new marks inactive

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -133,7 +133,6 @@ export class AgentRunner implements SessionRuntime {
 
   private workspaceIdleTimer: ReturnType<typeof setTimeout> | undefined;
 
-  private staleSessionTimer: ReturnType<typeof setInterval> | undefined;
   private mcpClientManager: McpClientManager | undefined;
 
   private static DEBUG = false;
@@ -173,19 +172,6 @@ export class AgentRunner implements SessionRuntime {
       at: new Date().toISOString(),
     });
     return runner;
-  }
-
-  /**
-   * Start the periodic stale-session sweep. Scheduling itself lives in
-   * the gateway-level central scheduler (see
-   * `apps/gateway/src/central-scheduler.ts`); the runner only exposes
-   * `runScheduledJob` so the central scheduler can drive a fire.
-   */
-  startBackgroundTimers(): void {
-    void this.markStaleSessions();
-    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-    this.staleSessionTimer = setInterval(() => void this.markStaleSessions(), ONE_DAY_MS);
-    this.staleSessionTimer.unref?.();
   }
 
   /**
@@ -431,11 +417,6 @@ export class AgentRunner implements SessionRuntime {
       }
     }
 
-    if (this.staleSessionTimer) {
-      clearInterval(this.staleSessionTimer);
-      this.staleSessionTimer = undefined;
-    }
-
     if (this.workspaceIdleTimer) {
       clearTimeout(this.workspaceIdleTimer);
       this.workspaceIdleTimer = undefined;
@@ -455,20 +436,6 @@ export class AgentRunner implements SessionRuntime {
       agentId: this.scope.agentId,
       at: new Date().toISOString(),
     });
-  }
-
-  private static STALE_SESSION_DAYS = 3;
-
-  private async markStaleSessions(): Promise<void> {
-    try {
-      const cutoff = new Date(Date.now() - AgentRunner.STALE_SESSION_DAYS * 24 * 60 * 60 * 1000).toISOString();
-      const count = await this.store.sessions.markStaleInactive(this.scope, cutoff);
-      if (count > 0) {
-        this.logRuntime(`marked ${count} stale session(s) as inactive (no activity for ${AgentRunner.STALE_SESSION_DAYS}+ days)`);
-      }
-    } catch (error) {
-      this.logRuntime(`failed to mark stale sessions: ${error instanceof Error ? error.message : String(error)}`);
-    }
   }
 
   async openSession(spec: SessionSpec, caller?: Caller): Promise<SessionDescriptor> {

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -238,10 +238,6 @@ export class AgentInstanceManager {
       }
     }
 
-    // 8. Start background timers (stale-session sweep, etc.). Schedule
-    //    firing happens at the gateway level (see CentralScheduler).
-    runner.startBackgroundTimers();
-
     this.touch(agentId);
     return runner;
   }

--- a/packages/store/src/impl/session-store.ts
+++ b/packages/store/src/impl/session-store.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { eq, and, ne, lt, desc, sql } from 'drizzle-orm';
+import { eq, and, ne, desc, sql } from 'drizzle-orm';
 import pg from 'pg';
 import type { MetadataValue, SessionStatus, SessionType } from '@openhermit/protocol';
 
@@ -109,17 +109,6 @@ export class DbSessionStore implements SessionStore {
     await this.db.delete(sessionEvents)
       .where(and(eq(sessionEvents.agentId, scope.agentId), eq(sessionEvents.sessionId, sessionId)));
     await this.db.delete(sessions).where(where);
-  }
-
-  async markStaleInactive(scope: StoreScope, olderThanIso: string): Promise<number> {
-    const result = await this.db.update(sessions).set({ status: 'inactive' })
-      .where(and(
-        eq(sessions.agentId, scope.agentId),
-        ne(sessions.status, 'inactive'),
-        lt(sessions.lastActivityAt, olderThanIso),
-      ))
-      .returning();
-    return result.length;
   }
 
   private rowToEntry(row: typeof sessions.$inferSelect): PersistedSessionIndexEntry {

--- a/packages/store/src/interfaces.ts
+++ b/packages/store/src/interfaces.ts
@@ -45,7 +45,6 @@ export interface SessionStore {
   updateDescription(scope: StoreScope, sessionId: string, description: string, source: 'fallback' | 'ai'): Promise<void>;
   updateStatus(scope: StoreScope, sessionId: string, status: string): Promise<void>;
   delete(scope: StoreScope, sessionId: string): Promise<void>;
-  markStaleInactive(scope: StoreScope, olderThanIso: string): Promise<number>;
   waitForIdle(): Promise<void>;
 }
 


### PR DESCRIPTION
## Summary
- Removes the 24h background sweep that auto-marked sessions inactive after 3 days of silence.
- Drops `SessionStore.markStaleInactive` (interface + Drizzle impl) — no longer called anywhere.
- Only explicit user action (`/new`) checkpoints a session to inactive and opens a fresh one.

## Why
Sessions don't need an automatic lifecycle. Inbound channel messages already land on the most recent session for the channel; when the user wants a fresh one, `/new` is the explicit signal. No auto-reactivation needed because nothing was auto-deactivating in the first place once this timer is gone.

## Test plan
- [x] `npm run build` clean across monorepo
- [ ] Manually verify on test deploy: send a message, run `/new`, send again — second message starts a new session; old session shows as inactive in `/list`.
- [ ] Confirm no scheduled sweep fires after restart (no `marked N stale session(s)` log lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal session and agent lifecycle management by removing automatic background-scheduled stale session cleanup. Session handling is now managed through streamlined mechanisms rather than periodic interval timers, optimizing system architecture and initialization flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->