### PR TITLE
fix(agent): restore user-message attachments on first turn after resume

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -13,7 +13,7 @@ type AfterToolCallHook = (
   ctx: AfterToolCallContext,
   signal?: AbortSignal,
 ) => Promise<AfterToolCallResult | undefined>;
-import type { MessageSender, SessionHistoryMessage, SessionListQuery, SessionMessage, SessionSpec, SessionSummary } from '@openhermit/protocol';
+import type { MessageSender, SessionAttachment, SessionHistoryMessage, SessionListQuery, SessionMessage, SessionSpec, SessionSummary } from '@openhermit/protocol';
 import { NotFoundError, ValidationError, getErrorMessage } from '@openhermit/shared';
 import {
   type InternalStateStore,
@@ -2252,7 +2252,7 @@ export class AgentRunner implements SessionRuntime {
    */
   private async buildResumptionMessages(
     sessionId: string,
-    targetModel?: { provider: string; api: string; modelId: string },
+    targetModel?: { provider: string; api: string; modelId: string; supportsImageInput?: boolean },
   ): Promise<AgentMessage[]> {
     // Some providers (DeepSeek thinking models) reject any historical
     // tool-use assistant turn that lacks reasoning_content. When the
@@ -2290,10 +2290,43 @@ export class AgentRunner implements SessionRuntime {
       if (entry.role === 'user' && typeof entry.content === 'string') {
         lastAssistant = null;
         const userName = typeof entry.userName === 'string' ? entry.userName : undefined;
-        const content = isGroup && userName
+        const textContent = isGroup && userName
           ? `[${userName}] ${entry.content}`
           : entry.content;
-        messages.push({ role: 'user', content, timestamp: ts });
+        const rawAttachments = (entry as { attachments?: unknown }).attachments;
+        const attachments = Array.isArray(rawAttachments)
+          ? (rawAttachments as SessionAttachment[])
+          : [];
+        if (attachments.length === 0) {
+          messages.push({ role: 'user', content: textContent, timestamp: ts });
+          continue;
+        }
+        // Mirror the live postMessage path: rebuild the user message as
+        // structured blocks so vision-capable models see the image inline,
+        // and text-only models still get an `[attachment]` reference. Without
+        // this, the first turn after a session is rehydrated from DB loses
+        // every historical attachment — the model only sees the plain text,
+        // and cannot tell that a file was ever attached.
+        const attachmentBlocks = await prepareAttachmentContent(
+          attachments,
+          {
+            ...(this.options.attachmentStore
+              ? { attachmentStore: this.options.attachmentStore }
+              : {}),
+            ...(this.options.attachmentStorage
+              ? { attachmentStorage: this.options.attachmentStorage }
+              : {}),
+          },
+          {
+            supportsImageInput: targetModel?.supportsImageInput ?? true,
+            log: (m) => console.warn(`[agent-runner] ${m}`),
+          },
+        );
+        const blocks: typeof attachmentBlocks = [];
+        if (textContent.length > 0) blocks.push({ type: 'text', text: textContent });
+        for (const b of attachmentBlocks) blocks.push(b);
+        if (blocks.length === 0) blocks.push({ type: 'text', text: '' });
+        messages.push({ role: 'user', content: blocks, timestamp: ts });
         continue;
       }
 
@@ -2489,10 +2522,15 @@ export class AgentRunner implements SessionRuntime {
     let restoredMessages: AgentMessage[] = [];
     if (session?.resumed && messages.length <= 1) {
       const resolved = resolveModel(config);
+      const modelInputs = (resolved as { input?: string[] }).input;
+      const supportsImageInput = Array.isArray(modelInputs)
+        ? modelInputs.includes('image')
+        : true;
       restoredMessages = await this.buildResumptionMessages(sessionId, {
         provider: config.model.provider,
         api: resolved.api,
         modelId: resolved.id,
+        supportsImageInput,
       });
       session.resumed = false;
     }

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -1,4 +1,9 @@
 import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { test } from 'node:test';
 
 import type { StreamFn } from '@mariozechner/pi-agent-core';
@@ -10,9 +15,11 @@ import {
   type Usage,
 } from '@mariozechner/pi-ai';
 
+import type { SessionAttachment } from '@openhermit/protocol';
+
 import { AgentRunner } from '../src/agent-runner.js';
 import type { LangfuseClientLike } from '../src/langfuse.js';
-import { DbInternalStateStore } from '@openhermit/store';
+import { DbAttachmentStore, DbInternalStateStore, LocalAttachmentStorage } from '@openhermit/store';
 
 // Each test now uses a unique agentId from the security fixture.
 import { createSecurityFixture } from './helpers.js';
@@ -1066,6 +1073,135 @@ test('AgentRunner does not duplicate the new user message on the first turn afte
     hiUserCount,
     1,
     `new user message "hi" must appear exactly once in the LLM context (got ${hiUserCount})`,
+  );
+});
+
+test('AgentRunner restores user-message attachments on the first turn after resume', async (t) => {
+  // Regression: before this fix, when a session was rehydrated from DB (e.g.
+  // after a gateway redeploy), `buildResumptionMessages` read only the text
+  // content of historical user entries. Any attachments on those entries —
+  // including the current turn's brand-new attachment, which the postMessage
+  // handler had just inlined — were dropped when `transformContext` replaced
+  // the in-memory message list with the DB-restored one. Result: vision models
+  // saw plain text and had no idea a file was ever attached. Observed in prod
+  // as a kimi-k2.6 reply of literally "&" (thinking-only fallback).
+  const { workspace, security, agentId } = await createSecurityFixture(t, {
+    secrets: {
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+    },
+  });
+  await security.load();
+
+  const attachmentStore = await DbAttachmentStore.open();
+  t.after(() => attachmentStore.close());
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'openhermit-resume-att-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const attachmentStorage = new LocalAttachmentStorage({ root });
+
+  // Minimal valid 1x1 PNG so magic-bytes.js can sniff `image/png`.
+  const PNG_BYTES = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4' +
+      '890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082',
+    'hex',
+  );
+
+  const sessionId = 'cli:resume-att-session';
+  const attachmentId = `att_${randomBytes(16).toString('hex')}`;
+  const putResult = await attachmentStorage.put({
+    agentId,
+    sessionId,
+    attachmentId,
+    filename: 'pic.png',
+    contentType: 'image/png',
+    body: Readable.from(PNG_BYTES),
+  });
+  await attachmentStore.create({
+    id: attachmentId,
+    agentId,
+    sessionId,
+    uploaderUserId: null,
+    originalName: 'pic.png',
+    safeName: 'pic.png',
+    mimeType: 'image/png',
+    sizeBytes: putResult.sizeBytes,
+    sha256: putResult.sha256,
+    storageProvider: attachmentStorage.name,
+    storageKey: putResult.storageKey,
+  });
+
+  const sessionAttachment: SessionAttachment = {
+    id: attachmentId,
+    type: 'file',
+    name: 'pic.png',
+    mimeType: 'image/png',
+    size: PNG_BYTES.length,
+    sha256: putResult.sha256,
+    sandboxPath: '/sandbox/pic.png',
+    materializationState: 'copied',
+  };
+
+  const runner1 = await AgentRunner.create({
+    workspace,
+    security,
+    attachmentStore,
+    attachmentStorage,
+    streamFn: createSequentialStreamFn([
+      () => createTextResponseStream('first reply'),
+    ]),
+  });
+  await runner1.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner1.postMessage(sessionId, {
+    text: 'look at this',
+    attachments: [sessionAttachment],
+  });
+  await runner1.waitForSessionIdle(sessionId);
+
+  // Fresh runner instance simulates a gateway restart: in-memory session is
+  // gone, but the persistent DB + storage are shared.
+  let capturedMessages: Context['messages'] = [];
+  const runner2 = await AgentRunner.create({
+    workspace,
+    security,
+    attachmentStore,
+    attachmentStorage,
+    streamFn: createSequentialStreamFn([
+      (context) => {
+        capturedMessages = context.messages;
+        return createTextResponseStream('second reply');
+      },
+    ]),
+  });
+  await runner2.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner2.postMessage(sessionId, {
+    text: 'how about this one',
+    attachments: [sessionAttachment],
+  });
+  await runner2.waitForSessionIdle(sessionId);
+
+  const hasAttachmentBlock = (msg: { content: unknown }): boolean => {
+    if (!Array.isArray(msg.content)) return false;
+    return (msg.content as unknown[]).some((part) => {
+      if (typeof part !== 'object' || part === null) return false;
+      const p = part as { type?: string; text?: string };
+      if (p.type === 'image') return true;
+      if (p.type === 'text' && typeof p.text === 'string' && p.text.includes('[attachment]')) {
+        return true;
+      }
+      return false;
+    });
+  };
+
+  const userMessages = capturedMessages.filter((m) => m.role === 'user');
+  const withAttachmentBlock = userMessages.filter(hasAttachmentBlock);
+  assert.ok(
+    withAttachmentBlock.length >= 1,
+    `expected at least one resumed user message to carry an inlined image or [attachment] reference; got ${withAttachmentBlock.length} of ${userMessages.length} user messages`,
   );
 });
 


### PR DESCRIPTION
## Summary

When a session was rehydrated from DB (e.g. after a gateway redeploy), `buildResumptionMessages` read only the text content of historical user entries. Any attachments on those entries — including the **current turn's brand-new attachment** that the postMessage handler had just inlined as an image block — were dropped when `transformContext` replaced the in-memory message list with the DB-restored one.

Result: vision-capable models saw plain text and had no idea a file had been attached. Reproduced in prod against `moonshotai/kimi-k2.6`: user sent `这张怎么样？` + image, model emitted a single-token thinking block `" &"` and stopped (Langfuse trace `67a8fb05-ba2a-4ee4-b9e8-e504dd1f777b`, 120s wallclock, `usage.output=1`).

Fix mirrors the live postMessage path inside `buildResumptionMessages`: when a restored user entry carries `attachments`, run them through `prepareAttachmentContent` so vision-capable models get inline image blocks and text-only models get an `[attachment]` text reference. `supportsImageInput` is threaded in from the resolved model's `input` capability flags, matching the live path at `agent-runner.ts:1117-1132`.

## Why it only triggered on the *first* turn after resume

`transformContext` only restores from DB when `session.resumed === true && messages.length <= 1` (the very first prompt after rehydration). Subsequent turns use the live in-memory `messages`, where the postMessage path's `prepareAttachmentContent` output is preserved. So the bug only surfaced after a gateway restart / session eviction — invisible during normal operation.

## Test plan

- [x] Added regression test `AgentRunner restores user-message attachments on the first turn after resume` — spins up two `AgentRunner` instances against shared `DbAttachmentStore` + `LocalAttachmentStorage` to simulate a redeploy, then asserts the captured LLM context for the first turn after resume has a user message with either an inline `image` block or an `[attachment]` text reference.
- [x] Verified the new test fails on `main` (0 of 2 user messages carry the block) and passes with this fix.
- [x] Pre-existing failures in `agent-runner.test.ts` are identical on `main` (default-model assertions, unrelated config drift).
- [x] `prepare-attachment-content.test.ts` + `attachment-url-passthrough.test.ts` still pass (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed session resumption to properly restore user messages with attachments, including images.

* **Tests**
  * Added regression test to verify attachment restoration on session resume.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->