### PR TITLE
fix(skills): scope user-skill ids per-owner

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1979,7 +1979,9 @@ export class AgentRunner implements SessionRuntime {
         const resyncSkills = async (): Promise<void> => {
           const enabled = await skillStore.listEnabled(agentId);
           await this.syncSkills(
-            enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+            // SyncSkillEntry.id is the folder basename — must be the slug,
+            // not the (possibly encoded) storage id.
+            enabled.map((s) => ({ id: s.slug, sourcePath: s.path, source: s.source })),
           );
         };
         toolsets.push(wrapToolset(createSkillManagementToolset(skillStore, agentId, resyncSkills)));

--- a/apps/agent/src/skills.ts
+++ b/apps/agent/src/skills.ts
@@ -148,11 +148,14 @@ export const loadSkillIndex = async (
     const dbSkills = await skillStore.listEnabled(agentId);
     for (const skill of dbSkills) {
       const sub = skill.source === 'user' ? 'user' : 'system';
-      entries.set(skill.id, {
-        id: skill.id,
+      // skill.slug is the user-visible identifier (folder name and prompt
+      // index id). For user skills skill.id is the encoded storage key —
+      // never use it as a folder name.
+      entries.set(skill.slug, {
+        id: skill.slug,
         name: skill.name,
         description: skill.description,
-        path: `${home}/.openhermit/skills/${sub}/${skill.id}`,
+        path: `${home}/.openhermit/skills/${sub}/${skill.slug}`,
         source: 'system',
       });
     }

--- a/apps/agent/src/tools/skills.ts
+++ b/apps/agent/src/tools/skills.ts
@@ -19,7 +19,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 
 import { Type, type Static } from '@mariozechner/pi-ai';
 import { resolveAgentDataDir, ValidationError } from '@openhermit/shared';
-import type { SkillStore } from '@openhermit/store';
+import { skillStorageId, type SkillStore } from '@openhermit/store';
 
 import { asTextContent, formatJson, type PolicyAwareTool, type Toolset } from './shared.js';
 
@@ -117,13 +117,16 @@ export const createSkillInstallTool = (
       );
     }
 
-    // Refuse to overwrite a system skill (or any skill not owned by this agent)
-    // by re-using its id. The DB constraint isn't enough — the upsert would
-    // happily flip source out from under it.
-    const existing = await skillStore.get(args.id);
-    if (existing && (existing.source !== 'user' || existing.ownerAgentId !== agentId)) {
+    // Refuse to shadow a system skill with the same slug. User skills are
+    // already scoped per-owner by the storage id, so two agents can install
+    // a user skill named "foo" without colliding — but a user-skill "foo"
+    // alongside a system-skill "foo" would confuse the prompt index.
+    const storageId = skillStorageId('user', args.id, agentId);
+    const existing = await skillStore.get(storageId);
+    const systemConflict = await skillStore.get(args.id);
+    if (systemConflict && systemConflict.source === 'system') {
       throw new ValidationError(
-        `Skill "${args.id}" already exists and is not owned by this agent. Choose a different id.`,
+        `Skill "${args.id}" is already in use by a system skill. Choose a different id.`,
       );
     }
 
@@ -139,7 +142,8 @@ export const createSkillInstallTool = (
 
     const now = new Date().toISOString();
     await skillStore.upsert({
-      id: args.id,
+      id: storageId,
+      slug: args.id,
       name: args.name,
       description: args.description,
       path: sourceDir,
@@ -148,7 +152,7 @@ export const createSkillInstallTool = (
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     });
-    await skillStore.enable(agentId, args.id);
+    await skillStore.enable(agentId, storageId);
 
     await resyncSkills();
 
@@ -181,18 +185,16 @@ export const createSkillUninstallTool = (
   parameters: SkillUninstallParams,
   execute: async (_toolCallId, args: Static<typeof SkillUninstallParams>) => {
     validateSkillId(args.id);
-    const existing = await skillStore.get(args.id);
-    if (!existing) {
-      throw new ValidationError(`Skill "${args.id}" not found.`);
-    }
-    if (existing.source !== 'user' || existing.ownerAgentId !== agentId) {
+    const storageId = skillStorageId('user', args.id, agentId);
+    const existing = await skillStore.get(storageId);
+    if (!existing || existing.source !== 'user' || existing.ownerAgentId !== agentId) {
       throw new ValidationError(
         `Skill "${args.id}" is not a user skill installed by this agent and cannot be removed via skill_uninstall.`,
       );
     }
 
-    await skillStore.disable(agentId, args.id);
-    await skillStore.delete(args.id);
+    await skillStore.disable(agentId, storageId);
+    await skillStore.delete(storageId);
     await rm(userSkillSourceDir(agentId, args.id), { recursive: true, force: true });
 
     await resyncSkills();

--- a/apps/agent/test/skills.test.ts
+++ b/apps/agent/test/skills.test.ts
@@ -100,7 +100,7 @@ test('loadSkillIndex merges DB and workspace skills', async (t) => {
 
   const fakeStore = {
     listEnabled: async () => [
-      { id: 'db-skill', name: 'DB Skill', description: 'From DB', path: '/some/path' },
+      { id: 'db-skill', slug: 'db-skill', name: 'DB Skill', description: 'From DB', path: '/some/path' },
     ],
   };
 
@@ -122,7 +122,7 @@ test('loadSkillIndex workspace skills take priority over DB skills with same id'
 
   const fakeStore = {
     listEnabled: async () => [
-      { id: 'shared', name: 'DB Version', description: 'From DB', path: '/db/path' },
+      { id: 'shared', slug: 'shared', name: 'DB Version', description: 'From DB', path: '/db/path' },
     ],
   };
 
@@ -159,7 +159,8 @@ test('loadSkillIndex emits user-source DB skills under the user/ subdir', async 
   const fakeStore = {
     listEnabled: async () => [
       {
-        id: 'mine',
+        id: 'user:agent-1:mine',
+        slug: 'mine',
         name: 'Mine',
         description: 'Owner-installed',
         path: '/db/path',

--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -233,7 +233,9 @@ export class AgentInstanceManager {
       try {
         const enabled = await this.skillStore.listEnabled(agentId);
         await runner.syncSkills(
-          enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+          // SyncSkillEntry.id is the folder basename — use slug, not the
+          // encoded storage id.
+          enabled.map((s) => ({ id: s.slug, sourcePath: s.path, source: s.source })),
         );
       } catch (err) {
         log(`[${agentId}] skill sync failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2058,6 +2058,8 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const now = new Date().toISOString();
     await store.upsert({
       id: body.id,
+      // System skills: slug equals id (storage id == user-visible id).
+      slug: body.id,
       name: body.name,
       description: body.description,
       path: body.path,
@@ -2134,8 +2136,8 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     // No workspace info available — return DB-enabled skills only.
     const dbSkills = await store.listEnabled(agentId);
     return c.json(dbSkills.map((s) => ({
-      id: s.id, name: s.name, description: s.description,
-      path: `/skills/${s.id}`, source: 'system' as const,
+      id: s.slug, name: s.name, description: s.description,
+      path: `/skills/${s.slug}`, source: 'system' as const,
     })));
   });
 

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -403,6 +403,7 @@ export const main = async (): Promise<void> => {
       const now = new Date().toISOString();
       await skillStore.upsert({
         id: skill.id,
+        slug: skill.id,
         name: skill.name,
         description: skill.description,
         path: skill.path,

--- a/apps/gateway/src/skill-mounts.ts
+++ b/apps/gateway/src/skill-mounts.ts
@@ -15,6 +15,8 @@ export const syncSkillMounts = async (
 ): Promise<void> => {
   const enabled = await skillStore.listEnabled(agentId);
   await runner.syncSkills(
-    enabled.map((s) => ({ id: s.id, sourcePath: s.path, source: s.source })),
+    // SyncSkillEntry.id is the folder basename — use slug (not the encoded
+    // storage id) so user-skill folders are named like the user-visible id.
+    enabled.map((s) => ({ id: s.slug, sourcePath: s.path, source: s.source })),
   );
 };

--- a/packages/store/drizzle/0030_skill_slug.sql
+++ b/packages/store/drizzle/0030_skill_slug.sql
@@ -1,0 +1,42 @@
+-- Allow user skills with the same slug to coexist across different owners.
+-- Two agents owned by different users should each be able to install a user
+-- skill named e.g. "weread-helper" without colliding on the global `id` PK.
+--
+-- New layout:
+--   * `slug` (new column) is the user-visible identifier — the folder name
+--     synced into <agentHome>/.openhermit/skills/{system,user}/<slug>/ and
+--     the id the LLM sees in the prompt index.
+--   * `id` remains the storage PK, but for user skills it is now encoded as
+--     `user:<owner_agent_id>:<slug>` so the same slug can appear under
+--     different owners.
+--   * Partial unique indexes preserve the invariant that slugs are unique
+--     within each scope: globally for system skills, per-owner for user
+--     skills.
+
+ALTER TABLE "skills" ADD COLUMN "slug" text;
+
+UPDATE "skills" SET "slug" = "id";
+
+ALTER TABLE "skills" ALTER COLUMN "slug" SET NOT NULL;
+
+-- Re-key user skills first in agent_skills, then in skills itself. Order
+-- matters: the join needs the old slug to still be present on skills.id.
+-- Catch every assignment regardless of whose agent_id is on the row, since
+-- admin endpoints can cross-enable a user skill onto another agent.
+UPDATE "agent_skills" AS a
+SET "skill_id" = 'user:' || s."owner_agent_id" || ':' || s."id"
+FROM "skills" AS s
+WHERE s."source" = 'user'
+  AND s."id" = a."skill_id";
+
+UPDATE "skills"
+SET "id" = 'user:' || "owner_agent_id" || ':' || "slug"
+WHERE "source" = 'user';
+
+CREATE UNIQUE INDEX "skills_system_slug_unique"
+  ON "skills" ("slug")
+  WHERE "source" = 'system';
+
+CREATE UNIQUE INDEX "skills_user_owner_slug_unique"
+  ON "skills" ("owner_agent_id", "slug")
+  WHERE "source" = 'user';

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1779700000000,
       "tag": "0029_skill_source",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1779800000000,
+      "tag": "0030_skill_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/skill-store.ts
+++ b/packages/store/src/impl/skill-store.ts
@@ -30,6 +30,7 @@ export class DbSkillStore implements SkillStore {
 
   async upsert(skill: SkillRecord): Promise<void> {
     const data = {
+      slug: skill.slug,
       name: skill.name,
       description: skill.description,
       path: skill.path,
@@ -87,6 +88,7 @@ export class DbSkillStore implements SkillStore {
       assignmentAgentId: agentSkills.agentId,
       enabled: agentSkills.enabled,
       id: skills.id,
+      slug: skills.slug,
       name: skills.name,
       description: skills.description,
       path: skills.path,
@@ -129,6 +131,7 @@ export class DbSkillStore implements SkillStore {
 
   private rowToRecord(row: {
     id: string;
+    slug: string;
     name: string;
     description: string;
     path: string;
@@ -142,6 +145,7 @@ export class DbSkillStore implements SkillStore {
     const source = row.source === 'user' ? 'user' : 'system';
     return {
       id: row.id,
+      slug: row.slug,
       name: row.name,
       description: row.description,
       path: row.path,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -65,7 +65,7 @@ export type {
   AttachmentStorageProvider,
 } from './types.js';
 
-export { STANDALONE_AGENT_ID, standaloneScope } from './types.js';
+export { STANDALONE_AGENT_ID, standaloneScope, skillStorageId } from './types.js';
 
 /**
  * Reserved session id for the per-agent owner inbox feed (read-only).

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -268,7 +268,16 @@ export const userIdentities = pgTable('user_identities', {
 ]);
 
 export const skills = pgTable('skills', {
+  // Storage PK. For source='system' this equals `slug`. For source='user' it
+  // is encoded as `user:<owner_agent_id>:<slug>` so the same slug can coexist
+  // across owners. Consumers should treat this as opaque and use `slug` for
+  // the user-visible identifier (folder name, prompt index).
   id: text('id').primaryKey(),
+  // User-visible identifier — becomes the basename of the synced skill
+  // directory and the id the LLM sees. Unique among system skills; unique
+  // per (owner_agent_id) among user skills (enforced via partial unique
+  // indexes added in migration 0030).
+  slug: text('slug').notNull(),
   name: text('name').notNull(),
   description: text('description').notNull(),
   path: text('path').notNull(),

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   pgTable,
   text,
@@ -292,6 +293,15 @@ export const skills = pgTable('skills', {
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
   index('idx_skills_owner_agent').on(table.ownerAgentId),
+  // Mirrors the partial unique indexes created in migration 0030. Source of
+  // truth lives here so drizzle-kit generate stays consistent with the
+  // applied schema.
+  uniqueIndex('skills_system_slug_unique')
+    .on(table.slug)
+    .where(sql`source = 'system'`),
+  uniqueIndex('skills_user_owner_slug_unique')
+    .on(table.ownerAgentId, table.slug)
+    .where(sql`source = 'user'`),
 ]);
 
 export const agentSkills = pgTable('agent_skills', {

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -273,7 +273,15 @@ export interface UserIdentity {
 export type SkillSource = 'system' | 'user';
 
 export interface SkillRecord {
+  /**
+   * Opaque storage id. For system skills this equals `slug`. For user skills
+   * it is encoded as `user:<ownerAgentId>:<slug>` so the same slug can
+   * coexist across owners. Consumers should not parse this; use `slug` for
+   * the user-visible identifier (folder name, prompt index).
+   */
   id: string;
+  /** User-visible identifier — folder name and prompt-index id. */
+  slug: string;
   name: string;
   description: string;
   path: string;
@@ -284,6 +292,25 @@ export interface SkillRecord {
   createdAt: string;
   updatedAt: string;
 }
+
+/**
+ * Compute the storage id for a skill. System skills use the slug as-is so
+ * existing rows and the operator-facing CLI continue to work. User skills
+ * embed the owner so multiple agents can install a skill with the same slug.
+ */
+export const skillStorageId = (
+  source: SkillSource,
+  slug: string,
+  ownerAgentId: string | undefined,
+): string => {
+  if (source === 'user') {
+    if (!ownerAgentId) {
+      throw new Error('User skills require ownerAgentId to derive a storage id.');
+    }
+    return `user:${ownerAgentId}:${slug}`;
+  }
+  return slug;
+};
 
 export interface AgentSkillRecord {
   agentId: string;


### PR DESCRIPTION
## Summary

Different agents (typically under different users) couldn't both install a user skill with the same id. The DB primary key on \`skills.id\` was global, so once any agent owned skill \`foo\`, every other \`skill_install foo\` call hit:

> Skill \"foo\" already exists and is not owned by this agent. Choose a different id.

User skills are already isolated per-owner everywhere else (filesystem path, runtime visibility, ownership gating). The only place the conflict lived was the DB PK.

## Fix

Introduce a separation between **storage id** (DB PK) and **slug** (user-visible id):

| | storage \`id\` | \`slug\` |
|---|---|---|
| system skill | same as slug (back-compat) | the user-visible name |
| user skill | \`user:<ownerAgentId>:<slug>\` | the user-visible name |

- \`slug\` is the folder basename under \`<agentHome>/.openhermit/skills/{system,user}/<slug>/\` and the id the LLM sees in the prompt index.
- \`id\` stays an opaque DB key. Consumers must not parse it.
- Partial unique indexes preserve uniqueness within each scope:
  - system: \`slug\` is globally unique
  - user:   \`(owner_agent_id, slug)\` is unique

Two agents under different users can now both install \`weread-helper\` (or any other slug) without colliding.

## Changes

- \`packages/store/drizzle/0030_skill_slug.sql\` — add \`slug\` column, migrate \`skills.id\` and \`agent_skills.skill_id\` to the encoded form for user skills, add the partial unique indexes.
- \`packages/store/src/schema.ts\` / \`types.ts\` — add \`slug\` to \`skills\` and to \`SkillRecord\`; export a \`skillStorageId()\` helper.
- \`apps/agent/src/tools/skills.ts\` — \`skill_install\` / \`skill_uninstall\` now compute the storage id via \`skillStorageId('user', slug, agentId)\` and pass both \`id\` and \`slug\` on upsert. The system-skill conflict check is preserved (you still can't shadow a system skill).
- \`apps/agent/src/skills.ts\`, \`apps/gateway/src/skill-mounts.ts\`, \`apps/gateway/src/agent-instance.ts\`, \`apps/agent/src/agent-runner.ts\` — all callers that previously passed \`skill.id\` as a folder basename now pass \`skill.slug\`.
- \`apps/gateway/src/app.ts\` — admin \`POST /api/admin/skills\` (system-skill create) and the fallback shape in \`GET /api/agents/:id/skills\` updated to set/return \`slug\`.
- \`apps/agent/test/skills.test.ts\` — fakes updated to include \`slug\`.

## Test plan

- [ ] After deploying & migrating, agent A installs user skill \`foo\` and agent B (different owner) installs user skill \`foo\` — both succeed; each agent sees its own \`foo\` SKILL.md.
- [ ] Each agent's \`skill_uninstall foo\` removes only its own row; the other agent's \`foo\` remains.
- [ ] Existing \`weread-helper\` and \`weread-skills\` rows continue to function for their owners.
- [ ] An agent attempting to install a user skill with a slug that already exists as a system skill is still rejected.
- [ ] Folder layout inside the sandbox: \`<agentHome>/.openhermit/skills/user/<slug>/SKILL.md\` (no encoded storage id leaking into the path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database Updates**
  * Added a new skill "slug" column so user-visible skill names are distinct from internal storage keys; uniqueness enforced per scope.

* **Bug Fixes & Improvements**
  * Skill sync, listing, and install/uninstall now use user-visible identifiers for folder paths and API responses, reducing conflicts and improving consistency.

* **Chores**
  * Aligned storage and gateway flows to persist and return the new slug consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->