### PR TITLE
chore(channel-signal): 0.1.0 → 0.1.1

### DIFF
--- a/apps/channels/signal/package.json
+++ b/apps/channels/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-signal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenHermit channel plugin for Signal via signal-cli-rest-api (json-rpc receive WS + QR-link setup wizard).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.5.0",


### PR DESCRIPTION
## Summary
- Bumps `@openhermit/channel-signal` to `0.1.1` so the wizard-copy fix from #132 (drop the outdated `MODE=normal` note) can be published to npm and picked up by deployments that load the package as an external manifest.

## Test plan
- [ ] After merge + `npm publish`, install `@openhermit/channel-signal@0.1.1` in a gateway and confirm the Signal link wizard no longer mentions `MODE=normal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version patch released for the signal channel package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->