### PR TITLE
fix(channel-signal): propagate sender identity via x-channel-user-id header

### DIFF
--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -131,10 +131,16 @@ export class SignalBridge implements ChannelOutbound {
 
     const key = conversationKey(msg);
     const sessionId = await this.getSessionId(key, msg);
-    await this.ensureSession(sessionId, msg);
-
     const senderChannelUserId = msg.sourceUuid ?? msg.sourceNumber ?? 'unknown';
+    await this.ensureSession(sessionId, msg, senderChannelUserId);
+
     const senderName = msg.sourceName;
+    // For DMs the sender IS the session user — surface that identity to the
+    // gateway via `x-channel-user-id` so tools like identity_link_request
+    // see a populated `currentChannel` / `currentChannelUserId`. For groups
+    // identity is per-message (the agent-runner derives it from the sender
+    // body field on each turn), so we don't claim a session-level user.
+    const postOpts = msg.groupId ? undefined : { channelUserId: senderChannelUserId };
     const postResult = await this.client.postMessage(sessionId, {
       text: msg.text,
       mentioned: true,
@@ -143,7 +149,7 @@ export class SignalBridge implements ChannelOutbound {
         channelUserId: senderChannelUserId,
         ...(senderName ? { displayName: senderName } : {}),
       },
-    });
+    }, postOpts);
 
     if (!(postResult as { triggered?: boolean }).triggered) return;
 
@@ -190,6 +196,7 @@ export class SignalBridge implements ChannelOutbound {
   private async ensureSession(
     sessionId: string,
     msg: SignalIncomingMessage,
+    senderChannelUserId: string,
   ): Promise<void> {
     const metadata: Record<string, string> = {};
     if (msg.groupId) metadata.signal_group_id = msg.groupId;
@@ -197,6 +204,9 @@ export class SignalBridge implements ChannelOutbound {
     else if (msg.sourceNumber) metadata.signal_source = msg.sourceNumber;
     if (msg.sourceNumber) metadata.signal_source_number = msg.sourceNumber;
 
+    // DMs: pass the sender so the runtime sees a populated caller. Groups:
+    // don't claim a session-level user (identity is per-message).
+    const openOpts = msg.groupId ? undefined : { channelUserId: senderChannelUserId };
     await this.client.openSession({
       sessionId,
       source: {
@@ -206,7 +216,7 @@ export class SignalBridge implements ChannelOutbound {
         type: msg.groupId ? 'group' : 'direct',
       },
       metadata,
-    });
+    }, openOpts);
   }
 
   private async waitForAgentResponse(sessionId: string): Promise<TurnResult> {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,8 +44,14 @@ export class AgentLocalClient {
     this.fetchImpl = options.fetch ?? fetch;
   }
 
-  async openSession(spec: SessionSpec): Promise<{ sessionId: string }> {
-    return this.postJson(agentLocalRoutes.sessions, spec);
+  async openSession(
+    spec: SessionSpec,
+    opts?: { channelUserId?: string },
+  ): Promise<{ sessionId: string }> {
+    const headers = opts?.channelUserId
+      ? { 'x-channel-user-id': opts.channelUserId }
+      : undefined;
+    return this.postJson(agentLocalRoutes.sessions, spec, headers);
   }
 
   async listSessions(query: SessionListQuery = {}): Promise<SessionSummary[]> {
@@ -91,8 +97,16 @@ export class AgentLocalClient {
   async postMessage(
     sessionId: string,
     message: SessionMessage,
+    opts?: { channelUserId?: string },
   ): Promise<{ sessionId: string; messageId?: string }> {
-    return this.postJson(agentLocalRoutes.sessionMessages(sessionId), message);
+    const headers = opts?.channelUserId
+      ? { 'x-channel-user-id': opts.channelUserId }
+      : undefined;
+    return this.postJson(
+      agentLocalRoutes.sessionMessages(sessionId),
+      message,
+      headers,
+    );
   }
 
   async appendMessage(


### PR DESCRIPTION
## Summary

- Signal DMs were opening sessions with no caller identity → gateway saw `auth.channelUserId = ''` → `caller=undefined` → `resolveSessionUser` fell back to `deriveChannelUserId`, which only knows telegram/cli → `session.resolvedChannel` stayed unset → `identity_link_request` threw \`requires a known caller channel\`.
- Rather than add another `if (platform === 'signal')` branch to the agent-runner core, mirror the pattern `submitApproval` already uses: the SDK forwards the caller's `channelUserId` via `x-channel-user-id`, and the channel bridge — which knows its own identity — passes it explicitly. Core stays channel-agnostic.

## Changes

- `packages/sdk`: `openSession(spec, { channelUserId? })` and `postMessage(sessionId, msg, { channelUserId? })` attach `x-channel-user-id` when set.
- `apps/channels/signal`: for DMs, pass `sourceUuid ?? sourceNumber` on both calls. Groups skip it — identity is per-message (resolved from sender body field each turn).
- Telegram still works via the existing metadata-derive path; that legacy path is a separate cleanup.

## Test plan

- [ ] Signal DM: agent answers and `identity_link_request` no longer throws \`requires a known caller channel\`.
- [ ] Signal group: behavior unchanged (per-message sender resolution still works).
- [ ] Telegram DM: regression check — identity still resolves via metadata path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better sender identity handling for Signal direct messages so DMs are correctly attributed.
  * Group messages retain prior identity behavior to avoid changing group attribution.

* **Updates**
  * SDK session and message APIs accept optional channel-user identification to propagate per-sender identity when available.

* **Chores**
  * SDK package version bumped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->