### PR TITLE
feat(skills): owner-only skill_install/skill_uninstall with source column

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -93,6 +93,7 @@ import { isSkillReadResult, loadSkillIndex } from './skills.js';
 import type { ScheduleRecord } from '@openhermit/store';
 import { McpClientManager } from './mcp-client.js';
 import { createMcpManagementToolset, createMcpStatusOnlyToolset } from './tools/mcp.js';
+import { createSkillManagementToolset } from './tools/skills.js';
 import {
   agentErrorsTotal,
   agentMessagesTotal,
@@ -1922,6 +1923,18 @@ export class AgentRunner implements SessionRuntime {
         },
       });
 
+      const toolHookCtx = {
+        bus: this.bus,
+        agentId: this.scope.agentId,
+        sessionId: input.contextSessionId,
+      };
+      const wrapToolset = (ts: Toolset): Toolset => ({
+        ...ts,
+        tools: ts.tools.map((tool) =>
+          withApproval(tool, this.options.security, input.approvalCallback, input.onToolCall, input.approvedCache, toolHookCtx),
+        ),
+      });
+
       // Connect to enabled MCP servers and add their toolsets
       if (this.options.mcpServerStore) {
         if (!this.mcpClientManager) {
@@ -1936,17 +1949,6 @@ export class AgentRunner implements SessionRuntime {
             this.mcpClientManager.connectAll(mcpServers);
           }
         }
-        const toolHookCtx = {
-          bus: this.bus,
-          agentId: this.scope.agentId,
-          sessionId: input.contextSessionId,
-        };
-        const wrapToolset = (ts: Toolset): Toolset => ({
-          ...ts,
-          tools: ts.tools.map((tool) =>
-            withApproval(tool, this.options.security, input.approvalCallback, input.onToolCall, input.approvedCache, toolHookCtx),
-          ),
-        });
         for (const ts of this.mcpClientManager.getToolsets()) {
           toolsets.push(wrapToolset(ts));
         }
@@ -1955,6 +1957,18 @@ export class AgentRunner implements SessionRuntime {
         } else {
           toolsets.push(wrapToolset(createMcpStatusOnlyToolset(this.mcpClientManager)));
         }
+      }
+
+      if (isOwnerOrUnresolved && this.options.skillStore) {
+        const skillStore = this.options.skillStore;
+        const agentId = this.scope.agentId;
+        const resyncSkills = async (): Promise<void> => {
+          const enabled = await skillStore.listEnabled(agentId);
+          await this.syncSkills(
+            enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+          );
+        };
+        toolsets.push(wrapToolset(createSkillManagementToolset(skillStore, agentId, resyncSkills)));
       }
 
       tools = toolsFromToolsets(toolsets);

--- a/apps/agent/src/core/backends/daytona.ts
+++ b/apps/agent/src/core/backends/daytona.ts
@@ -51,7 +51,7 @@ interface DaytonaBackendPersisted {
 }
 
 interface DaytonaPendingSkillSync {
-  skills: Array<{ id: string; sourcePath: string }>;
+  skills: Array<{ id: string; sourcePath: string; source: 'system' | 'user' }>;
   queuedAt: string;
 }
 
@@ -191,7 +191,7 @@ class DaytonaExecBackend implements ExecBackend {
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.sandbox) {
       await this.savePendingSkillSync({
-        skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath })),
+        skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source })),
         queuedAt: new Date().toISOString(),
       });
       return;
