### PR TITLE
feat(channel-signal): target HCF signal-cli-rest-api fork (PR #2038 backport)

### DIFF
--- a/apps/channels/signal/README.md
+++ b/apps/channels/signal/README.md
@@ -1,7 +1,7 @@
 # Signal Channel Adapter
 
 `@openhermit/channel-signal` connects an OpenHermit agent to a Signal
-account via [`bbernhard/signal-cli-rest-api`](https://github.com/bbernhard/signal-cli-rest-api).
+account via [HCF Studios' fork of `signal-cli-rest-api`](https://github.com/HCF-STUDIOS/signal-cli-rest-api) (pinned to `ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038`, which back-ports [signal-cli PR #2038](https://github.com/AsamK/signal-cli/pull/2038)).
 The plugin is **not bundled** in the CLI — operators install it
 explicitly when they want Signal support.
 
@@ -11,8 +11,7 @@ explicitly when they want Signal support.
 - DMs and group messages
 - QR-link wizard via `ChannelSetup`
 - Optional allow-lists (`allowed_senders`, `allowed_group_ids`)
-- `MODE=json-rpc` enforced at runtime; the wizard temporarily uses the
-  daemon's `MODE=normal` mode for the QR-link step
+- Single-mode operation: the HCF fork handles QR-link and the receive WebSocket without flipping `MODE` mid-flow.
 
 ## Loading the plugin
 
@@ -49,42 +48,19 @@ admin UI's "Add channel" picker.
 4. Once the daemon registers the new linked device, the wizard auto-
    advances to `done` and the channel row is persisted.
 
-For the QR-link to work, the daemon must run in `MODE=normal` (its
-default). After the device is linked, restart the daemon with
-`MODE=json-rpc` so the receive WebSocket comes online — that's what
-the bridge uses for inbound messages.
+The HCF fork handles both QR-link and receive in a single mode, so the daemon just needs to be running with a linked account. The plugin's startup probe only checks `/v1/about` is reachable.
 
-## Daemon docker-compose snippets
-
-The daemon's `MODE` env var must change between linking and steady-state
-operation. Restart (or redeploy) the container after switching.
-
-### 1. Linking mode (first-time QR link)
+## Daemon docker-compose snippet
 
 ```yaml
-signal:
-  image: bbernhard/signal-cli-rest-api:latest
-  environment:
-    # MODE=normal exposes the QR-link endpoint used by the wizard.
-    MODE: normal
-  volumes:
-    - signal-data:/home/.local/share/signal-cli
-  ports:
-    - "8080:8080"
-```
-
-### 2. Runtime mode (after linking)
-
-```yaml
-signal:
-  image: bbernhard/signal-cli-rest-api:latest
-  environment:
-    # MODE=json-rpc enables the receive WebSocket the bridge consumes.
-    MODE: json-rpc
-  volumes:
-    - signal-data:/home/.local/share/signal-cli
-  ports:
-    - "8080:8080"
+services:
+  signal:
+    image: ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038
+    ports: ['8080:8080']
+    volumes:
+      - signal_data:/home/.local/share/signal-cli
+volumes:
+  signal_data:
 ```
 
 ## Stored config

--- a/apps/channels/signal/src/bot.ts
+++ b/apps/channels/signal/src/bot.ts
@@ -30,7 +30,7 @@ export class SignalBot {
       const controller = new AbortController();
       this.abortController = controller;
       await this.signal.probeReceiveMode();
-      this.log('probe ok: signal-cli-rest-api MODE=json-rpc');
+      this.log('probe ok: signal-cli-rest-api reachable');
       this.running = true;
       this.loopPromise = this.receiveLoop(controller.signal);
     })().finally(() => {

--- a/apps/channels/signal/src/manifest.ts
+++ b/apps/channels/signal/src/manifest.ts
@@ -1,5 +1,5 @@
 /**
- * Channel plugin manifest for Signal (signal-cli-rest-api).
+ * Channel plugin manifest for Signal (signal-cli-rest-api; HCF fork ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038).
  *
  * Loaded by the gateway when `@openhermit/channel-signal` is listed under
  * `channelPackages` in gateway config. See `docs/channel-plugin-design.md`.

--- a/apps/channels/signal/src/manifest.ts
+++ b/apps/channels/signal/src/manifest.ts
@@ -1,5 +1,5 @@
 /**
- * Channel plugin manifest for Signal (signal-cli-rest-api; HCF fork ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038).
+ * Channel plugin manifest for Signal (HCF fork of signal-cli-rest-api).
  *
  * Loaded by the gateway when `@openhermit/channel-signal` is listed under
  * `channelPackages` in gateway config. See `docs/channel-plugin-design.md`.

--- a/apps/channels/signal/src/setup.ts
+++ b/apps/channels/signal/src/setup.ts
@@ -42,7 +42,7 @@ export const createSignalSetup = (
   const userInputState = (): ChannelSetupState => ({
     kind: 'awaiting_user_input',
     instructions:
-      'Enter the URL of your signal-cli-rest-api daemon and the bot phone number. Use the HCF fork ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038 (or the official image once signal-cli PR #2038 ships) so QR-link and receive work without switching modes.',
+      'Enter the URL of your signal-cli-rest-api daemon (use the HCF fork — see README) and the bot phone number.',
     fields: [
       {
         key: 'http_url',

--- a/apps/channels/signal/src/setup.ts
+++ b/apps/channels/signal/src/setup.ts
@@ -42,7 +42,7 @@ export const createSignalSetup = (
   const userInputState = (): ChannelSetupState => ({
     kind: 'awaiting_user_input',
     instructions:
-      'Enter the URL of your signal-cli-rest-api daemon and the bot phone number. The daemon must run with MODE=normal for the QR-link step (you can switch to MODE=json-rpc after linking).',
+      'Enter the URL of your signal-cli-rest-api daemon and the bot phone number. Use the HCF fork ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038 (or the official image once signal-cli PR #2038 ships) so QR-link and receive work without switching modes.',
     fields: [
       {
         key: 'http_url',

--- a/apps/channels/signal/src/signal-api.ts
+++ b/apps/channels/signal/src/signal-api.ts
@@ -86,13 +86,11 @@ export class SignalApi {
     if (!res.ok) {
       throw new Error(`signal-cli-rest-api /v1/about returned ${res.status}; is the URL correct?`);
     }
-    const json = (await res.json()) as { mode?: string };
-    if (json.mode !== 'json-rpc') {
-      throw new Error(
-        `signal-cli-rest-api must run with MODE=json-rpc (got ${json.mode ?? 'unknown'}). ` +
-          `Set MODE=json-rpc in the container env and restart.`,
-      );
-    }
+    // The HCF fork (signal-cli-rest-api:0.99-pr2038) handles both QR-link and
+    // receive WS in any mode, so we only verify the daemon is reachable.
+    await res.json().catch(() => {
+      throw new Error(`signal-cli-rest-api /v1/about did not return JSON; is the URL correct?`);
+    });
   }
 
   async *streamMessages(opts: { signal?: AbortSignal } = {}): AsyncGenerator<SignalIncomingMessage> {

--- a/apps/channels/signal/src/signal-api.ts
+++ b/apps/channels/signal/src/signal-api.ts
@@ -86,8 +86,6 @@ export class SignalApi {
     if (!res.ok) {
       throw new Error(`signal-cli-rest-api /v1/about returned ${res.status}; is the URL correct?`);
     }
-    // The HCF fork (signal-cli-rest-api:0.99-pr2038) handles both QR-link and
-    // receive WS in any mode, so we only verify the daemon is reachable.
     await res.json().catch(() => {
       throw new Error(`signal-cli-rest-api /v1/about did not return JSON; is the URL correct?`);
     });

--- a/apps/channels/signal/test/signal-api.test.ts
+++ b/apps/channels/signal/test/signal-api.test.ts
@@ -86,19 +86,29 @@ test('SignalApi.sendDirectMessage throws on non-2xx with the response body', asy
   await assert.rejects(() => api.sendDirectMessage('+1', 'x'), /invalid recipient/);
 });
 
-test('SignalApi.probeReceiveMode rejects when probe endpoint returns non-json-rpc mode', async () => {
-  const { fetch: spy } = makeFetchSpy({ body: { mode: 'normal', version: '0.x' } });
-  const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });
+test('SignalApi.probeReceiveMode resolves for any mode the daemon reports', async () => {
+  for (const body of [{ mode: 'json-rpc' }, { mode: 'normal' }, { mode: 'native' }, {}]) {
+    const { fetch: spy } = makeFetchSpy({ body });
+    const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });
+    await api.probeReceiveMode();
+  }
+});
 
+test('SignalApi.probeReceiveMode rejects when /v1/about returns non-2xx', async () => {
+  const { fetch: spy } = makeFetchSpy({ status: 502, body: { error: 'bad gateway' } });
+  const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });
   await assert.rejects(
     () => api.probeReceiveMode(),
-    /MODE=json-rpc/,
+    /returned 502/,
   );
 });
 
-test('SignalApi.probeReceiveMode resolves when /v1/about reports mode=json-rpc', async () => {
-  const { fetch: spy } = makeFetchSpy({ body: { mode: 'json-rpc', version: '0.x' } });
+test('SignalApi.probeReceiveMode rejects when /v1/about returns non-JSON', async () => {
+  const spy = (async () =>
+    new Response('hello world', { status: 200, headers: { 'content-type': 'text/plain' } })) as typeof fetch;
   const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });
-
-  await api.probeReceiveMode(); // does not throw
+  await assert.rejects(
+    () => api.probeReceiveMode(),
+    /did not return JSON/,
+  );
 });

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -20,7 +20,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 
 | Platform | Package | Connection |
 |----------|---------|------------|
-| Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard |
+| Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket via HCF fork (`ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038`); QR-link setup wizard |
 | WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.

--- a/docs/channel-plugin-design.md
+++ b/docs/channel-plugin-design.md
@@ -102,7 +102,7 @@ Existing built-in channels (`telegram`, `slack`, `discord`) are refactored to ex
 
 ## Interactive Setup
 
-Token-only channels (telegram, slack, discord) start with a known config: the operator pastes a bot token into the admin UI, the row is saved, the channel is enabled. Some channels — Signal (QR-link via [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api)), WhatsApp-Web, anything OAuth — have a multi-step interactive flow that produces the persistent config only *after* the user completes an external action (scanning a QR, granting consent in a browser).
+Token-only channels (telegram, slack, discord) start with a known config: the operator pastes a bot token into the admin UI, the row is saved, the channel is enabled. Some channels — Signal (QR-link via [HCF fork of signal-cli-rest-api](https://github.com/HCF-STUDIOS/signal-cli-rest-api)), WhatsApp-Web, anything OAuth — have a multi-step interactive flow that produces the persistent config only *after* the user completes an external action (scanning a QR, granting consent in a browser).
 
 The `setup` field on `ChannelManifest` describes a state machine for this flow:
 


### PR DESCRIPTION
## Summary
- Drops the dual-mode dance (`MODE=normal` for linking, `MODE=json-rpc` for receive) by targeting [HCF Studios' fork of signal-cli-rest-api](https://github.com/HCF-STUDIOS/signal-cli-rest-api), pinned to `ghcr.io/hcf-studios/signal-cli-rest-api:0.99-pr2038`. The fork applies [signal-cli PR #2038](https://github.com/AsamK/signal-cli/pull/2038), which fixes the upstream bug where one of (linking, messaging) silently stops depending on `MODE`.
- `probeReceiveMode()` no longer enforces `mode === 'json-rpc'`; it just verifies `/v1/about` is reachable and returns JSON.
- README, wizard hint, `docs/channel-adapter.md`, `docs/channel-plugin-design.md`, and the manifest JSDoc all updated to reference the fork image.
- Tests: replaced the two probe-mode tests with three new ones (reachable in any mode, rejects non-2xx, rejects non-JSON).
