### PR TITLE
feat(schedule): restore session_mode (dedicated|ephemeral) + cap compaction at 160K tokens

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -178,8 +178,9 @@ export class AgentRunner implements SessionRuntime {
   /**
    * Fire a single scheduled job. Called by the central scheduler. The
    * caller owns row bookkeeping (`startRun` / `markRun` / `finishRun`);
-   * this method only opens the session, runs the prompt, and tears the
-   * session down for one-off schedules.
+   * this method opens the session, runs the prompt, and tears the
+   * session down at the end of each firing. Cron schedules pass a
+   * per-firing sessionId so history doesn't accumulate across firings.
    */
   async runScheduledJob(schedule: ScheduleRecord, sessionId: string): Promise<void> {
     await this.openSession({
@@ -208,22 +209,23 @@ export class AgentRunner implements SessionRuntime {
     };
     await this.postMessage(sessionId, { text: transformed.prompt, metadata });
 
-    if (schedule.type === 'once') {
-      const session = this.sessions.get(sessionId);
-      if (session) {
-        session.status = 'inactive';
-        this.clearIdleSummaryTimer(session);
-        this.persistSessionIndex(session);
-        this.sessions.delete(sessionId);
-      } else {
-        await this.store.sessions.updateStatus(this.scope, sessionId, 'inactive');
-      }
-      await this.bus.emit('session.closed@v1', {
-        agentId: this.scope.agentId,
-        sessionId,
-        reason: 'idle',
-      });
+    // Every scheduled firing tears down its session. Cron schedules use
+    // a per-firing sessionId (see central-scheduler) so this leaves no
+    // long-lived "schedule:<id>" session accumulating history forever.
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.status = 'inactive';
+      this.clearIdleSummaryTimer(session);
+      this.persistSessionIndex(session);
+      this.sessions.delete(sessionId);
+    } else {
+      await this.store.sessions.updateStatus(this.scope, sessionId, 'inactive');
     }
+    await this.bus.emit('session.closed@v1', {
+      agentId: this.scope.agentId,
+      sessionId,
+      reason: 'idle',
+    });
   }
 
   /**

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -179,8 +179,8 @@ export class AgentRunner implements SessionRuntime {
    * Fire a single scheduled job. Called by the central scheduler. The
    * caller owns row bookkeeping (`startRun` / `markRun` / `finishRun`);
    * this method opens the session, runs the prompt, and tears the
-   * session down at the end of each firing. Cron schedules pass a
-   * per-firing sessionId so history doesn't accumulate across firings.
+   * session down for one-off and ephemeral schedules. `dedicated` cron
+   * schedules keep their session alive across firings.
    */
   async runScheduledJob(schedule: ScheduleRecord, sessionId: string): Promise<void> {
     await this.openSession({
@@ -209,23 +209,26 @@ export class AgentRunner implements SessionRuntime {
     };
     await this.postMessage(sessionId, { text: transformed.prompt, metadata });
 
-    // Every scheduled firing tears down its session. Cron schedules use
-    // a per-firing sessionId (see central-scheduler) so this leaves no
-    // long-lived "schedule:<id>" session accumulating history forever.
-    const session = this.sessions.get(sessionId);
-    if (session) {
-      session.status = 'inactive';
-      this.clearIdleSummaryTimer(session);
-      this.persistSessionIndex(session);
-      this.sessions.delete(sessionId);
-    } else {
-      await this.store.sessions.updateStatus(this.scope, sessionId, 'inactive');
+    // Tear down for one-off schedules and for ephemeral cron firings.
+    // Dedicated cron schedules keep history across firings on purpose.
+    const shouldTearDown =
+      schedule.type === 'once' || schedule.sessionMode.kind === 'ephemeral';
+    if (shouldTearDown) {
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        session.status = 'inactive';
+        this.clearIdleSummaryTimer(session);
+        this.persistSessionIndex(session);
+        this.sessions.delete(sessionId);
+      } else {
+        await this.store.sessions.updateStatus(this.scope, sessionId, 'inactive');
+      }
+      await this.bus.emit('session.closed@v1', {
+        agentId: this.scope.agentId,
+        sessionId,
+        reason: 'idle',
+      });
     }
-    await this.bus.emit('session.closed@v1', {
-      agentId: this.scope.agentId,
-      sessionId,
-      reason: 'idle',
-    });
   }
 
   /**

--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -14,6 +14,12 @@ export const DEFAULT_CONTEXT_COMPACTION_SUMMARY_MAX_CHARS = 2_400;
 
 export const DEFAULT_CONTEXT_COMPACTION_SAFETY_MARGIN_TOKENS = 2_048;
 
+// Hard ceiling on the auto-derived compaction threshold. Without this,
+// models with huge context windows (e.g. Gemini's 1M) would only compact
+// at ~1M input tokens — single turns hit 700K+ tokens before kicking in.
+// Users with explicit `contextCompactionMaxTokens` set can still raise it.
+export const DEFAULT_CONTEXT_COMPACTION_MAX_TOKENS_CEILING = 160_000;
+
 // ── Token estimation ───────────────────────────────────────────────────
 
 export const estimateTextTokens = (text: string): number =>
@@ -232,9 +238,12 @@ export const getContextCompactionMaxTokens = (
 
   return Math.max(
     2_048,
-    model.contextWindow
-    - reservedOutputTokens
-    - DEFAULT_CONTEXT_COMPACTION_SAFETY_MARGIN_TOKENS,
+    Math.min(
+      DEFAULT_CONTEXT_COMPACTION_MAX_TOKENS_CEILING,
+      model.contextWindow
+      - reservedOutputTokens
+      - DEFAULT_CONTEXT_COMPACTION_SAFETY_MARGIN_TOKENS,
+    ),
   );
 };
 

--- a/apps/agent/src/tools/schedule.ts
+++ b/apps/agent/src/tools/schedule.ts
@@ -25,6 +25,10 @@ const ScheduleCreateParams = Type.Object({
   cron_expression: Type.Optional(Type.String({ description: 'Cron expression (required for type "cron"). e.g. "0 9 * * *" for daily at 9am UTC.' })),
   run_at: Type.Optional(Type.String({ description: 'ISO 8601 datetime for one-time execution (required for type "once").' })),
   id: Type.Optional(Type.String({ description: 'Custom schedule ID. Auto-generated if omitted.' })),
+  session_mode: Type.Optional(Type.Union([
+    Type.Literal('dedicated'),
+    Type.Literal('ephemeral'),
+  ], { description: 'How firings map onto sessions. "dedicated" (default) reuses one session across firings — pick this when the agent should remember context between runs. "ephemeral" opens a fresh session per firing and tears it down after — pick this for stateless recurring work (feed scans, periodic checks) to keep token cost bounded.' })),
   delivery: Type.Optional(Type.Union([
     Type.Literal('silent'),
     Type.Object({
@@ -45,6 +49,10 @@ const ScheduleUpdateParams = Type.Object({
   prompt: Type.Optional(Type.String({ description: 'Update the prompt.' })),
   cron_expression: Type.Optional(Type.String({ description: 'Update the cron expression.' })),
   run_at: Type.Optional(Type.String({ description: 'Update the run_at time (once type only).' })),
+  session_mode: Type.Optional(Type.Union([
+    Type.Literal('dedicated'),
+    Type.Literal('ephemeral'),
+  ], { description: 'Change session strategy. "dedicated" reuses one session across firings. "ephemeral" opens a fresh session per firing. Switching from dedicated → ephemeral takes effect on the next firing; the existing dedicated session is left in place.' })),
 });
 
 type ScheduleUpdateArgs = Static<typeof ScheduleUpdateParams>;
@@ -93,6 +101,7 @@ const createScheduleListTool = (context: ToolContext): PolicyAwareTool<typeof Sc
       ...(s.cronExpression ? { cron: s.cronExpression } : {}),
       ...(s.runAt ? { runAt: s.runAt } : {}),
       prompt: s.prompt.length > 100 ? `${s.prompt.slice(0, 100)}…` : s.prompt,
+      sessionMode: s.sessionMode.kind,
       delivery: s.delivery.kind,
       runCount: s.runCount,
       ...(s.nextRunAt ? { nextRunAt: s.nextRunAt } : {}),
@@ -131,6 +140,10 @@ const createScheduleCreateTool = (context: ToolContext): PolicyAwareTool<typeof 
       throw new ValidationError('run_at is required for type "once".');
     }
 
+    const sessionMode: { kind: 'dedicated' | 'ephemeral' } = args.session_mode
+      ? { kind: args.session_mode }
+      : { kind: 'dedicated' };
+
     // Parse delivery
     let delivery: { kind: 'silent' | 'session'; sessionId?: string } = { kind: 'silent' };
     if (args.delivery) {
@@ -151,6 +164,7 @@ const createScheduleCreateTool = (context: ToolContext): PolicyAwareTool<typeof 
       ...(args.cron_expression ? { cronExpression: args.cron_expression } : {}),
       ...(args.run_at ? { runAt: args.run_at } : {}),
       prompt: args.prompt,
+      sessionMode,
       delivery,
       policy,
       ...(context.currentUserId ? { createdBy: context.currentUserId } : {}),
@@ -185,6 +199,7 @@ const createScheduleUpdateTool = (context: ToolContext): PolicyAwareTool<typeof 
     if (args.prompt !== undefined) patch.prompt = args.prompt;
     if (args.cron_expression !== undefined) patch.cronExpression = args.cron_expression;
     if (args.run_at !== undefined) patch.runAt = args.run_at;
+    if (args.session_mode !== undefined) patch.sessionMode = { kind: args.session_mode };
 
     const updated = await context.scheduleStore.update(context.storeScope, args.id, patch);
 
@@ -302,7 +317,9 @@ You can create and manage scheduled jobs that run automatically at specified tim
 - **Cron jobs**: Recurring tasks using cron expressions (e.g. "0 9 * * *" for daily at 9am UTC)
 - **One-time jobs**: Execute once at a specified time
 
-Each job runs in a dedicated session. The \`prompt\` field is an **instruction to yourself** — it will be sent to you as a user message in a separate schedule session. Write it as a clear directive, not as the raw user input.
+Each job runs in a schedule session. The \`prompt\` field is an **instruction to yourself** — it will be sent to you as a user message in a separate schedule session. Write it as a clear directive, not as the raw user input.
+
+By default schedules use \`session_mode: "dedicated"\` — every firing writes to the same session \`schedule:<id>\`, so the agent accumulates context across firings (useful for "what's new since last time" workflows). For stateless recurring work (feed scans, periodic checks, daily summaries) pass \`session_mode: "ephemeral"\` so each firing gets a fresh disposable session; this keeps per-firing token cost bounded.
 
 For example, if the user says "remind me in 5 minutes to buy milk", the prompt should be:
   \`Send this message to the delivery session: "Reminder: buy milk"\`

--- a/apps/agent/test/schedule-tools.test.ts
+++ b/apps/agent/test/schedule-tools.test.ts
@@ -22,6 +22,7 @@ const makeRecord = (overrides: Partial<ScheduleRecord> = {}): ScheduleRecord => 
   status: 'active',
   cronExpression: '0 9 * * *',
   prompt: 'do something',
+  sessionMode: { kind: 'dedicated' },
   delivery: { kind: 'silent' },
   policy: {},
   createdAt: '2026-01-01T00:00:00.000Z',
@@ -148,7 +149,7 @@ test('schedule_create once without run_at throws ValidationError', async (t) => 
   );
 });
 
-test('schedule_create does NOT pass sessionMode', async (t) => {
+test('schedule_create defaults sessionMode to dedicated', async (t) => {
   let capturedInput: Record<string, unknown> = {};
   const { tools } = await setupContext(t, {
     create: async (_scope, input) => {
@@ -158,7 +159,38 @@ test('schedule_create does NOT pass sessionMode', async (t) => {
   });
   const tool = findTool(tools, 'schedule_create');
   await tool.execute('call-1', { type: 'cron', prompt: 'test', cron_expression: '0 * * * *' });
-  assert.equal(capturedInput.sessionMode, undefined, 'create input should not have sessionMode');
+  assert.deepEqual(capturedInput.sessionMode, { kind: 'dedicated' });
+});
+
+test('schedule_create with session_mode=ephemeral passes through', async (t) => {
+  let capturedInput: Record<string, unknown> = {};
+  const { tools } = await setupContext(t, {
+    create: async (_scope, input) => {
+      capturedInput = input as Record<string, unknown>;
+      return makeRecord({ sessionMode: { kind: 'ephemeral' } });
+    },
+  });
+  const tool = findTool(tools, 'schedule_create');
+  await tool.execute('call-1', {
+    type: 'cron',
+    prompt: 'test',
+    cron_expression: '0 * * * *',
+    session_mode: 'ephemeral',
+  });
+  assert.deepEqual(capturedInput.sessionMode, { kind: 'ephemeral' });
+});
+
+test('schedule_update with session_mode passes through to store', async (t) => {
+  let capturedPatch: Record<string, unknown> = {};
+  const { tools } = await setupContext(t, {
+    update: async (_scope, id, input) => {
+      capturedPatch = input as Record<string, unknown>;
+      return makeRecord({ scheduleId: id, sessionMode: { kind: 'ephemeral' } });
+    },
+  });
+  const tool = findTool(tools, 'schedule_update');
+  await tool.execute('call-1', { id: 'sched-1', session_mode: 'ephemeral' });
+  assert.deepEqual(capturedPatch.sessionMode, { kind: 'ephemeral' });
 });
 
 test('schedule_create with delivery config passes through correctly', async (t) => {

--- a/apps/gateway/src/central-scheduler.ts
+++ b/apps/gateway/src/central-scheduler.ts
@@ -148,7 +148,13 @@ export class CentralScheduler {
         return;
       }
 
-      const sessionId = `schedule:${fresh.scheduleId}`;
+      // Cron schedules use a per-firing sessionId so history doesn't
+      // accumulate forever in one session (which previously produced
+      // 200K+ input-token turns and runaway cost). One-off schedules
+      // keep the stable id; they only fire once anyway.
+      const sessionId = fresh.type === 'cron'
+        ? `schedule:${fresh.scheduleId}:${new Date().toISOString().replace(/[:.]/g, '-')}`
+        : `schedule:${fresh.scheduleId}`;
       const run = await this.store.startRun(scope, fresh.scheduleId, sessionId, fresh.prompt);
 
       try {

--- a/apps/gateway/src/central-scheduler.ts
+++ b/apps/gateway/src/central-scheduler.ts
@@ -148,11 +148,12 @@ export class CentralScheduler {
         return;
       }
 
-      // Cron schedules use a per-firing sessionId so history doesn't
-      // accumulate forever in one session (which previously produced
-      // 200K+ input-token turns and runaway cost). One-off schedules
-      // keep the stable id; they only fire once anyway.
-      const sessionId = fresh.type === 'cron'
+      // `ephemeral` schedules use a per-firing sessionId so history
+      // doesn't accumulate forever (which previously produced 200K+
+      // input-token turns and runaway cost). `dedicated` reuses one
+      // session across firings — pick this when the agent should
+      // remember context between runs.
+      const sessionId = fresh.sessionMode.kind === 'ephemeral'
         ? `schedule:${fresh.scheduleId}:${new Date().toISOString().replace(/[:.]/g, '-')}`
         : `schedule:${fresh.scheduleId}`;
       const run = await this.store.startRun(scope, fresh.scheduleId, sessionId, fresh.prompt);

--- a/packages/store/src/impl/schedule-store.ts
+++ b/packages/store/src/impl/schedule-store.ts
@@ -11,6 +11,7 @@ import type {
   ScheduleRecord,
   ScheduleRunRecord,
   ScheduleRunStatus,
+  ScheduleSessionMode,
   ScheduleStatus,
   ScheduleType,
   ScheduleUpdateInput,
@@ -37,6 +38,7 @@ export class DbScheduleStore implements ScheduleStore {
   async create(scope: StoreScope, input: ScheduleCreateInput): Promise<ScheduleRecord> {
     const now = new Date().toISOString();
     const scheduleId = input.scheduleId ?? randomUUID().slice(0, 8);
+    const sessionMode: ScheduleSessionMode = input.sessionMode ?? { kind: 'dedicated' };
     const delivery: ScheduleDelivery = input.delivery ?? { kind: 'silent' };
     const policy = input.policy ?? {};
     const nextRunAt = input.type === 'once' ? (input.runAt ?? null) : null;
@@ -49,7 +51,7 @@ export class DbScheduleStore implements ScheduleStore {
       cronExpression: input.cronExpression ?? null,
       runAt: input.runAt ?? null,
       prompt: input.prompt,
-      sessionMode: JSON.stringify({ kind: 'dedicated' }),
+      sessionMode: JSON.stringify(sessionMode),
       delivery: delivery as unknown,
       policy: policy as Record<string, unknown>,
       createdBy: input.createdBy ?? null,
@@ -133,6 +135,7 @@ export class DbScheduleStore implements ScheduleStore {
       data.nextRunAt = input.runAt;
     }
     if (input.prompt !== undefined) data.prompt = input.prompt;
+    if (input.sessionMode !== undefined) data.sessionMode = JSON.stringify(input.sessionMode);
     if (input.delivery !== undefined) data.delivery = input.delivery;
     if (input.policy !== undefined) data.policy = input.policy;
 
@@ -239,6 +242,7 @@ export class DbScheduleStore implements ScheduleStore {
       ...(row.cronExpression ? { cronExpression: row.cronExpression } : {}),
       ...(row.runAt ? { runAt: row.runAt } : {}),
       prompt: row.prompt,
+      sessionMode: parseSessionMode(row.sessionMode),
       delivery: (row.delivery ?? { kind: 'silent' }) as ScheduleDelivery,
       policy: (row.policy ?? {}) as SchedulePolicy,
       ...(row.createdBy ? { createdBy: row.createdBy } : {}),
@@ -251,4 +255,24 @@ export class DbScheduleStore implements ScheduleStore {
       ...(row.lastError ? { lastError: row.lastError } : {}),
     };
   }
+}
+
+// Legacy rows have either the JSON-encoded `{"kind":"dedicated"}` (written
+// while the field was dead) or the bare default `dedicated` (column
+// default for rows inserted via raw SQL). Accept both.
+function parseSessionMode(raw: string | null | undefined): ScheduleSessionMode {
+  if (!raw) return { kind: 'dedicated' };
+  const trimmed = raw.trim();
+  if (trimmed === 'dedicated' || trimmed === 'ephemeral') {
+    return { kind: trimmed };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { kind?: unknown };
+    if (parsed && (parsed.kind === 'dedicated' || parsed.kind === 'ephemeral')) {
+      return { kind: parsed.kind };
+    }
+  } catch {
+    /* fall through */
+  }
+  return { kind: 'dedicated' };
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -33,6 +33,7 @@ export type {
   ScheduleUpdateInput,
   ScheduleType,
   ScheduleStatus,
+  ScheduleSessionMode,
   ScheduleDelivery,
   SchedulePolicy,
   ScheduleRunRecord,

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -317,6 +317,22 @@ export interface AgentMcpServerRecord {
 export type ScheduleType = 'cron' | 'once';
 export type ScheduleStatus = 'active' | 'paused' | 'completed' | 'failed';
 
+/**
+ * How firings of a schedule map onto sessions.
+ *
+ * - `dedicated` — every firing of this schedule writes to the same
+ *   long-lived session `schedule:<id>`. Useful when the agent should
+ *   accumulate context across firings (e.g. "compare today's metrics to
+ *   yesterday's"). Watch out for unbounded history growth.
+ * - `ephemeral` — every firing opens a fresh session
+ *   `schedule:<id>:<iso-ts>` that is torn down at the end of the firing.
+ *   Use for stateless work (feed scans, periodic notifications) to keep
+ *   per-firing token cost bounded.
+ */
+export interface ScheduleSessionMode {
+  kind: 'dedicated' | 'ephemeral';
+}
+
 export interface ScheduleDelivery {
   kind: 'silent' | 'session';
   sessionId?: string;
@@ -337,6 +353,7 @@ export interface ScheduleRecord {
   cronExpression?: string;
   runAt?: string;
   prompt: string;
+  sessionMode: ScheduleSessionMode;
   delivery: ScheduleDelivery;
   policy: SchedulePolicy;
   createdBy?: string;
@@ -355,6 +372,7 @@ export interface ScheduleCreateInput {
   cronExpression?: string;
   runAt?: string;
   prompt: string;
+  sessionMode?: ScheduleSessionMode;
   delivery?: ScheduleDelivery;
   policy?: SchedulePolicy;
   createdBy?: string;
@@ -365,6 +383,7 @@ export interface ScheduleUpdateInput {
   cronExpression?: string;
   runAt?: string;
   prompt?: string;
+  sessionMode?: ScheduleSessionMode;
   delivery?: ScheduleDelivery;
   policy?: SchedulePolicy;
 }


### PR DESCRIPTION
## Summary

Two related fixes for the runaway token usage observed in Langfuse traces (5/16 → 5/18 daily cost \$3.84 → \$7.17). Driven entirely by a restored, per-schedule `session_mode` field — no hardcoded type checks.

### 1. `session_mode` restored end-to-end

The `schedule.session_mode` column was decommissioned in `9dc896e` ("All schedules now use dedicated sessions"). Code paths and tooling were ripped out but the column stuck around. This brings it back so operators choose the strategy per schedule:

- **`dedicated`** (default) — every firing writes to the same long-lived `schedule:<id>` session. The agent accumulates context across firings; pick this for "what's new since last time" workflows.
- **`ephemeral`** — every firing opens a fresh `schedule:<id>:<iso-ts>` session that is torn down at the end. Per-firing token cost stays bounded; pick this for stateless recurring work (feed scans, periodic checks).

Wired through:
- `packages/store/src/types.ts` — `ScheduleSessionMode` type + field on `ScheduleRecord` / `ScheduleCreateInput` / `ScheduleUpdateInput`.
- `packages/store/src/impl/schedule-store.ts` — `create` / `update` accept it; `rowToRecord` parses, tolerating legacy plaintext `'dedicated'` and JSON-encoded `'{"kind":...}'` rows alike.
- `apps/agent/src/tools/schedule.ts` — `schedule_create` and `schedule_update` accept `session_mode`; `schedule_list` surfaces it.
- `apps/gateway/src/central-scheduler.ts` — sessionId is per-firing iff `sessionMode.kind === 'ephemeral'`.
- `apps/agent/src/agent-runner.ts` — teardown runs for `type === 'once'` and `ephemeral`; `dedicated` cron preserves the original session-reuse behavior.

Default stays `dedicated` to preserve existing schedule behavior. To stop the bleed on `schedule:feed-scan-comment-default`, operator runs after deploy:

```
schedule_update id=feed-scan-comment-default session_mode=ephemeral
```

### 2. Compaction threshold capped at 160K input tokens

`getContextCompactionMaxTokens` returned ~`model.contextWindow`. For gemini-3-flash (1M window), compaction only kicked in near 1M tokens — a single amiko session hit **773,410** input tokens before triggering. Added `DEFAULT_CONTEXT_COMPACTION_MAX_TOKENS_CEILING = 160_000` as a hard upper bound on the auto-derived threshold. Callers passing explicit `contextCompactionMaxTokens` can still go higher.

## Why now

Langfuse trace audit (5 days, 2,844 generations):
- `schedule:feed-scan-comment-default`: 1,158 calls, 24.78M tokens, **\$13.56** — ≈55% of total spend, all accumulated into one session.
- One amiko session peaked at **773,410** input tokens because compaction never triggered.

## Files

- `packages/store/src/types.ts`, `packages/store/src/index.ts`
- `packages/store/src/impl/schedule-store.ts`
- `apps/agent/src/tools/schedule.ts`
- `apps/agent/src/agent-runner.ts`
- `apps/agent/src/agent-runner/context-compaction.ts` — new ceiling constant
- `apps/agent/test/schedule-tools.test.ts` — replaced "does NOT pass sessionMode" with positive tests
- `apps/gateway/src/central-scheduler.ts`

## Test plan

- [x] `node --import tsx --test test/context-compaction.test.ts test/schedule-tools.test.ts` — 66/66 pass
- [x] `npm run typecheck -w apps/gateway -w packages/store` — clean
- [ ] After merge + deploy: `schedule_update id=feed-scan-comment-default session_mode=ephemeral` in prod
- [ ] Confirm next firing produces a session named `schedule:feed-scan-comment-default:2026-05-19T...`
- [ ] Confirm single-firing input tokens drop back to ~10K-30K range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schedule session modes ("dedicated" vs "ephemeral") with UI/tooling to create, update, and show them.
  * Session IDs for scheduled runs now vary by session mode.

* **Bug Fixes**
  * Scheduled-job teardown now respects session mode, improving session lifecycle behavior.
  * Context compaction enforces an upper token ceiling.

* **Tests**
  * Tests updated to cover session mode defaults and propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->