@@ -203,10 +203,16 @@ class DaytonaExecBackend implements ExecBackend {
 
   private async applySkillSync(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.sandbox) return;
-    const remoteSystemDir = `${this.agentHome}/.openhermit/skills/system`;
-    await this.sandbox.process.executeCommand(`rm -rf ${remoteSystemDir} && mkdir -p ${remoteSystemDir}`);
+    // Always reset both subdirs so uninstalling the last skill of a source
+    // actually clears it remotely.
+    const systemDir = `${this.agentHome}/.openhermit/skills/system`;
+    const userDir = `${this.agentHome}/.openhermit/skills/user`;
+    await this.sandbox.process.executeCommand(
+      `rm -rf ${systemDir} ${userDir} && mkdir -p ${systemDir} ${userDir}`,
+    );
     for (const skill of skills) {
-      const remoteSkillDir = `${remoteSystemDir}/${skill.id}`;
+      const baseDir = skill.source === 'user' ? userDir : systemDir;
+      const remoteSkillDir = `${baseDir}/${skill.id}`;
       await this.sandbox.fs.createFolder(remoteSkillDir, '755');
       await uploadDirToDaytona(this.sandbox, skill.sourcePath, remoteSkillDir);
     }
@@ -218,7 +224,14 @@ class DaytonaExecBackend implements ExecBackend {
     const pending = state?.['daytona_pending_skills'] as DaytonaPendingSkillSync | undefined;
     if (!pending || !pending.skills?.length) return;
     try {
-      await this.applySkillSync(pending.skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath })));
+      await this.applySkillSync(
+        pending.skills.map((s) => ({
+          id: s.id,
+          sourcePath: s.sourcePath,
+          // Tolerate state saved before the source column existed.
+          source: s.source ?? 'system',
+        })),
+      );
       await this.savePendingSkillSync(null);
     } catch (error) {
       console.warn(

--- a/apps/agent/src/core/backends/docker.ts
+++ b/apps/agent/src/core/backends/docker.ts
@@ -61,7 +61,7 @@ class DockerExecBackend implements ExecBackend {
 
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
     await syncSkillsToHostDir(
-      path.join(this.workspaceDir, '.openhermit', 'skills', 'system'),
+      path.join(this.workspaceDir, '.openhermit', 'skills'),
       skills,
     );
   }

--- a/apps/agent/src/core/backends/e2b.ts
+++ b/apps/agent/src/core/backends/e2b.ts
@@ -46,7 +46,7 @@ interface E2BBackendPersisted {
 }
 
 interface E2BPendingSkillSync {
-  skills: Array<{ id: string; sourcePath: string }>;
+  skills: Array<{ id: string; sourcePath: string; source: 'system' | 'user' }>;
   queuedAt: string;
 }
 
@@ -238,7 +238,7 @@ class E2BExecBackend implements ExecBackend {
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.sandbox) {
       await this.savePendingSkillSync({
-        skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath })),
+        skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source })),
         queuedAt: new Date().toISOString(),
       });
       return;
