### PR TITLE
fix(agent): close compaction blind spots and stop image re-inlining on resumption

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -82,6 +82,7 @@ import {
 import {
   compactContextIfNeeded,
   estimateAgentMessagesTokens,
+  estimateFixedOverheadTokens,
   estimateTextTokens,
   getContextCompactionMaxTokens,
   truncateToolResults,
@@ -2285,7 +2286,26 @@ export class AgentRunner implements SessionRuntime {
     // Track the last assistant message so tool_call entries can be appended to it.
     let lastAssistant: import('@mariozechner/pi-ai').AssistantMessage | null = null;
 
-    for (const entry of entries) {
+    // To prevent post-resume payload blowups (observed at 773K input
+    // tokens on a session that had accumulated several image uploads),
+    // inline images only for the *most recent* user-with-attachment
+    // entry. Earlier entries are still preserved as text references so
+    // the model knows the file existed and can call `attachment_fetch`,
+    // but we don't re-encode every historical image as base64 on every
+    // turn after resumption.
+    let lastAttachmentEntryIndex = -1;
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      const e = entries[i];
+      if (e?.role !== 'user') continue;
+      const att = (e as { attachments?: unknown }).attachments;
+      if (Array.isArray(att) && att.length > 0) {
+        lastAttachmentEntryIndex = i;
+        break;
+      }
+    }
+
+    for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+      const entry = entries[entryIndex]!;
       const ts = new Date(entry.ts).getTime() || Date.now();
 
       if (entry.role === 'system') continue;
@@ -2312,6 +2332,15 @@ export class AgentRunner implements SessionRuntime {
         // this, the first turn after a session is rehydrated from DB loses
         // every historical attachment — the model only sees the plain text,
         // and cannot tell that a file was ever attached.
+        //
+        // Inlining image bytes is only done for the *most recent* user
+        // message with attachments. Older entries keep a text reference
+        // pointing at the sandbox path / attachment id, so the model
+        // still knows "an image existed here" but we don't re-encode
+        // every historical PNG as base64 on every resumed turn. A real
+        // session that uploaded 5 images previously could otherwise
+        // ship ~5 MB of base64 ⇒ ~700 K tokens on a single LLM call.
+        const isLatestAttachmentMessage = entryIndex === lastAttachmentEntryIndex;
         const attachmentBlocks = await prepareAttachmentContent(
           attachments,
           {
@@ -2323,7 +2352,8 @@ export class AgentRunner implements SessionRuntime {
               : {}),
           },
           {
-            supportsImageInput: targetModel?.supportsImageInput ?? true,
+            supportsImageInput:
+              isLatestAttachmentMessage && (targetModel?.supportsImageInput ?? true),
             log: (m) => console.warn(`[agent-runner] ${m}`),
           },
         );
@@ -2574,6 +2604,17 @@ export class AgentRunner implements SessionRuntime {
     const canRunLlmCompaction =
       !this.options.streamFn && Boolean(this.resolveApiKey(config.model.provider));
 
+    // System prompt + tool catalog also live in every request payload.
+    // Surface them to compaction so its budget check sees the real wire
+    // size, not just the messages portion. Read from the active session's
+    // agent state when available — that's the same `systemPrompt` /
+    // `tools` snapshot the LLM call will use.
+    const agentState = this.sessions.get(sessionId)?.agent.state;
+    const overheadTokens = estimateFixedOverheadTokens({
+      systemPrompt: agentState?.systemPrompt,
+      tools: agentState?.tools,
+    });
+
     const finalMessages = await compactContextIfNeeded(sessionId, config, contextBlocks, truncatedMessages, {
       store: this.store,
       scope: this.scope,
@@ -2581,6 +2622,8 @@ export class AgentRunner implements SessionRuntime {
         contextCompactionMaxTokens: this.options.contextCompactionMaxTokens,
         contextCompactionRecentMessageCount: this.options.contextCompactionRecentMessageCount,
         contextCompactionSummaryMaxChars: this.options.contextCompactionSummaryMaxChars,
+        contextCompactionMaxMessages: this.options.contextCompactionMaxMessages,
+        fixedOverheadTokens: overheadTokens,
       },
       createCompactionAgent: canRunLlmCompaction
         ? (sid) => this.createCompactionAgent(sid, config)

--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -20,6 +20,13 @@ export const DEFAULT_CONTEXT_COMPACTION_SAFETY_MARGIN_TOKENS = 2_048;
 // Users with explicit `contextCompactionMaxTokens` set can still raise it.
 export const DEFAULT_CONTEXT_COMPACTION_MAX_TOKENS_CEILING = 160_000;
 
+// Secondary trigger: regardless of token estimate, compact when the
+// message list grows past this count. A long history of small messages
+// (tool ping-pong, image attachments, etc.) can stay below the token
+// ceiling and never trigger compaction, leaving 400+ messages on the
+// wire — which kills prompt caching and inflates per-turn latency.
+export const DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES = 80;
+
 // ── Token estimation ───────────────────────────────────────────────────
 
 export const estimateTextTokens = (text: string): number =>
@@ -83,19 +90,69 @@ export const estimateAgentMessageTokens = (message: AgentMessage): number => {
 export const estimateAgentMessagesTokens = (messages: AgentMessage[]): number =>
   messages.reduce((total, message) => total + estimateAgentMessageTokens(message), 0);
 
+/**
+ * Estimate the fixed-overhead tokens that get sent on every LLM call:
+ * the system prompt and the serialized tool catalog. Without this,
+ * compaction's budget comparison only sees message tokens — but real
+ * payloads also carry a 28K-char system prompt + 50K-char tools catalog
+ * that together add ~20K tokens, pushing the actual request well above
+ * a 160K "messages" budget while compaction thinks it's safe.
+ */
+export const estimateFixedOverheadTokens = (input: {
+  systemPrompt?: string | undefined;
+  tools?: ReadonlyArray<unknown> | undefined;
+}): number => {
+  let total = 0;
+  if (input.systemPrompt) {
+    total += estimateTextTokens(input.systemPrompt);
+  }
+  if (input.tools && input.tools.length > 0) {
+    // Tool definitions are serialized to JSON on the wire (name +
+    // description + parameter schema). Stringify each tool individually
+    // so a circular ref in one entry doesn't take down the whole
+    // estimate.
+    for (const tool of input.tools) {
+      try {
+        total += estimateTextTokens(JSON.stringify(tool));
+      } catch {
+        total += 256; // fallback placeholder
+      }
+    }
+  }
+  return total;
+};
+
 // ── Per-message truncation ────────────────────────────────────────────
 
 /**
- * Max share of the context window a single tool result may occupy.
- * Anything larger is truncated with a marker.
+ * Max share of the context window a single tool result may occupy,
+ * applied at LLM-call time. Bounded above by `TOOL_RESULT_MAX_CHARS_CAP`
+ * so that on huge-context models (e.g. 256K kimi, 1M gemini) a single
+ * tool result can't quietly consume tens of thousands of tokens of
+ * history slot.
  */
 export const TOOL_RESULT_MAX_CONTEXT_RATIO = 0.25;
+
+/**
+ * Absolute cap (in chars) for any individual tool result inlined in the
+ * LLM request. Matches the persistence threshold in
+ * `tool-result-persistence.ts` — anything bigger has already been written
+ * to disk under workspace/.openhermit/tool_results/<id>.json, so the
+ * agent can pull the full text via `read_file` on demand. The previous
+ * ratio-only formula let a 55K-char document fit comfortably under a
+ * 64K-char per-call budget and sit in history forever; this cap keeps
+ * the inline footprint bounded regardless of context window size.
+ */
+export const TOOL_RESULT_MAX_CHARS_CAP = 8_000;
 
 export const truncateToolResults = (
   messages: AgentMessage[],
   contextWindow: number,
 ): AgentMessage[] => {
-  const maxChars = Math.floor(contextWindow * TOOL_RESULT_MAX_CONTEXT_RATIO * 4); // tokens × ~4 chars/token
+  const maxChars = Math.min(
+    TOOL_RESULT_MAX_CHARS_CAP,
+    Math.floor(contextWindow * TOOL_RESULT_MAX_CONTEXT_RATIO * 4), // tokens × ~4 chars/token
+  );
 
   return messages.map((message) => {
     if (message.role !== 'toolResult') {
@@ -220,6 +277,20 @@ export interface CompactionOptions {
   contextCompactionMaxTokens?: number | undefined;
   contextCompactionRecentMessageCount?: number | undefined;
   contextCompactionSummaryMaxChars?: number | undefined;
+  /**
+   * Secondary trigger — when the post-context message list grows past
+   * this count, compact even if the token estimate is still under
+   * budget. Default `DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES`.
+   */
+  contextCompactionMaxMessages?: number | undefined;
+  /**
+   * Pre-computed fixed overhead (system prompt + serialized tools) that
+   * will be sent on every LLM call. Subtracted from the budget so the
+   * compaction decision reflects the real wire payload, not just the
+   * messages portion. Caller is expected to compute this via
+   * `estimateFixedOverheadTokens` once per turn.
+   */
+  fixedOverheadTokens?: number | undefined;
 }
 
 export const getContextCompactionMaxTokens = (
@@ -258,6 +329,12 @@ export const getContextCompactionSummaryMaxChars = (
 ): number =>
   options.contextCompactionSummaryMaxChars
     ?? DEFAULT_CONTEXT_COMPACTION_SUMMARY_MAX_CHARS;
+
+export const getContextCompactionMaxMessages = (
+  options: CompactionOptions,
+): number =>
+  options.contextCompactionMaxMessages
+    ?? DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES;
 
 // ── LLM compaction summary ────────────────────────────────────────────
 
@@ -428,8 +505,19 @@ export const compactContextIfNeeded = async (
 ): Promise<AgentMessage[]> => {
   const combined = contextBlocks.concat(messages);
   const budget = getContextCompactionMaxTokens(config, deps.options);
+  const overhead = deps.options.fixedOverheadTokens ?? 0;
+  const maxMessages = getContextCompactionMaxMessages(deps.options);
 
-  if (messages.length <= 1 || estimateAgentMessagesTokens(combined) <= budget) {
+  // Decision sees the real wire payload: messages + system prompt +
+  // tools. The previous budget-only check ignored ~20K of overhead and
+  // never triggered when the messages portion sat just under 160K.
+  const effectiveTokens = (msgs: AgentMessage[]) =>
+    estimateAgentMessagesTokens(msgs) + overhead;
+
+  const overflowTokens = effectiveTokens(combined) > budget;
+  const overflowCount = messages.length > maxMessages;
+
+  if (messages.length <= 1 || (!overflowTokens && !overflowCount)) {
     return combined;
   }
 
@@ -460,15 +548,19 @@ export const compactContextIfNeeded = async (
   // First pass: find the retain count without LLM summary (text-extraction only).
   let compacted = buildCandidate(retainCount, undefined);
 
-  while (estimateAgentMessagesTokens(compacted) > budget && retainCount > 1) {
+  while (effectiveTokens(compacted) > budget && retainCount > 1) {
     retainCount -= 1;
     compacted = buildCandidate(retainCount, undefined);
   }
 
+  // Expansion phase: grow retainCount as long as we stay under the
+  // token budget AND under the message-count cap. Without the count
+  // cap, count-only triggers (lots of tiny messages well below budget)
+  // would expand right back to the full list and undo the compaction.
   while (retainCount < messages.length) {
     const expanded = buildCandidate(retainCount + 1, undefined);
 
-    if (estimateAgentMessagesTokens(expanded) > budget) {
+    if (effectiveTokens(expanded) > budget || expanded.length > maxMessages) {
       break;
     }
 
@@ -521,14 +613,26 @@ export const compactContextIfNeeded = async (
   // Rebuild with the LLM summary (or undefined for text-extraction fallback).
   compacted = buildCandidate(retainCount, llmSummary);
 
+  const beforeTokens = estimateAgentMessagesTokens(combined);
   const compactedTokens = estimateAgentMessagesTokens(compacted);
 
-  if (compactedTokens >= estimateAgentMessagesTokens(combined)) {
+  // If compaction was triggered only by message count (tokens still
+  // under budget), accept a wash on tokens as long as message count
+  // actually shrank — the goal there is to bound list length, not
+  // tokens.
+  const tokenWin = compactedTokens < beforeTokens;
+  const countWin = compacted.length < combined.length;
+  if (!tokenWin && !countWin) {
     return combined;
   }
 
+  const reason = overflowTokens && overflowCount
+    ? 'tokens+count'
+    : overflowTokens
+      ? 'tokens'
+      : 'count';
   deps.logRuntime(
-    `context compacted: ${sessionId} estimated ${estimateAgentMessagesTokens(combined)} -> ${compactedTokens} tokens${llmSummary ? ' (LLM summary)' : ' (text extraction)'}`,
+    `context compacted: ${sessionId} estimated ${beforeTokens} -> ${compactedTokens} tokens, ${combined.length} -> ${compacted.length} msgs, trigger=${reason}, overhead=${overhead}${llmSummary ? ' (LLM summary)' : ' (text extraction)'}`,
   );
 
   return compacted;

--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -548,7 +548,10 @@ export const compactContextIfNeeded = async (
   // First pass: find the retain count without LLM summary (text-extraction only).
   let compacted = buildCandidate(retainCount, undefined);
 
-  while (effectiveTokens(compacted) > budget && retainCount > 1) {
+  while (
+    (effectiveTokens(compacted) > budget || compacted.length > maxMessages)
+    && retainCount > 1
+  ) {
     retainCount -= 1;
     compacted = buildCandidate(retainCount, undefined);
   }

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -55,6 +55,7 @@ export interface AgentRunnerOptions {
   contextCompactionMaxTokens?: number;
   contextCompactionRecentMessageCount?: number;
   contextCompactionSummaryMaxChars?: number;
+  contextCompactionMaxMessages?: number;
   /**
    * Sandbox store — when provided, ExecBackendManager loads backends from
    * sandbox rows (one per agent). Without it, AgentRunner falls back to

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -846,6 +846,33 @@ test('compactContextIfNeeded compacts when message count exceeds threshold even 
   assert.ok(result.length < messages.length, 'message-count trigger must compact');
 });
 
+test('compactContextIfNeeded enforces count cap when recentMessageCount > maxMessages', async () => {
+  // Initial retainCount (10) starts ABOVE the count cap (5). Tokens fit
+  // under budget so the token-only shrink loop would never enter — the
+  // candidate must still come back at or under the cap.
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < 14; i += 1) {
+    messages.push(makeUserMessage(`q${i}`));
+    messages.push(makeAssistantMessage(`a${i}`));
+  }
+  const totalTokens = estimateAgentMessagesTokens(messages);
+  assert.ok(totalTokens < 100_000, 'precondition: well under token budget');
+
+  const deps = createStubDeps({
+    options: {
+      contextCompactionMaxTokens: 100_000,
+      contextCompactionRecentMessageCount: 10,
+      contextCompactionMaxMessages: 5,
+    },
+  });
+
+  const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
+  assert.ok(
+    result.length <= 5 + 1, // +1 leeway for a leading compaction summary block
+    `result kept ${result.length} retained messages, expected ≤ 6 including summary`,
+  );
+});
+
 // ── truncateToolResults absolute cap ──────────────────────────────────
 
 test('TOOL_RESULT_MAX_CHARS_CAP caps inline tool result regardless of context window', () => {

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -9,18 +9,22 @@ import {
   estimateContentTokens,
   estimateAgentMessageTokens,
   estimateAgentMessagesTokens,
+  estimateFixedOverheadTokens,
   getCompactionRetainedStartIndex,
   summarizeMessageForCompaction,
   buildContextCompactionBlock,
   compactContextIfNeeded,
   truncateToolResults,
   TOOL_RESULT_MAX_CONTEXT_RATIO,
+  TOOL_RESULT_MAX_CHARS_CAP,
   getContextCompactionMaxTokens,
+  getContextCompactionMaxMessages,
   getContextCompactionRecentMessageCount,
   getContextCompactionSummaryMaxChars,
   DEFAULT_CONTEXT_COMPACTION_RECENT_MESSAGE_COUNT,
   DEFAULT_CONTEXT_COMPACTION_SUMMARY_MAX_CHARS,
   DEFAULT_CONTEXT_COMPACTION_SAFETY_MARGIN_TOKENS,
+  DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES,
   runCompactionSummaryTurn,
   type CompactionDeps,
   type CompactionOptions,
@@ -724,4 +728,141 @@ test('compactContextIfNeeded returns original when compaction does not reduce to
   const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
   // When compacted >= original, should return original combined
   assert.ok(result.length >= 2);
+});
+
+// ── estimateFixedOverheadTokens ───────────────────────────────────────
+
+test('estimateFixedOverheadTokens returns 0 for empty input', () => {
+  assert.equal(estimateFixedOverheadTokens({}), 0);
+});
+
+test('estimateFixedOverheadTokens counts system prompt only', () => {
+  const tokens = estimateFixedOverheadTokens({ systemPrompt: 'a'.repeat(400) });
+  assert.equal(tokens, estimateTextTokens('a'.repeat(400)));
+});
+
+test('estimateFixedOverheadTokens counts each tool independently', () => {
+  const tools = [
+    { name: 'echo', description: 'echoes back', parameters: { type: 'object' } },
+    { name: 'read', description: 'read file', parameters: { type: 'object' } },
+  ];
+  const tokens = estimateFixedOverheadTokens({ tools });
+  const expected = tools.reduce((sum, t) => sum + estimateTextTokens(JSON.stringify(t)), 0);
+  assert.equal(tokens, expected);
+});
+
+test('estimateFixedOverheadTokens tolerates circular tool refs', () => {
+  const circular: Record<string, unknown> = { name: 'self' };
+  circular.self = circular;
+  // Should fall back to the 256-token placeholder rather than throwing.
+  const tokens = estimateFixedOverheadTokens({ tools: [circular] });
+  assert.equal(tokens, 256);
+});
+
+test('estimateFixedOverheadTokens sums prompt and tools', () => {
+  const tools = [{ name: 't' }];
+  const prompt = 'hello world';
+  const tokens = estimateFixedOverheadTokens({ systemPrompt: prompt, tools });
+  assert.equal(
+    tokens,
+    estimateTextTokens(prompt) + estimateTextTokens(JSON.stringify(tools[0])),
+  );
+});
+
+// ── fixedOverheadTokens compaction trigger ────────────────────────────
+
+test('compactContextIfNeeded compacts when overhead pushes payload past budget', async () => {
+  // Messages alone fit comfortably under a 1500-token budget, but
+  // overhead pushes the real payload over — must still compact.
+  const messages = [
+    makeUserMessage('word '.repeat(80).trim()),   // ~100 tokens
+    makeAssistantMessage('word '.repeat(80).trim()),
+    makeUserMessage('word '.repeat(80).trim()),
+    makeAssistantMessage('word '.repeat(80).trim()),
+    makeUserMessage('recent question'),
+    makeAssistantMessage('recent answer'),
+  ];
+  const messageTokens = estimateAgentMessagesTokens(messages);
+  assert.ok(messageTokens < 1500, `precondition: messages should fit under budget; got ${messageTokens}`);
+
+  const deps = createStubDeps({
+    options: {
+      contextCompactionMaxTokens: 1500,
+      contextCompactionRecentMessageCount: 2,
+      // 2000 tokens of overhead — easily exceeds the 1500 budget.
+      fixedOverheadTokens: 2000,
+    },
+  });
+
+  const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
+  assert.ok(result.length < messages.length, 'overhead alone must trigger compaction');
+});
+
+test('compactContextIfNeeded skips compaction when overhead absent and messages fit', async () => {
+  const messages = [
+    makeUserMessage('word '.repeat(80).trim()),
+    makeAssistantMessage('word '.repeat(80).trim()),
+  ];
+  const deps = createStubDeps({
+    options: {
+      contextCompactionMaxTokens: 1500,
+      contextCompactionRecentMessageCount: 2,
+    },
+  });
+  const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
+  assert.equal(result.length, messages.length);
+});
+
+// ── message-count secondary trigger ───────────────────────────────────
+
+test('getContextCompactionMaxMessages returns option when set', () => {
+  assert.equal(getContextCompactionMaxMessages({ contextCompactionMaxMessages: 5 }), 5);
+});
+
+test('getContextCompactionMaxMessages returns default when unset', () => {
+  assert.equal(getContextCompactionMaxMessages({}), DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES);
+});
+
+test('compactContextIfNeeded compacts when message count exceeds threshold even under budget', async () => {
+  // 12 tiny messages — well under any reasonable token budget, but
+  // pushing past a 5-message count threshold.
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < 12; i += 1) {
+    messages.push(makeUserMessage(`q${i}`));
+    messages.push(makeAssistantMessage(`a${i}`));
+  }
+  const totalTokens = estimateAgentMessagesTokens(messages);
+  assert.ok(totalTokens < 100_000, 'precondition: well under token budget');
+
+  const deps = createStubDeps({
+    options: {
+      contextCompactionMaxTokens: 100_000,
+      contextCompactionRecentMessageCount: 3,
+      contextCompactionMaxMessages: 5,
+    },
+  });
+
+  const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
+  assert.ok(result.length < messages.length, 'message-count trigger must compact');
+});
+
+// ── truncateToolResults absolute cap ──────────────────────────────────
+
+test('TOOL_RESULT_MAX_CHARS_CAP caps inline tool result regardless of context window', () => {
+  // Even with a huge context window where ratio*4 would allow 256K
+  // chars, the absolute cap kicks in.
+  const text = 'x'.repeat(50_000);
+  const messages: AgentMessage[] = [{
+    role: 'toolResult',
+    toolCallId: 'call-doc',
+    toolName: 'doc_read',
+    content: [{ type: 'text', text }],
+    isError: false,
+    timestamp: Date.now(),
+  }];
+  const result = truncateToolResults(messages, 1_000_000);
+  const resultText = (result[0] as { content: Array<{ text: string }> }).content[0]!.text;
+  assert.ok(resultText.length <= TOOL_RESULT_MAX_CHARS_CAP + 200, // +marker overhead
+    `result kept ${resultText.length} chars, expected ≤ ~${TOOL_RESULT_MAX_CHARS_CAP}`);
+  assert.ok(resultText.includes('[truncated:'));
 });


### PR DESCRIPTION
## Summary

Three context-bloat regressions surfaced from amiko session telemetry (\$1.96 / 27 traces / 21.7% cache hit; one 773K-input trace post-resumption):

- **Compaction budget ignored fixed overhead.** The 28K-char system prompt + ~50K-char tool catalog (~20K tokens combined) rode on every request but were excluded from the threshold check. Added `estimateFixedOverheadTokens` and routed it through `transformContext` → `compactContextIfNeeded`; the threshold, expansion loop, and acceptance gate all use the effective figure now.
- **Long sessions never tripped the token threshold.** Per-call totals stayed just under 160K while message count grew to 400+. Added a secondary count-based trigger (`contextCompactionMaxMessages`, default 80); compaction now fires on either condition, and the expansion loop short-circuits once the count cap is reached.
- **Tool results were sized off the model's huge context window.** kimi-k2.6's 1M-token window gave ~64K chars per inline tool result — whitepapers etc. sat in history forever. Capped at 8K chars (`TOOL_RESULT_MAX_CHARS_CAP`), aligning with the downstream persistence threshold.

Plus a separate finding from the 773K-input trace (`f9855004`, gemini-3-flash-preview, turn 73, only 3 messages):

- **Resumption re-inlined every historical image as base64.** `buildResumptionMessages` called `prepareAttachmentContent` for every user entry with attachments, accumulating base64 payloads across all prior turns. Now only the **last** user-with-attachments entry gets image bytes inlined; older ones fall back to text references.

## Test plan

- [x] `node --test apps/agent/test/context-compaction.test.ts` — 60/60 pass (12 new tests cover overhead estimation, count trigger, and the 8K cap)
- [ ] Watch a real session resume on test.openhermit.ai — confirm post-resumption traces no longer carry 700K+ input tokens
- [ ] Confirm long amiko sessions trigger count-based compaction (look for `agent.compaction.applied` events at message-count thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum message-count cap for context compaction.
  * Context compaction now factors in system prompt and tool overhead when budgeting tokens.

* **Performance**
  * Session resumption now avoids re-inlining large attachments for every historical message, reducing payload size.
  * Tool outputs are capped in size when inlined, preventing oversized context growth.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->