### PR TITLE
feat(sdk): attachment API on AgentLocalClient (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SDK 0.5.1 — 2026-05-18
+
+- **Added** `AgentLocalClient.uploadAttachment` / `listAttachments` / `getAttachment` — the same per-session attachment surface that `GatewayClient` already exposed, but on the per-agent client, so callers holding a channel-mode token (not an admin token) can upload directly under `/api/agents/:id/sessions/:sid/attachments`. Server-side auth is unchanged: same `requireAuth` → `enforceSessionNamespace` → `requireSessionAccessHttp` chain that `postMessage` uses, so any token that can `postMessage` on a session can also `uploadAttachment` to it.
+- **Added** `SessionAttachment` and `AttachmentMaterializationState` to the package's top-level exports so downstream consumers no longer need to mirror them locally or recover them via `Awaited<ReturnType<...>>`.
+- **Added** `agentLocalRoutes.sessionAttachments(sessionId)` / `sessionAttachmentById(sessionId, attachmentId)` (plus their `*Pattern` siblings) in `@openhermit/protocol`, mirroring the existing `gatewayRoutes.agentSessionAttachments*` entries.
+
 ## 0.8.0 — 2026-05-18
 
 ### File attachments end-to-end

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -677,6 +677,12 @@ export const agentLocalRoutes = {
   sessionCheckpointPattern: '/sessions/:sessionId/checkpoint',
   sessionCheckpoint: (sessionId: string): string =>
     `/sessions/${encodeURIComponent(sessionId)}/checkpoint`,
+  sessionAttachmentsPattern: '/sessions/:sessionId/attachments',
+  sessionAttachments: (sessionId: string): string =>
+    `/sessions/${encodeURIComponent(sessionId)}/attachments`,
+  sessionAttachmentByIdPattern: '/sessions/:sessionId/attachments/:attachmentId',
+  sessionAttachmentById: (sessionId: string, attachmentId: string): string =>
+    `/sessions/${encodeURIComponent(sessionId)}/attachments/${encodeURIComponent(attachmentId)}`,
   eventsUrl: (sessionId: string): string =>
     `/sessions/${encodeURIComponent(sessionId)}/events`,
   ws: '/ws',

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,6 +4,7 @@ import {
   agentLocalRoutes,
   gatewayRoutes,
   type AgentInfo,
+  type AttachmentMaterializationState,
   type CreateAgentRequest,
   type OutboundEvent,
   type SessionHistoryMessage,
@@ -20,6 +21,8 @@ import {
   type WsServerMessage,
   isWsRequest,
 } from '@openhermit/protocol';
+
+export type { SessionAttachment, AttachmentMaterializationState };
 import {
   OpenHermitError,
   type OpenHermitStatusCode,
@@ -114,6 +117,100 @@ export class AgentLocalClient {
     request: SessionCheckpointRequest = {},
   ): Promise<{ checkpointed: boolean }> {
     return this.postJson(agentLocalRoutes.sessionCheckpoint(sessionId), request);
+  }
+
+  /**
+   * Upload a file as a session attachment, using this client's per-agent
+   * token. Equivalent to `GatewayClient.uploadAttachment(agentId, ...)` but
+   * `agentId` is implicit — the client is already scoped to one agent.
+   *
+   * Pass a `File` (name taken from `file.name`) or a `Blob` with an explicit
+   * `filename`. Resolves with the attachment record; embed `id` in a
+   * subsequent `postMessage` as `{ type: 'file', id }`.
+   */
+  async uploadAttachment(
+    sessionId: string,
+    file: File | Blob,
+    filename?: string,
+  ): Promise<SessionAttachment> {
+    const form = new FormData();
+    const resolvedName =
+      filename ?? (file instanceof File ? file.name : undefined);
+    if (!resolvedName) {
+      throw new OpenHermitError(
+        'uploadAttachment requires a filename when body is a Blob without a name.',
+        'agent_api_error',
+        400,
+      );
+    }
+    form.append('file', file, resolvedName);
+
+    const url = joinUrl(
+      this.options.baseUrl,
+      agentLocalRoutes.sessionAttachments(sessionId),
+    );
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${this.options.token}` },
+        body: form,
+      });
+    } catch (error) {
+      throw this.buildFetchFailedError(
+        agentLocalRoutes.sessionAttachments(sessionId),
+        error,
+      );
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      const statusCode: OpenHermitStatusCode =
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 404 ||
+        response.status === 500
+          ? response.status
+          : 500;
+      throw new OpenHermitError(
+        `uploadAttachment failed (${response.status}): ${responseText || response.statusText}`,
+        'agent_api_error',
+        statusCode,
+      );
+    }
+
+    const body = (await response.json()) as { attachment: SessionAttachment };
+    return body.attachment;
+  }
+
+  /**
+   * List attachments for a session. Default scope is the current session
+   * only; `scope: 'user'` widens to every attachment the caller has uploaded
+   * across the agent's sessions (requires an authenticated user).
+   */
+  async listAttachments(
+    sessionId: string,
+    options?: { scope?: 'session' | 'user' },
+  ): Promise<SessionAttachment[]> {
+    let path = agentLocalRoutes.sessionAttachments(sessionId);
+    if (options?.scope === 'user') {
+      path += '?scope=user';
+    }
+    const body = await this.getJson<{ attachments: SessionAttachment[] }>(path);
+    return body.attachments;
+  }
+
+  /**
+   * Fetch a single attachment's metadata by id.
+   */
+  async getAttachment(
+    sessionId: string,
+    attachmentId: string,
+  ): Promise<SessionAttachment> {
+    const path = agentLocalRoutes.sessionAttachmentById(sessionId, attachmentId);
+    const body = await this.getJson<{ attachment: SessionAttachment }>(path);
+    return body.attachment;
   }
 
   async reviewApprovalRequest(


### PR DESCRIPTION
## Summary
- Add `uploadAttachment` / `listAttachments` / `getAttachment` to `AgentLocalClient` — same shape as the existing `GatewayClient` methods, but with an implicit `agentId` (this client is already scoped to one agent).
- Export `SessionAttachment` and `AttachmentMaterializationState` from the SDK's top-level so downstream consumers stop mirroring them locally or recovering them via `Awaited<ReturnType<...>>`.
- Add the matching `agentLocalRoutes.sessionAttachments*` route helpers in `@openhermit/protocol`.
- Bump `@openhermit/sdk` 0.5.0 → 0.5.1.

## Why
amiko-chat (and other per-twin / channel-mode callers) hold a per-agent token, not an admin token, so the existing `GatewayClient.uploadAttachment` is out of reach for them. They were forced to mirror the wire types and raw-`fetch` to `/api/agents/:id/sessions/:sid/attachments` themselves. That endpoint already accepts channel-mode tokens — same `requireAuth` → `enforceSessionNamespace` → `requireSessionAccessHttp` chain `postMessage` uses, so the auth policy was already in place; only the client-side symmetry was missing.

## Server-side note
No gateway changes needed: attachment routes share the same auth chain as `postMessage`/`approve`/`interrupt`, so any token that can `postMessage` on a session can also `uploadAttachment` to it.

## Test plan
- [x] `npm run build` clean across monorepo.
- [ ] Spot-check from amiko-chat: `client.uploadAttachment(sessionId, blob, 'file.png')` returns a `SessionAttachment` with a real `id`; embed that id in the next `postMessageStream` and confirm the agent sees it.
- [ ] Spot-check `listAttachments(sessionId)` and `listAttachments(sessionId, { scope: 'user' })`.

Spec doc: `/tmp/openhermit-sdk-attachment-on-agent-local-client.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session attachment capabilities: upload files to sessions, list session attachments, and retrieve attachment details.
  * Attachments work with per-session access tokens using the same authorization framework as session messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->