### PR TITLE
fix(channels): make signal + wechat plugins actually publishable

### DIFF
--- a/apps/channels/signal/package.json
+++ b/apps/channels/signal/package.json
@@ -9,12 +9,14 @@
   "exports": {
     ".": {
       "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },
   "files": [
-    "dist/**/*.js",
-    "dist/**/*.js.map",
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
     "README.md",
     "LICENSE"
   ],
@@ -39,7 +41,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsup",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
     "dev": "tsx src/index.ts",
     "test": "node --import tsx --test test/*.test.ts",
@@ -48,16 +50,18 @@
     "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "0.3.7",
+    "@openhermit/sdk": "^0.5.0",
     "jsqr": "^1.4.0",
     "pngjs": "^7.0.0",
     "ws": "^8.20.0"
   },
   "devDependencies": {
+    "@openhermit/protocol": "0.2.0",
     "@openhermit/shared": "0.2.0",
     "@types/pngjs": "^6.0.5",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.13",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "tsup": "^8.5.1"
   }
 }

--- a/apps/channels/signal/package.json
+++ b/apps/channels/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-signal",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "OpenHermit channel plugin for Signal via signal-cli-rest-api (json-rpc receive WS + QR-link setup wizard).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/signal/tsconfig.build.json
+++ b/apps/channels/signal/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "outDir": "dist",
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../../../packages/protocol/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/signal/tsup.config.ts
+++ b/apps/channels/signal/tsup.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tsup';
+
+// Workspace packages that are `private: true` and therefore unreachable
+// for an external `npm install`. Bundle them into the published artifact
+// so consumers don't need to resolve them at runtime or compile time.
+const internalPackages = [
+  '@openhermit/protocol',
+  '@openhermit/shared',
+];
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  platform: 'node',
+  outDir: 'dist',
+  clean: true,
+  splitting: false,
+  tsconfig: 'tsconfig.build.json',
+  dts: { resolve: true },
+  sourcemap: true,
+  noExternal: internalPackages,
+  esbuildOptions(options) {
+    options.conditions = ['development'];
+  },
+});

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text-only v0.",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -5,15 +5,18 @@
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },
   "files": [
-    "dist/**/*.js",
-    "dist/**/*.js.map",
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
     "README.md",
     "LICENSE"
   ],
@@ -40,7 +43,7 @@
   },
   "ilink_appid": "",
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsup",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run build",
@@ -49,5 +52,10 @@
   },
   "dependencies": {
     "@openhermit/sdk": "^0.5.0"
+  },
+  "devDependencies": {
+    "@openhermit/protocol": "0.2.0",
+    "@openhermit/shared": "0.2.0",
+    "tsup": "^8.5.1"
   }
 }

--- a/apps/channels/wechat/scripts/strip-dev-condition.mjs
+++ b/apps/channels/wechat/scripts/strip-dev-condition.mjs
@@ -2,7 +2,7 @@
 // prepack: back up package.json and remove the `development` export
 // condition so the published tarball only exposes built artifacts.
 // Restored by scripts/restore-package-json.mjs in postpack.
-import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -10,7 +10,12 @@ const here = dirname(fileURLToPath(import.meta.url));
 const pkgPath = resolve(here, '..', 'package.json');
 const backupPath = `${pkgPath}.bak`;
 
-copyFileSync(pkgPath, backupPath);
+// Only create the backup if one doesn't already exist — otherwise a
+// repeated prepack run would overwrite the original with an already
+// stripped manifest, leaving postpack with nothing to restore.
+if (!existsSync(backupPath)) {
+  copyFileSync(pkgPath, backupPath);
+}
 
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const dot = pkg.exports?.['.'];

--- a/apps/channels/wechat/tsconfig.build.json
+++ b/apps/channels/wechat/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "outDir": "dist",
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../../../packages/protocol/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/wechat/tsup.config.ts
+++ b/apps/channels/wechat/tsup.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tsup';
+
+// Workspace packages that are `private: true` and therefore unreachable
+// for an external `npm install`. Bundle them into the published artifact
+// so consumers don't need to resolve them at runtime or compile time.
+const internalPackages = [
+  '@openhermit/protocol',
+  '@openhermit/shared',
+];
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  platform: 'node',
+  outDir: 'dist',
+  clean: true,
+  splitting: false,
+  tsconfig: 'tsconfig.build.json',
+  dts: { resolve: true },
+  sourcemap: true,
+  noExternal: internalPackages,
+  esbuildOptions(options) {
+    options.conditions = ['development'];
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
-      "version": "0.2.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.5.0",
@@ -135,7 +135,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,32 +54,34 @@
         "discord.js": "^14.16.3"
       }
     },
