### PR TITLE
fix(gateway): seed channel rows with manifest.defaultConfig

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -937,10 +937,15 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     // built-in token-based ones).
     if (options.agentChannelStore) {
       for (const key of options.manifestRegistry.keys()) {
+        // Seed config from the manifest so secret placeholders
+        // (`${{TOKEN}}`) are already in place when the owner first enables
+        // the channel — no need to know the field names by heart.
+        const defaults = options.manifestRegistry.get(key)?.defaultConfig;
         await options.agentChannelStore.createBuiltin({
           agentId: record.agentId,
           channelType: key,
           enabled: false,
+          ...(defaults ? { config: { ...defaults } } : {}),
         });
       }
     }
@@ -2517,11 +2522,16 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
           `A channel of type "${channelType}" already exists on this agent.`,
         );
       }
+      const defaults = manifest.defaultConfig;
       const created = await store.createBuiltin({
         agentId,
         channelType,
         ...(body.label ? { label: body.label } : {}),
-        ...(body.config ? { config: body.config } : {}),
+        ...(body.config
+          ? { config: body.config }
+          : defaults
+            ? { config: { ...defaults } }
+            : {}),
         ...(typeof body.enabled === 'boolean' ? { enabled: body.enabled } : {}),
       });
 
@@ -2594,6 +2604,10 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
 
     // For builtin channels, when first enabling we apply the default
     // config skeleton so the user doesn't have to know the field names.
+    // Prefer the hardcoded gateway table (telegram/discord/slack) for
+    // continuity, then fall back to the manifest — covers any channel
+    // plugin (debox, wechat, future externals) that declares its own
+    // `defaultConfig` with `${{SECRET}}` placeholders.
     let effectiveConfig: Record<string, unknown> | undefined = body.config;
     if (
       existing.kind === 'builtin'
@@ -2602,7 +2616,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       && !body.config
     ) {
       const def = BUILTIN_CHANNEL_DEFS[existing.channelType];
-      if (def) effectiveConfig = { ...def.defaultConfig };
+      const manifestDefaults = options.manifestRegistry.get(existing.channelType)?.defaultConfig;
+      const fallback = def?.defaultConfig ?? manifestDefaults;
+      if (fallback) effectiveConfig = { ...fallback };
     }
 
     const updated = await store.update(channelId, {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -253,7 +253,14 @@ export const main = async (): Promise<void> => {
             if (existing) continue;
             const legacy = legacyChannels[key];
             const enabled = !!legacy?.enabled;
-            const cfg = legacy ? { ...legacy } : {};
+            // Seed config from manifest.defaultConfig (carries `${{SECRET}}`
+            // placeholders) so the interpolation step has something to
+            // expand at start time. Legacy values from the pre-DB
+            // `channels` blob, if any, override the defaults.
+            const defaults = manifestRegistry.get(key)?.defaultConfig ?? {};
+            const cfg: Record<string, unknown> = legacy
+              ? { ...defaults, ...legacy }
+              : { ...defaults };
             delete (cfg as { enabled?: unknown }).enabled;
             await agentChannelStore.createBuiltin({
               agentId: agent.agentId,


### PR DESCRIPTION
## Summary

- New `agent_channels` rows were being created with `config: {}` even when the manifest declared a `defaultConfig` carrying `${{SECRET}}` placeholders. At start time, interpolation had nothing to expand, so any channel whose manifest relies on placeholder-based secret linking (debox, wechat, future externals) would fail to boot.
- Fixes three creation paths plus the late-binding PATCH fallback so all builtin-row inserts (agent-creation seed, boot-time backfill, explicit `POST /channels`) and the first-enable heuristic consult `manifestRegistry.get(key).defaultConfig`.
- The hardcoded `BUILTIN_CHANNEL_DEFS` table (telegram/discord/slack only) is kept as the preferred source for those three for continuity, with `manifest.defaultConfig` as a fallback for anything else.

## Why this matters

Symptom in the wild: agent `cmoxp4ssm0001quryavfg11yw` on `hermit.heyamiko.com` had debox enabled in the UI but reported `Failed to start`. The row was inserted by the boot-time backfill (which only fires for newly-registered manifests like `@openhermit/channel-debox`), and that path used `{}` for config — so the manifest's `api_key: '${{DEBOX_API_KEY}}'` placeholder never made it into the row, leaving nothing for the secret-interpolation step to bind to.

## Healing existing data

This PR is creation-side only — it doesn't migrate pre-existing empty-config rows. Once merged + deployed, broken rows can be healed operationally by deleting them; the boot-time backfill (now fixed) re-inserts them with the correct defaults.

## Test plan

- [x] Type-check passes (`npx tsc --noEmit` in `apps/gateway`)
- [ ] On test deploy: delete a stuck debox `agent_channels` row, restart gateway, confirm the row is re-seeded with `{api_key: '${{DEBOX_API_KEY}}', api_secret: '${{DEBOX_API_SECRET}}', mode: 'polling'}` and the channel boots once the operator sets the secrets.
- [ ] Sanity-check that creating a new agent pre-seeds telegram/discord/slack rows with the same placeholders they had before (the hardcoded `BUILTIN_CHANNEL_DEFS` path is preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Builtin channels now correctly initialize with default configurations from their manifests, ensuring channels have appropriate settings instead of starting empty
* When creating new channels or enabling existing channels, the system properly applies manifest-defined defaults as fallbacks
* Agent channel backfill now seeds channels with manifest defaults before applying any legacy settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->