### PR TITLE
fix(store): 0030_skill_slug FK ordering

### DIFF
--- a/packages/store/drizzle/0030_skill_slug.sql
+++ b/packages/store/drizzle/0030_skill_slug.sql
@@ -19,16 +19,11 @@ UPDATE "skills" SET "slug" = "id";
 
 ALTER TABLE "skills" ALTER COLUMN "slug" SET NOT NULL;
 
--- Re-key user skills first in agent_skills, then in skills itself. Order
--- matters: the join needs the old slug to still be present on skills.id.
--- Catch every assignment regardless of whose agent_id is on the row, since
--- admin endpoints can cross-enable a user skill onto another agent.
-UPDATE "agent_skills" AS a
-SET "skill_id" = 'user:' || s."owner_agent_id" || ':' || s."id"
-FROM "skills" AS s
-WHERE s."source" = 'user'
-  AND s."id" = a."skill_id";
-
+-- Re-key user skills. The FK agent_skills.skill_id -> skills.id is declared
+-- ON UPDATE CASCADE, so updating skills.id propagates to every referencing
+-- agent_skills row in the same statement. An earlier draft of this file
+-- also issued an explicit UPDATE on agent_skills first, which violated the
+-- FK because the new id did not yet exist in skills at that point.
 UPDATE "skills"
 SET "id" = 'user:' || "owner_agent_id" || ':' || "slug"
 WHERE "source" = 'user';


### PR DESCRIPTION
## Summary
- Drop the explicit `UPDATE "agent_skills"` step in migration `0030_skill_slug.sql`; the FK is `ON UPDATE CASCADE`, so updating `skills.id` propagates to every referencing row in the same statement.

## Problem
`test.openhermit.ai` could not boot after pulling main:

```
agent store unavailable: Failed query: -- Allow user skills with the same slug to coexist across different owners.
...
insert or update on table "agent_skills" violates foreign key constraint "agent_skills_skill_id_fkey"
Key (skill_id)=(user:one:liteparse) is not present in table "skills".
```

The migration set `agent_skills.skill_id = 'user:<owner>:<slug>'` BEFORE updating `skills.id`. The FK fired against a value that did not yet exist on the parent table.

Other deploys did not exercise the failing path because they had no user-skill rows referenced from `agent_skills` — the bad UPDATE became a silent zero-row no-op.

## Test plan
- [x] Dry-run the corrected SQL against the affected test DB inside a transaction; `skills.id` updates and `agent_skills.skill_id` cascades correctly. Rolled back.
- [ ] Pull this branch on `test.openhermit.ai`, restart gateway, confirm boot reaches `agent store connected` and all channels register.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database migration for skills handling to improve data integrity and consistency.
  * Added slug-based identification for skills to enable cleaner referencing and organization.
  * Enhanced uniqueness constraints for system and user-owned skills to prevent conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->