### PR TITLE
fix(cli): make bundled CJS require() resolve in ESM (0.8.0 → 0.8.1)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -45,5 +45,17 @@ export default defineConfig({
   // Shebang on every entry — harmless on gateway.js / web.js (they're never
   // exec'd directly), required for cli.js when invoked as the `openhermit` bin.
   // The per-entry callback didn't fire under `splitting: true`.
-  banner: { js: '#!/usr/bin/env node' },
+  //
+  // createRequire shim: tsup inlines transitive CJS deps (e.g. `mime-types`
+  // pulled in by @openhermit/gateway) and emits `__require("path")` calls
+  // that fall back to a throw because ESM has no `require`. Defining
+  // `require` per chunk via `createRequire(import.meta.url)` lets those
+  // calls resolve like normal Node CJS.
+  banner: {
+    js: [
+      '#!/usr/bin/env node',
+      "import { createRequire as __cjsCreateRequire } from 'node:module';",
+      'const require = __cjsCreateRequire(import.meta.url);',
+    ].join('\n'),
+  },
 });


### PR DESCRIPTION
## Summary
- 0.8.0 crashed at gateway boot with `Error: Dynamic require of "path" is not supported`, originating from the inlined `mime-types` CJS module.
- Root cause: tsup bundles `mime-types` (transitive dep via `@openhermit/gateway` → `attachment-routes.ts`) into an ESM output. Its `require("path")` calls hit tsup's `__require` fallback, which throws because ESM has no `require`.
- Fix: inject a `createRequire(import.meta.url)` shim into the tsup banner. Now bundled CJS modules can resolve Node builtins (and anything else `require`-shaped) at runtime.
- Bumps `apps/cli` to 0.8.1.

## Repro
```
$ node dist/gateway.js
file:///.../chunk-YDXINIXI.js:12
  throw Error('Dynamic require of "' + x + '" is not supported');
        ^
Error: Dynamic require of "path" is not supported
    at ../../node_modules/mime-types/index.js (gateway.js:10758:19)
```

## Test plan
- [x] `npm run bundle` in `apps/cli` succeeds.
- [x] New bundle's `gateway.js` boots locally past the `mime-types` load point, listens on :4000.
- [x] All 13 CLI tests pass (`npm test`).
- [ ] Smoke test after publish: `npm i -g openhermit@0.8.1 && hermit gateway run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved module resolution issues to ensure CommonJS dependencies are properly handled in the CLI's ESM environment at runtime.

* **Chores**
  * Updated CLI package version to 0.8.1.
  * Enhanced build configuration for improved module compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->