### PR TITLE
feat(sdk): channelUserId option on remaining session API methods (0.5.4)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -112,9 +112,13 @@ export class AgentLocalClient {
   async appendMessage(
     sessionId: string,
     message: SessionMessage,
+    opts?: { channelUserId?: string },
   ): Promise<{ sessionId: string; appended: boolean; deduped?: true }> {
     const path = `${agentLocalRoutes.sessionMessages(sessionId)}?append=true`;
-    return this.postJson(path, message);
+    const headers = opts?.channelUserId
+      ? { 'x-channel-user-id': opts.channelUserId }
+      : undefined;
+    return this.postJson(path, message, headers);
   }
 
   async submitApproval(
@@ -248,18 +252,21 @@ export class AgentLocalClient {
   async postMessageSync(
     sessionId: string,
     message: SessionMessage,
-    options?: { timeout?: number },
+    options?: { timeout?: number; channelUserId?: string },
   ): Promise<SyncResponse> {
     const params = new URLSearchParams({ wait: 'true' });
     if (options?.timeout) params.set('timeout', String(options.timeout));
     const path = `${agentLocalRoutes.sessionMessages(sessionId)}?${params.toString()}`;
-    return this.postJson(path, message);
+    const headers = options?.channelUserId
+      ? { 'x-channel-user-id': options.channelUserId }
+      : undefined;
+    return this.postJson(path, message, headers);
   }
 
   async *postMessageStream(
     sessionId: string,
     message: SessionMessage,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; channelUserId?: string },
   ): AsyncIterable<OutboundEvent> {
     const path = `${agentLocalRoutes.sessionMessages(sessionId)}?stream=true`;
     const url = joinUrl(this.options.baseUrl, path);
@@ -269,6 +276,9 @@ export class AgentLocalClient {
       headers: {
         authorization: `Bearer ${this.options.token}`,
         'content-type': 'application/json',
+        ...(options?.channelUserId
+          ? { 'x-channel-user-id': options.channelUserId }
+          : {}),
       },
       body: JSON.stringify(message),
       signal: options?.signal ?? null,


### PR DESCRIPTION
## Summary

0.5.3 added \`{ channelUserId }\` to \`openSession\` and \`postMessage\` so channel bridges could forward sender identity via the \`x-channel-user-id\` header. amiko-chat and similar downstreams use \`appendMessage\`, \`postMessageSync\`, and \`postMessageStream\` too — they need the same option, otherwise tools like \`identity_link_confirm\` keep throwing \`requires a known caller channel\`.

Purely additive — existing callers untouched.

## Changes
- \`appendMessage(sessionId, msg, { channelUserId? })\`
- \`postMessageSync(sessionId, msg, { timeout?, channelUserId? })\`
- \`postMessageStream(sessionId, msg, { signal?, channelUserId? })\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDK now supports optional channel user identification in message operations.

* **Chores**
  * Updated SDK version to 0.5.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->