### PR TITLE
fix(agent): wait for LLM completion before deactivating ephemeral/once schedule sessions

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -217,6 +217,14 @@ export class AgentRunner implements SessionRuntime {
     if (shouldTearDown) {
       const session = this.sessions.get(sessionId);
       if (session) {
+        // postMessage returns as soon as the turn is queued; wait for the
+        // LLM call and any side effects to actually finish before tearing
+        // the session down. Without this the central scheduler treats a
+        // firing as "done" the moment it's queued, so a burst of missed
+        // cron slots all run in parallel.
+        await session.queue;
+        await session.sideEffects;
+        await session.backgroundTasks;
         session.status = 'inactive';
         this.clearIdleSummaryTimer(session);
         this.persistSessionIndex(session);


### PR DESCRIPTION
## Summary

- For `once` schedules and `ephemeral`-mode cron schedules, the session is now marked inactive **after** the LLM turn (and its side effects) actually completes, not the moment the turn is queued.
- Fixes a catch-up storm: when the gateway came back from downtime with several missed cron slots, every backed-up firing opened a session and dispatched its LLM call in parallel, because the scheduler treated each firing as "done" as soon as `postMessage` returned.

## What was happening

`AgentRunner.runScheduledJob` did:

```ts
await this.postMessage(sessionId, { text: ..., metadata });  // queues onto session.queue, returns immediately

if (shouldTearDown) {
  session.status = 'inactive';
  this.sessions.delete(sessionId);
  await this.bus.emit('session.closed@v1', ...);
}
```

`postMessage` returns as soon as the turn is queued. The central scheduler then called `finishRun` and set `next_run_at`, so consecutive firings (e.g. 4 missed cron slots) could all run in parallel — all of them sitting on the upstream LLM at the same time, with the agent's user messages queued behind them.

## Fix

Before tearing down, await the session's outstanding work:

```ts
await session.queue;
await session.sideEffects;
await session.backgroundTasks;
```

This means:
1. `ephemeral` / `once` sessions are only marked inactive after the work has truly finished.
2. The central scheduler's `withBusy` wrapper holds the busy counter for the full duration, so consecutive cron firings now serialize naturally.

## Test plan

- [ ] Trigger a `once`-type schedule and confirm the session moves to `inactive` only after the response is persisted (not the moment it's queued).
- [ ] Trigger an `ephemeral`-mode cron schedule and confirm the same.
- [ ] Trigger a `dedicated`-mode cron schedule and confirm the session is NOT torn down (existing behavior).
- [ ] Simulate a catch-up scenario: take the gateway down through several cron slots, restart, and verify the missed firings run sequentially rather than in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled job execution reliability by ensuring jobs complete their full processing lifecycle before cleanup, preventing simultaneous execution of missed job slots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->