+    "apps/channels/discord/node_modules/@openhermit/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-jEmgROts9qTOmMR3ZwCBx6caqXCROxrcTNF31mUrkFMwQUhN0oGFx4u0yiqGyB9o/JXZLsk94yoYPxY/VHJEtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@openhermit/sdk": "0.3.7",
-        "@openhermit/shared": "0.2.0",
+        "@openhermit/sdk": "^0.5.0",
         "jsqr": "^1.4.0",
         "pngjs": "^7.0.0",
         "ws": "^8.20.0"
       },
       "devDependencies": {
+        "@openhermit/protocol": "0.2.0",
+        "@openhermit/shared": "0.2.0",
         "@types/pngjs": "^6.0.5",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.13",
-        "qrcode": "^1.5.4"
+        "qrcode": "^1.5.4",
+        "tsup": "^8.5.1"
       },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "apps/channels/signal/node_modules/@openhermit/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-Tn1neqE+BfcoZoaRKhFzVatWQCLXLzkeALxYbThkZPHz+4UpX12OxUI725fHLbiJicrE1eSUe+rjTsrTnw9ebA==",
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       }
@@ -103,6 +105,15 @@
         "@slack/web-api": "^7.9.1"
       }
     },
+    "apps/channels/slack/node_modules/@openhermit/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-jEmgROts9qTOmMR3ZwCBx6caqXCROxrcTNF31mUrkFMwQUhN0oGFx4u0yiqGyB9o/JXZLsk94yoYPxY/VHJEtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/channels/telegram": {
       "name": "@openhermit/channel-telegram",
       "version": "0.2.0",
@@ -113,12 +124,26 @@
         "remend": "^1.3.0"
       }
     },
+    "apps/channels/telegram/node_modules/@openhermit/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-jEmgROts9qTOmMR3ZwCBx6caqXCROxrcTNF31mUrkFMwQUhN0oGFx4u0yiqGyB9o/JXZLsk94yoYPxY/VHJEtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.5.0"
+      },
+      "devDependencies": {
+        "@openhermit/protocol": "0.2.0",
+        "@openhermit/shared": "0.2.0",
+        "tsup": "^8.5.1"
       },
       "engines": {
         "node": ">=20"
@@ -165,6 +190,16 @@
         "@openhermit/web": "0.2.0",
         "tsup": "^8.5.1"
       },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/cli/node_modules/@openhermit/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@openhermit/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-jEmgROts9qTOmMR3ZwCBx6caqXCROxrcTNF31mUrkFMwQUhN0oGFx4u0yiqGyB9o/JXZLsk94yoYPxY/VHJEtA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20"
       }
@@ -544,6 +579,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
       "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1330,6 +1366,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1604,13 +1641,15 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -1709,6 +1748,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1731,6 +1771,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3186,6 +3227,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5183,6 +5225,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -5215,6 +5258,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5310,6 +5354,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5593,6 +5638,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6922,6 +6968,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7086,6 +7133,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7725,6 +7773,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7985,6 +8034,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -8885,6 +8935,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9399,6 +9450,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10302,6 +10354,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10352,6 +10405,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10462,6 +10516,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11141,6 +11196,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11229,6 +11285,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11248,7 +11305,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",


### PR DESCRIPTION
## Summary

Followup to #92. The signal channel plugin (and the pre-existing wechat one) were configured to publish to npm but the produced tarball couldn't actually work for external consumers — `tsc -b` left `@openhermit/protocol` and `@openhermit/shared` references in the JS/`.d.ts`, both of which are `private: true` and unreachable via `npm install`. The published `types` entry also pointed at a `.d.ts` that the `files` glob didn't ship.

Switch both builds to `tsup` with `noExternal: ['@openhermit/protocol', '@openhermit/shared']`, mirroring `packages/sdk/tsup.config.ts`. The published tarball is now a single bundled `dist/index.js` + `dist/index.d.ts` with only `@openhermit/sdk` (publicly published) as a runtime import.

### What changed per package

- **signal**:
  - `build: tsc -b` → `tsup`, `tsup.config.ts` + `tsconfig.build.json` added
  - `files` now lists `dist/index.d.ts` (was missing)
  - `exports['.']` gains a `types` condition
  - `@openhermit/sdk: 0.3.7` → `^0.5.0` (was stale; current is 0.5.2)
- **wechat**: same build switch + `files` + `exports` changes, plus its `strip-dev-condition.mjs` picks up the idempotent-backup guard signal already had

### Verification

- `npm test` in apps/channels/signal: 51/51 pass
- `npm pack --dry-run` shows clean 6-file tarball for both packages (LICENSE, README, package.json, dist/index.{js,js.map,d.ts})
- `grep '@openhermit'` in built output: only `@openhermit/sdk` remains as an external import
- Root `npm run typecheck`: 70 pre-existing errors in `apps/agent/test/*` unchanged (verified by stashing this diff and rerunning on bare main)

### Out of scope

discord/slack/telegram are still `"private": true` workspace-only packages and have a much simpler `package.json`. They're untouched until they get the same publish treatment, which is a larger uplift (README, LICENSE, exports map, prepack scripts, version policy).

## Test plan

- [x] signal tests pass
- [x] both packages build via tsup
- [x] both packages produce clean `npm pack --dry-run` tarballs
- [x] no new typecheck errors at repo root
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Signal and WeChat channel builds to a modern bundler for more consistent distribution artifacts.
  * Added and exposed package type declarations and tightened published artifacts to explicit distribution files.
  * Updated build configs and dev tooling versions for more reliable builds and idempotent prepack behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->