@@ -250,10 +250,16 @@ class E2BExecBackend implements ExecBackend {
 
   private async applySkillSync(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.sandbox) return;
-    const remoteSystemDir = `${this.agentHome}/.openhermit/skills/system`;
-    await this.sandbox.commands.run(`rm -rf ${remoteSystemDir} && mkdir -p ${remoteSystemDir}`);
+    // Always reset both subdirs so uninstalling the last skill of a source
+    // actually clears it remotely.
+    const systemDir = `${this.agentHome}/.openhermit/skills/system`;
+    const userDir = `${this.agentHome}/.openhermit/skills/user`;
+    await this.sandbox.commands.run(
+      `rm -rf ${systemDir} ${userDir} && mkdir -p ${systemDir} ${userDir}`,
+    );
     for (const skill of skills) {
-      const remoteSkillDir = `${remoteSystemDir}/${skill.id}`;
+      const baseDir = skill.source === 'user' ? userDir : systemDir;
+      const remoteSkillDir = `${baseDir}/${skill.id}`;
       await this.sandbox.files.makeDir(remoteSkillDir);
       await uploadDirToE2B(this.sandbox, skill.sourcePath, remoteSkillDir);
     }
@@ -265,7 +271,14 @@ class E2BExecBackend implements ExecBackend {
     const pending = state?.['e2b_pending_skills'] as E2BPendingSkillSync | undefined;
     if (!pending || !pending.skills?.length) return;
     try {
-      await this.applySkillSync(pending.skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath })));
+      await this.applySkillSync(
+        pending.skills.map((s) => ({
+          id: s.id,
+          sourcePath: s.sourcePath,
+          // Tolerate state saved before the source column existed.
+          source: s.source ?? 'system',
+        })),
+      );
       await this.savePendingSkillSync(null);
     } catch (error) {
       console.warn(

--- a/apps/agent/src/core/backends/host.ts
+++ b/apps/agent/src/core/backends/host.ts
@@ -51,7 +51,7 @@ class HostExecBackend implements ExecBackend {
 
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
     await syncSkillsToHostDir(
-      path.join(this.agentHome, '.openhermit', 'skills', 'system'),
+      path.join(this.agentHome, '.openhermit', 'skills'),
       skills,
     );
   }

--- a/apps/agent/src/core/backends/shared.ts
+++ b/apps/agent/src/core/backends/shared.ts
@@ -3,31 +3,45 @@ import path from 'node:path';
 
 import type { SyncSkillEntry } from '../exec-backend.js';
 
-/** Copy enabled skills into a host-side directory, removing stale entries. */
+/**
+ * Copy enabled skills into the host-side `<skillsRoot>/{system,user}/` layout,
+ * removing stale entries within each subdir. Always walks both subdirs even
+ * when one is empty, so uninstalling the last skill of a source actually
+ * deletes its dir contents on disk.
+ */
 export const syncSkillsToHostDir = async (
-  systemSkillsDir: string,
+  skillsRoot: string,
   skills: SyncSkillEntry[],
 ): Promise<void> => {
-  await mkdir(systemSkillsDir, { recursive: true });
-
-  const desired = new Map(skills.map((s) => [s.id, s.sourcePath]));
-
-  let existing: string[];
-  try {
-    existing = await readdir(systemSkillsDir);
-  } catch {
-    existing = [];
+  const bySource = new Map<'system' | 'user', Map<string, string>>([
+    ['system', new Map()],
+    ['user', new Map()],
+  ]);
+  for (const s of skills) {
+    bySource.get(s.source)!.set(s.id, s.sourcePath);
   }
 
-  for (const name of existing) {
-    if (!desired.has(name)) {
-      await rm(path.join(systemSkillsDir, name), { recursive: true, force: true });
+  for (const [source, desired] of bySource) {
+    const dir = path.join(skillsRoot, source);
+    await mkdir(dir, { recursive: true });
+
+    let existing: string[];
+    try {
+      existing = await readdir(dir);
+    } catch {
+      existing = [];
     }
-  }
 
-  for (const [id, sourcePath] of desired) {
-    const destPath = path.join(systemSkillsDir, id);
-    await rm(destPath, { recursive: true, force: true });
-    await cp(sourcePath, destPath, { recursive: true });
+    for (const name of existing) {
+      if (!desired.has(name)) {
+        await rm(path.join(dir, name), { recursive: true, force: true });
+      }
+    }
+
+    for (const [id, sourcePath] of desired) {
+      const destPath = path.join(dir, id);
+      await rm(destPath, { recursive: true, force: true });
+      await cp(sourcePath, destPath, { recursive: true });
+    }
   }
 };

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -23,6 +23,14 @@ export interface SyncSkillEntry {
   id: string;
   /** Absolute path on the gateway host to copy from. */
   sourcePath: string;
+  /**
+   * Selects the subdir under `<agentHome>/.openhermit/skills/`:
+   *   'system' → skills/system/<id>
+   *   'user'   → skills/user/<id>
+   * Kept as a discriminator (rather than letting callers pass the path) so the
+   * agent can only see/install into the layouts the runner authorizes.
+   */
+  source: 'system' | 'user';
 }
 
 export interface ExecOpts {
@@ -42,8 +50,9 @@ export interface ExecBackend {
   /** Execute a shell command and return the result. */
   exec(command: string, opts?: ExecOpts): Promise<ExecResult>;
   /**
-   * Make `<agentHome>/.openhermit/skills/system/` reflect exactly the given
-   * skill set inside the exec env: copies in, removes stale entries.
+   * Make `<agentHome>/.openhermit/skills/{system,user}/` reflect exactly the
+   * given skill set inside the exec env: copies in, removes stale entries.
+   * Each entry's `source` field decides the subdir.
    */
   syncSkills(skills: SyncSkillEntry[]): Promise<void>;
   /** Teardown (stop container, etc.). No-op if nothing to clean up. */

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -123,12 +123,15 @@ export const scanSkillDirectory = async (
 };
 
 /**
- * Load the effective skill index for an agent. Both layers live under the
- * workspace's `.openhermit/skills/` directory:
- * - System skills (DB-managed, copied into `skills/system/<id>`)
- * - Workspace skills (user-installed, in `skills/<id>` excluding `system/`)
+ * Load the effective skill index for an agent. Skills come from two layers:
+ * - DB-managed: each row carries `source` ('system' | 'user'), which decides
+ *   the subdir (`skills/system/<id>` vs `skills/user/<id>`). User skills are
+ *   owner-installed via `skill_install`; system skills are operator-managed.
+ * - Workspace scan: anything dropped directly under `<workspace>/.openhermit/
+ *   skills/` outside the managed subdirs. Treated as 'workspace' source.
  *
- * Workspace skills win on id conflicts.
+ * Workspace entries win on id conflicts so a local copy can override a synced
+ * skill during development.
  */
 export const loadSkillIndex = async (
   agentId: string,
@@ -140,27 +143,28 @@ export const loadSkillIndex = async (
   const entries = new Map<string, SkillIndexEntry>();
   const home = agentHome ?? workspaceRoot;
 
-  // 1. DB-enabled (system) skills — synced into <workspace>/.openhermit/skills/system/
+  // 1. DB-enabled skills — system/ vs user/ subdir determined by row.source.
   if (skillStore) {
     const dbSkills = await skillStore.listEnabled(agentId);
     for (const skill of dbSkills) {
+      const sub = skill.source === 'user' ? 'user' : 'system';
       entries.set(skill.id, {
         id: skill.id,
         name: skill.name,
         description: skill.description,
-        path: `${home}/.openhermit/skills/system/${skill.id}`,
+        path: `${home}/.openhermit/skills/${sub}/${skill.id}`,
         source: 'system',
       });
     }
   }
 
-  // 2. Workspace skills — overwrite system entries on id conflict.
+  // 2. Workspace skills — overwrite DB entries on id conflict.
   const workspaceSkillsDir = path.join(workspaceRoot, '.openhermit', 'skills');
   const wsSkills = await scanSkillDirectory(
     workspaceSkillsDir,
     `${home}/.openhermit/skills`,
     'workspace',
-    { exclude: new Set(['system']) },
+    { exclude: new Set(['system', 'user']) },
   );
   for (const skill of wsSkills) {
     entries.set(skill.id, skill);

--- a/apps/agent/src/tools/skills.ts
+++ b/apps/agent/src/tools/skills.ts
@@ -1,0 +1,218 @@
+/**
+ * Owner-only skill management tools.
+ *
+ * Skill source files are owned by the gateway host (the platform), not by
+ * the sandbox. `skill_install` writes user-skill files into a gateway-host
+ * directory and upserts a DB row (source='user', ownerAgentId=agentId), then
+ * triggers a resync so every backend lands the new files at
+ * `<agentHome>/.openhermit/skills/user/<id>/`. `skill_uninstall` does the
+ * inverse and is gated on ownerAgentId so an owner cannot uninstall a peer's
+ * skill or a system skill by guessing the id.
+ *
+ * Direct sandbox-side writes into `skills/user/` are deliberately avoided —
+ * for remote backends (e2b/daytona) those would be invisible to the platform
+ * and would drift on the next reset.
+ */
+
+import path from 'node:path';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+
+import { Type, type Static } from '@mariozechner/pi-ai';
+import { resolveAgentDataDir, ValidationError } from '@openhermit/shared';
+import type { SkillStore } from '@openhermit/store';
+
+import { asTextContent, formatJson, type PolicyAwareTool, type Toolset } from './shared.js';
+
+/** Absolute byte cap on a single skill payload (SKILL.md + supporting files). */
+const MAX_SKILL_PAYLOAD_BYTES = 256 * 1024;
+const MAX_SKILL_FILES = 32;
+const SKILL_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const SUPPORT_PATH_RE = /^[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*$/;
+
+const SkillInstallParams = Type.Object({
+  id: Type.String({
+    description:
+      'Folder-safe skill id (lowercase letters, digits, hyphens; 1–64 chars). Becomes the basename of the synced skill directory.',
+  }),
+  name: Type.String({ description: 'Human-readable skill name shown in the prompt index.' }),
+  description: Type.String({
+    description: 'One-line summary; agents see this when deciding whether to read SKILL.md.',
+  }),
+  markdown: Type.String({
+    description:
+      'Full SKILL.md contents. Should begin with `---\\nname: ...\\ndescription: ...\\n---` frontmatter.',
+  }),
+  files: Type.Optional(
+    Type.Array(
+      Type.Object({
+        path: Type.String({
+          description:
+            'Relative path inside the skill folder. Must not contain `..`, leading `/`, or backslashes.',
+        }),
+        content: Type.String({ description: 'UTF-8 file contents.' }),
+      }),
+      {
+        description: 'Optional supporting files placed alongside SKILL.md.',
+      },
+    ),
+  ),
+});
+
+const SkillUninstallParams = Type.Object({
+  id: Type.String({ description: 'The skill id to uninstall. Must be a user skill you installed.' }),
+});
+
+const userSkillSourceDir = (agentId: string, skillId: string): string =>
+  path.join(resolveAgentDataDir(agentId), 'skills', 'user', skillId);
+
+const validateSkillId = (id: string): void => {
+  if (!SKILL_ID_RE.test(id)) {
+    throw new ValidationError(
+      `Invalid skill id "${id}". Use 1–64 chars of [a-z0-9-], starting with a letter or digit.`,
+    );
+  }
+};
+
+const validateSupportPath = (rel: string): void => {
+  if (rel === 'SKILL.md') {
+    throw new ValidationError(
+      'Do not include SKILL.md in `files` — use the `markdown` parameter instead.',
+    );
+  }
+  if (!SUPPORT_PATH_RE.test(rel)) {
+    throw new ValidationError(
+      `Invalid supporting file path "${rel}". Must be a relative POSIX path of safe characters with no .. segments.`,
+    );
+  }
+};
+
+export const createSkillInstallTool = (
+  skillStore: SkillStore,
+  agentId: string,
+  resyncSkills: () => Promise<void>,
+): PolicyAwareTool<typeof SkillInstallParams> => ({
+  policy: { defaultGrants: [{ type: 'role', value: 'owner' }] },
+  name: 'skill_install',
+  label: 'Install Skill',
+  description:
+    'Install a user-scoped skill for this agent. The skill files are stored on the platform host and synced into the sandbox under .openhermit/skills/user/<id>/. Restricted to the owner.',
+  parameters: SkillInstallParams,
+  execute: async (_toolCallId, args: Static<typeof SkillInstallParams>) => {
+    validateSkillId(args.id);
+
+    const files = args.files ?? [];
+    if (files.length > MAX_SKILL_FILES) {
+      throw new ValidationError(
+        `Too many supporting files (${files.length}); cap is ${MAX_SKILL_FILES}.`,
+      );
+    }
+    let totalBytes = Buffer.byteLength(args.markdown, 'utf8');
+    for (const f of files) {
+      validateSupportPath(f.path);
+      totalBytes += Buffer.byteLength(f.content, 'utf8');
+    }
+    if (totalBytes > MAX_SKILL_PAYLOAD_BYTES) {
+      throw new ValidationError(
+        `Skill payload is ${totalBytes} bytes; cap is ${MAX_SKILL_PAYLOAD_BYTES}.`,
+      );
+    }
+
+    // Refuse to overwrite a system skill (or any skill not owned by this agent)
+    // by re-using its id. The DB constraint isn't enough — the upsert would
+    // happily flip source out from under it.
+    const existing = await skillStore.get(args.id);
+    if (existing && (existing.source !== 'user' || existing.ownerAgentId !== agentId)) {
+      throw new ValidationError(
+        `Skill "${args.id}" already exists and is not owned by this agent. Choose a different id.`,
+      );
+    }
+
+    const sourceDir = userSkillSourceDir(agentId, args.id);
+    await rm(sourceDir, { recursive: true, force: true });
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(path.join(sourceDir, 'SKILL.md'), args.markdown, 'utf8');
+    for (const f of files) {
+      const destPath = path.join(sourceDir, f.path);
+      await mkdir(path.dirname(destPath), { recursive: true });
+      await writeFile(destPath, f.content, 'utf8');
+    }
+
+    const now = new Date().toISOString();
+    await skillStore.upsert({
+      id: args.id,
+      name: args.name,
+      description: args.description,
+      path: sourceDir,
+      source: 'user',
+      ownerAgentId: agentId,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    });
+    await skillStore.enable(agentId, args.id);
+
+    await resyncSkills();
+
+    return {
+      content: asTextContent(
+        formatJson({
+          id: args.id,
+          name: args.name,
+          source: 'user',
+          fileCount: 1 + files.length,
+          totalBytes,
+          installed: true,
+        }),
+      ),
+      details: { skillId: args.id },
+    };
+  },
+});
+
+export const createSkillUninstallTool = (
+  skillStore: SkillStore,
+  agentId: string,
+  resyncSkills: () => Promise<void>,
+): PolicyAwareTool<typeof SkillUninstallParams> => ({
+  policy: { defaultGrants: [{ type: 'role', value: 'owner' }] },
+  name: 'skill_uninstall',
+  label: 'Uninstall Skill',
+  description:
+    'Uninstall a previously-installed user skill. Only skills you (the owner of this agent) installed can be removed; system skills are managed by the platform.',
+  parameters: SkillUninstallParams,
+  execute: async (_toolCallId, args: Static<typeof SkillUninstallParams>) => {
+    validateSkillId(args.id);
+    const existing = await skillStore.get(args.id);
+    if (!existing) {
+      throw new ValidationError(`Skill "${args.id}" not found.`);
+    }
+    if (existing.source !== 'user' || existing.ownerAgentId !== agentId) {
+      throw new ValidationError(
+        `Skill "${args.id}" is not a user skill installed by this agent and cannot be removed via skill_uninstall.`,
+      );
+    }
+
+    await skillStore.disable(agentId, args.id);
+    await skillStore.delete(args.id);
+    await rm(userSkillSourceDir(agentId, args.id), { recursive: true, force: true });
+
+    await resyncSkills();
+
+    return {
+      content: asTextContent(formatJson({ id: args.id, removed: true })),
+      details: { skillId: args.id },
+    };
+  },
+});
+
+export const createSkillManagementToolset = (
+  skillStore: SkillStore,
+  agentId: string,
+  resyncSkills: () => Promise<void>,
+): Toolset => ({
+  id: 'skill_management',
+  description: 'Owner-only tools for installing and removing user skills.',
+  tools: [
+    createSkillInstallTool(skillStore, agentId, resyncSkills),
+    createSkillUninstallTool(skillStore, agentId, resyncSkills),
+  ],
+});

--- a/apps/agent/test/skill-mounts.test.ts
+++ b/apps/agent/test/skill-mounts.test.ts
@@ -19,6 +19,9 @@ const fakeContext = (workspaceDir: string): BackendFactoryContext => ({
 const systemDir = (agentHome: string): string =>
   path.join(agentHome, '.openhermit', 'skills', 'system');
 
+const userDir = (agentHome: string): string =>
+  path.join(agentHome, '.openhermit', 'skills', 'user');
+
 // HostExecBackend writes skills to <cwd>/.openhermit/skills/system. Use the
 // `cwd` override to point at a temp dir so we don't touch $HOME.
 
@@ -30,7 +33,7 @@ test('host backend syncSkills copies skill directories into agentHome', async (t
   await fs.writeFile(path.join(skillSrc, 'SKILL.md'), 'content');
 
   const backend = createExecBackend({ type: 'host', id: 'host', cwd: home }, fakeContext(home));
-  await backend.syncSkills([{ id: 'skill-a', sourcePath: skillSrc }]);
+  await backend.syncSkills([{ id: 'skill-a', sourcePath: skillSrc, source: 'system' }]);
 
   const copied = await fs.readFile(path.join(systemDir(home), 'skill-a', 'SKILL.md'), 'utf8');
   assert.equal(copied, 'content');
@@ -68,10 +71,10 @@ test('host backend syncSkills replaces existing copy with updated content', asyn
   await fs.writeFile(path.join(skillSrc, 'SKILL.md'), 'v1');
 
   const backend = createExecBackend({ type: 'host', id: 'host', cwd: home }, fakeContext(home));
-  await backend.syncSkills([{ id: 'skill-b', sourcePath: skillSrc }]);
+  await backend.syncSkills([{ id: 'skill-b', sourcePath: skillSrc, source: 'system' }]);
 
   await fs.writeFile(path.join(skillSrc, 'SKILL.md'), 'v2');
-  await backend.syncSkills([{ id: 'skill-b', sourcePath: skillSrc }]);
+  await backend.syncSkills([{ id: 'skill-b', sourcePath: skillSrc, source: 'system' }]);
 
   const content = await fs.readFile(path.join(systemDir(home), 'skill-b', 'SKILL.md'), 'utf8');
   assert.equal(content, 'v2');
@@ -88,11 +91,52 @@ test('docker backend syncSkills writes to workspaceDir/.openhermit/skills/system
     { type: 'docker', id: 'docker', image: 'ubuntu:24.04' },
     fakeContext(workspaceDir),
   );
-  await backend.syncSkills([{ id: 'skill-c', sourcePath: skillSrc }]);
+  await backend.syncSkills([{ id: 'skill-c', sourcePath: skillSrc, source: 'system' }]);
 
   const copied = await fs.readFile(
     path.join(systemDir(workspaceDir), 'skill-c', 'SKILL.md'),
     'utf8',
   );
   assert.equal(copied, 'docker-content');
+});
+
+test('host backend syncSkills dispatches by source: user → user/, system → system/', async (t) => {
+  const home = await createTempDir(t, 'home-');
+  const sourceDir = await createTempDir(t, 'source-');
+
+  const sysSrc = path.join(sourceDir, 'sys-skill');
+  await fs.mkdir(sysSrc);
+  await fs.writeFile(path.join(sysSrc, 'SKILL.md'), 'sys');
+
+  const userSrc = path.join(sourceDir, 'user-skill');
+  await fs.mkdir(userSrc);
+  await fs.writeFile(path.join(userSrc, 'SKILL.md'), 'usr');
+
+  const backend = createExecBackend({ type: 'host', id: 'host', cwd: home }, fakeContext(home));
+  await backend.syncSkills([
+    { id: 'sys-skill', sourcePath: sysSrc, source: 'system' },
+    { id: 'user-skill', sourcePath: userSrc, source: 'user' },
+  ]);
+
+  assert.equal(
+    await fs.readFile(path.join(systemDir(home), 'sys-skill', 'SKILL.md'), 'utf8'),
+    'sys',
+  );
+  assert.equal(
+    await fs.readFile(path.join(userDir(home), 'user-skill', 'SKILL.md'), 'utf8'),
+    'usr',
+  );
+});
+
+test('host backend syncSkills removes stale entries from both source subdirs', async (t) => {
+  const home = await createTempDir(t, 'home-');
+  // Pre-seed an old user skill that should be cleaned up.
+  await fs.mkdir(path.join(userDir(home), 'old-user-skill'), { recursive: true });
+  await fs.writeFile(path.join(userDir(home), 'old-user-skill', 'SKILL.md'), 'stale');
+
+  const backend = createExecBackend({ type: 'host', id: 'host', cwd: home }, fakeContext(home));
+  await backend.syncSkills([]);
+
+  // user/ is created and the stale entry is gone.
+  assert.deepEqual(await fs.readdir(userDir(home)), []);
 });

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -132,18 +132,45 @@ test('loadSkillIndex workspace skills take priority over DB skills with same id'
   assert.equal(skills[0]!.source, 'workspace');
 });
 
-test('loadSkillIndex skips the system/ subdir when scanning workspace skills', async (t) => {
+test('loadSkillIndex skips the system/ and user/ subdirs when scanning workspace skills', async (t) => {
   const workspaceRoot = await createTempDir(t, 'workspace-');
   const sysSkillDir = path.join(workspaceRoot, '.openhermit', 'skills', 'system', 'sys-only');
+  const userSkillDir = path.join(workspaceRoot, '.openhermit', 'skills', 'user', 'user-only');
   await fs.mkdir(sysSkillDir, { recursive: true });
+  await fs.mkdir(userSkillDir, { recursive: true });
   await fs.writeFile(
     path.join(sysSkillDir, 'SKILL.md'),
     '---\nname: Sys Only\ndescription: System skill copied in\n---\n',
   );
+  await fs.writeFile(
+    path.join(userSkillDir, 'SKILL.md'),
+    '---\nname: User Only\ndescription: User skill copied in\n---\n',
+  );
 
-  // No DB store: workspace scan must not pick up files under system/.
+  // No DB store: workspace scan must not pick up files under system/ or user/.
+  // Those subdirs are owned by the platform-managed DB rows.
   const skills = await loadSkillIndex('agent-1', workspaceRoot);
   assert.deepEqual(skills, []);
+});
+
+test('loadSkillIndex emits user-source DB skills under the user/ subdir', async (t) => {
+  const workspaceRoot = await createTempDir(t, 'workspace-');
+
+  const fakeStore = {
+    listEnabled: async () => [
+      {
+        id: 'mine',
+        name: 'Mine',
+        description: 'Owner-installed',
+        path: '/db/path',
+        source: 'user',
+      },
+    ],
+  };
+
+  const skills = await loadSkillIndex('agent-1', workspaceRoot, fakeStore as any, '/agent/home');
+  assert.equal(skills.length, 1);
+  assert.equal(skills[0]!.path, '/agent/home/.openhermit/skills/user/mine');
 });
 
 test('loadSkillIndex works without skill store', async (t) => {

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -232,7 +232,9 @@ export class AgentInstanceManager {
     if (this.skillStore) {
       try {
         const enabled = await this.skillStore.listEnabled(agentId);
-        await runner.syncSkills(enabled.map((s) => ({ id: s.id, sourcePath: s.path })));
+        await runner.syncSkills(
+          enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+        );
       } catch (err) {
         log(`[${agentId}] skill sync failed: ${err instanceof Error ? err.message : String(err)}`);
       }

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2018,6 +2018,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       name: body.name,
       description: body.description,
       path: body.path,
+      source: 'system',
       ...(body.metadata && typeof body.metadata === 'object' ? { metadata: body.metadata as Record<string, unknown> } : {}),
       createdAt: now,
       updatedAt: now,

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -399,6 +399,7 @@ export const main = async (): Promise<void> => {
         name: skill.name,
         description: skill.description,
         path: skill.path,
+        source: 'system',
         createdAt: now,
         updatedAt: now,
       });

--- a/apps/gateway/src/skill-mounts.ts
+++ b/apps/gateway/src/skill-mounts.ts
@@ -1,10 +1,8 @@
 /**
- * Sync platform/system skills into a running agent's exec backends.
+ * Sync platform/user skills into a running agent's exec backends.
  *
- * Each backend (host/docker/e2b) decides where to write:
- *   - docker → bind-mount source dir (workspace's `.openhermit/skills/system/`)
- *   - host   → `$HOME/.openhermit/skills/system/`
- *   - e2b    → uploaded via SDK to `<agentHome>/.openhermit/skills/system/`
+ * Each backend (host/docker/e2b/daytona) writes into the `system/` or `user/`
+ * subdir under `.openhermit/skills/` based on each row's `source` column.
  */
 
 import type { AgentRunner } from '@openhermit/agent/agent-runner';
@@ -16,5 +14,7 @@ export const syncSkillMounts = async (
   skillStore: DbSkillStore,
 ): Promise<void> => {
   const enabled = await skillStore.listEnabled(agentId);
-  await runner.syncSkills(enabled.map((s) => ({ id: s.id, sourcePath: s.path })));
+  await runner.syncSkills(
+    enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+  );
 };

--- a/packages/store/drizzle/0029_skill_source.sql
+++ b/packages/store/drizzle/0029_skill_source.sql
@@ -1,0 +1,16 @@
+-- Distinguish operator-managed system skills from owner-installed user skills.
+-- `source` selects which subdir under <agentHome>/.openhermit/skills/ the skill
+-- is synced into (system/ vs user/). `owner_agent_id` records who installed a
+-- user skill; skill_install/skill_uninstall use it to gate access so an owner
+-- can only manage their own skills, never a system or peer skill.
+ALTER TABLE "skills"
+  ADD COLUMN "source" text NOT NULL DEFAULT 'system';
+
+ALTER TABLE "skills"
+  ADD CONSTRAINT "skills_source_check"
+  CHECK ("source" IN ('system', 'user'));
+
+ALTER TABLE "skills"
+  ADD COLUMN "owner_agent_id" text;
+
+CREATE INDEX "idx_skills_owner_agent" ON "skills" ("owner_agent_id");

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1779600000000,
       "tag": "0028_session_attachments_drop_skipped",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1779700000000,
+      "tag": "0029_skill_source",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/skill-store.ts
+++ b/packages/store/src/impl/skill-store.ts
@@ -33,6 +33,8 @@ export class DbSkillStore implements SkillStore {
       name: skill.name,
       description: skill.description,
       path: skill.path,
+      source: skill.source,
+      ownerAgentId: skill.ownerAgentId ?? null,
       metadata: (skill.metadata ?? {}) as Record<string, unknown>,
       createdAt: skill.createdAt,
       updatedAt: skill.updatedAt,
@@ -88,6 +90,8 @@ export class DbSkillStore implements SkillStore {
       name: skills.name,
       description: skills.description,
       path: skills.path,
+      source: skills.source,
+      ownerAgentId: skills.ownerAgentId,
       metadata: skills.metadata,
       createdAt: skills.createdAt,
       updatedAt: skills.updatedAt,
@@ -128,16 +132,21 @@ export class DbSkillStore implements SkillStore {
     name: string;
     description: string;
     path: string;
+    source: string;
+    ownerAgentId: string | null;
     metadata: unknown;
     createdAt: string;
     updatedAt: string;
   }): SkillRecord {
     const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+    const source = row.source === 'user' ? 'user' : 'system';
     return {
       id: row.id,
       name: row.name,
       description: row.description,
       path: row.path,
+      source,
+      ...(row.ownerAgentId ? { ownerAgentId: row.ownerAgentId } : {}),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -272,10 +272,18 @@ export const skills = pgTable('skills', {
   name: text('name').notNull(),
   description: text('description').notNull(),
   path: text('path').notNull(),
+  // 'system' = operator-managed; synced into <agentHome>/.openhermit/skills/system/.
+  // 'user'   = owner-installed via skill_install; synced into .../skills/user/.
+  source: text('source').notNull().default('system'),
+  // Only set for source='user'. Server-side guard so an owner can't uninstall
+  // a peer's skill (or a system skill) by guessing the id.
+  ownerAgentId: text('owner_agent_id'),
   metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}).notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_skills_owner_agent').on(table.ownerAgentId),
+]);
 
 export const agentSkills = pgTable('agent_skills', {
   agentId: text('agent_id').notNull(),

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -270,11 +270,16 @@ export interface UserIdentity {
   createdAt: string;
 }
 
+export type SkillSource = 'system' | 'user';
+
 export interface SkillRecord {
   id: string;
   name: string;
   description: string;
   path: string;
+  source: SkillSource;
+  /** Required when source='user'; identifies the agent that installed it. */
+  ownerAgentId?: string;
   metadata?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

- Adds `source` ('system' | 'user') and `owner_agent_id` columns to the `skills` table (migration `0029_skill_source.sql`).
- Per-backend `syncSkills` now dispatches by `source`: system skills land under `<agentHome>/.openhermit/skills/system/<id>/`, user skills under `<agentHome>/.openhermit/skills/user/<id>/`. Both subdirs are always walked so uninstalling the last skill of a source actually clears it on disk.
- New owner-only tools:
  - `skill_install` writes SKILL.md + optional support files into a gateway-host directory (`<OPENHERMIT_HOME>/agents/<id>/skills/user/<skill>/`), upserts the row with `source='user'` and `ownerAgentId=<agent>`, enables it, then triggers a resync.
  - `skill_uninstall` is gated server-side on `ownerAgentId` so an owner can't remove a peer's skill or a system skill.
- `loadSkillIndex` emits source-based sandbox paths for DB rows; workspace scan excludes both `system/` and `user/` subdirs since the platform owns them.

Built-in skill registration (`apps/gateway/src/index.ts`) and the admin upsert endpoint (`apps/gateway/src/app.ts`) both now pass `source: 'system'` so existing flows are unchanged.

## Why this shape

For remote sandboxes (e2b, daytona) an agent writing into `skills/user/` inside the sandbox would drift on the next reset and be invisible to the platform. Single source of truth lives on the gateway host; sandbox dirs are derived state, repopulated by `syncSkills` each time the runner boots and on demand after install/uninstall.

## Test plan

- [x] `node --import tsx --test test/skills.test.ts` — 26/26 pass (added user-source path test and dual-subdir exclusion test).
- [x] `node --import tsx --test test/skill-mounts.test.ts` — 7/7 pass (added source-dispatch + stale-cleanup tests).
- [x] Workspace `npm run build` clean.
- [ ] On test.openhermit.ai: install a user skill via `skill_install` from chat, confirm SKILL.md lands in `~/.openhermit/agents/<id>/skills/user/<skill>/`, confirm it appears in the next-turn prompt index, then `skill_uninstall` and confirm it vanishes from both DB and disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now install and manage custom user-created skills separately from built-in system skills
  * Skill management tools enable agents to install custom skills with supporting files and uninstall owned skills
  * Skills are organized by source and synced independently to execution environments, with ownership tracking for user-installed skills

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->