### PR TITLE
fix(gateway): propagate channel-auth caller into openSession

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1106,7 +1106,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     // Pass caller identity directly to the runtime instead of injecting
     // it into session metadata — keeps "who's calling now" cleanly
     // separated from the session's persisted attributes.
-    const caller = auth.mode === 'user' && auth.channelUserId
+    const caller = (auth.mode === 'user' || auth.mode === 'channel') && auth.channelUserId
       ? { channel: auth.channel, channelUserId: auth.channelUserId }
       : undefined;
     const session = await runtime.openSession(payload, caller);


### PR DESCRIPTION
## Summary

- `apps/gateway/src/app.ts:1109` only built a `caller` for `auth.mode === 'user'`. Channel-token `openSession` calls (signal bridge etc.) landed in the runtime with `caller=undefined`.
- `resolveSessionUser` then fell back to `deriveChannelUserId`, which only knows telegram/cli — so for signal it returned `{}` and `session.resolvedChannel` / `resolvedChannelUserId` were never set.
- Visible symptom: `identity_link_request` throwing `"identity_link_request requires a known caller channel."` inside any signal session, because the agent tool context had no `currentChannel`/`currentChannelUserId` to read.
- Fix: mirror the existing `postMessage` handler (line 1203) which already accepts both `'user'` and `'channel'` modes.

## Test plan

- [ ] Open a signal session via the bridge (channel auth) and ask the agent to start an identity link from another platform — `identity_link_request` should now succeed.
- [ ] Regression: user-token `openSession` still propagates caller as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session creation now supports channel-authenticated requests in addition to user authentication methods, expanding authentication options for session management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->