### PR TITLE
revert(skills): drop <available_skills> XML, return to bullet list

### DIFF
--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -176,25 +176,13 @@ export const loadSkillIndex = async (
 export const formatSkillsPromptSection = (skills: SkillIndexEntry[]): string | undefined => {
   if (skills.length === 0) return undefined;
 
-  const escapeXml = (s: string) =>
-    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-  const entries = skills
-    .map(
-      (s) =>
-        `  <skill>
-    <name>${escapeXml(s.name)}</name>
-    <description>${escapeXml(s.description)}</description>
-    <location>${s.path}/SKILL.md</location>
-  </skill>`,
-    )
-    .join('\n');
+  const lines = skills.map(
+    (s) => `- **${s.name}**: ${s.description} — \`file_read ${s.path}/SKILL.md\``,
+  );
 
   return `## Skills
 
-The following skills provide specialized instructions for specific tasks. Before replying, scan the <description> entries below. When one clearly matches the task, read its SKILL.md in full with \`file_read <location>\`. You MUST use the exact <location> value from <available_skills> — never guess, fabricate, or hard-code a skill file path. Do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped.
+The following skills provide specialized instructions for specific tasks. When a task matches a skill's description, read its SKILL.md in full with \`file_read\` (do not use \`exec cat\`; \`file_read\` returns skill files verbatim and uncapped).
 
-<available_skills>
-${entries}
-</available_skills>`;
+${lines.join('\n')}`;
 };

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -158,27 +158,18 @@ test('formatSkillsPromptSection returns undefined for empty list', () => {
   assert.equal(formatSkillsPromptSection([]), undefined);
 });
 
-test('formatSkillsPromptSection formats skills as available_skills XML', () => {
+test('formatSkillsPromptSection formats skills as a bullet list', () => {
   const skills: SkillIndexEntry[] = [
     { id: 'test', name: 'Test', description: 'A test', path: '/skills/test', source: 'system' },
   ];
   const section = formatSkillsPromptSection(skills)!;
   assert.ok(section.includes('## Skills'));
-  // Structured <location> field — model copies path verbatim instead of
-  // reconstructing it from prose, which closes off path-hallucination.
-  assert.ok(section.includes('<available_skills>'));
-  assert.ok(section.includes('<name>Test</name>'));
-  assert.ok(section.includes('<description>A test</description>'));
-  assert.ok(section.includes('<location>/skills/test/SKILL.md</location>'));
-  // Anti-hallucination steer (borrowed from openclaw): the model must use
-  // the location value verbatim and not invent paths.
-  assert.ok(section.includes('never guess, fabricate, or hard-code'));
-  // Skill-aware read steering preserved from prior fix: `file_read` only,
-  // never `exec cat`, since cat output is head+tail-previewed and
-  // unrecoverable across session resumes. The anti-cat steer must appear
-  // in the prose, and there must be no per-skill `cat <path>` listing.
+  assert.ok(section.includes('- **Test**: A test — `file_read /skills/test/SKILL.md`'));
+  // Skill-aware read steering preserved: `file_read` only, never `exec cat`,
+  // since cat output is head+tail-previewed and unrecoverable across session
+  // resumes.
   assert.ok(section.includes('file_read'));
-  assert.ok(section.includes('Do not use `exec cat`'));
+  assert.ok(section.includes('do not use `exec cat`'));
   assert.ok(!section.includes('cat /skills/test/SKILL.md'));
 });
 
@@ -258,11 +249,3 @@ test('isSkillReadResult rejects malformed details', () => {
   assert.equal(isSkillReadResult('file_read', {}, '/home/user'), false);
 });
 
-test('formatSkillsPromptSection escapes XML special chars in name/description', () => {
-  const skills: SkillIndexEntry[] = [
-    { id: 'x', name: 'A & B', description: 'Has <angle> & chars', path: '/skills/x', source: 'system' },
-  ];
-  const section = formatSkillsPromptSection(skills)!;
-  assert.ok(section.includes('<name>A &amp; B</name>'));
-  assert.ok(section.includes('<description>Has &lt;angle&gt; &amp; chars</description>'));
-});


### PR DESCRIPTION
## Summary
Reverts the system-prompt skills section from the structured `<available_skills><skill>…</skill></available_skills>` block back to the simpler markdown bullet list:

```
- **<name>**: <description> — `file_read <path>/SKILL.md`
```

## Why
b4662ef added the XML wrapper plus an anti-hallucination paragraph telling the model to copy `<location>` verbatim and never invent paths. In practice the bullet form already presents the path in backticks, and the model copies that verbatim just as reliably. The XML markup, the special-char escaping plumbing, and the extra steering prose were noise without a measurable win.

Skill-aware read steering is preserved: `file_read` only, never `exec cat` (cat output is head+tail-previewed and unrecoverable across session resumes).

## Test plan
- [x] `npm run build` clean.
- [x] `apps/agent/test/skills.test.ts` — all 25 tests pass, including the rewritten `formats skills as a bullet list` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the skills display format in agent prompts. Skills are now presented as a cleaner bullet-point list instead of a structured format, improving readability and clarity when skills are referenced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->