### PR TITLE
fix(channel-signal): drop outdated MODE=normal note from link wizard

### DIFF
--- a/apps/channels/signal/src/setup.ts
+++ b/apps/channels/signal/src/setup.ts
@@ -42,7 +42,7 @@ export const createSignalSetup = (
   const userInputState = (): ChannelSetupState => ({
     kind: 'awaiting_user_input',
     instructions:
-      'Enter the URL of your signal-cli-rest-api daemon and the bot phone number. The daemon must run with MODE=normal for the QR-link step (you can switch to MODE=json-rpc after linking).',
+      'Enter the URL of your signal-cli-rest-api daemon and the bot phone number.',
     fields: [
       {
         key: 'http_url',


### PR DESCRIPTION
## Summary
- The Signal link-device wizard told users to run signal-cli-rest-api with `MODE=normal` and switch to `MODE=json-rpc` after linking. That hasn't been necessary since we moved channel-signal to use the JSON-RPC daemon for QR-link too.
- Trim the wizard copy to just the field-level guidance — no more daemon-mode lore.

## Test plan
- [ ] Open the Signal channel setup wizard at `/manage/channels` and confirm the instruction text no longer mentions `MODE=normal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Signal QR-link setup instructions for clarity by streamlining setup notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->