### PR TITLE
fix(telegram): tell agents their input was voice

### DIFF
--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -247,8 +247,16 @@ export class TelegramBridge implements ChannelOutbound {
       return;
     }
 
+    // Tell the agent that this turn was spoken, not typed. Without this
+    // marker the LLM has no way to know the text came from STT and the
+    // reply will be spoken — it may answer with code blocks, long lists,
+    // or even try to call a TTS tool itself.
+    const agentText = inboundWasVoice
+      ? `[Voice message, transcribed. Your reply will be converted to speech, so respond in plain prose without code blocks, markdown formatting, or long lists.]\n\n${text}`
+      : text;
+
     const sessionId = await this.getSessionId(chatId);
-    await this.sendToAgent(chatId, sessionId, text, message, isGroup, inboundWasVoice);
+    await this.sendToAgent(chatId, sessionId, agentText, message, isGroup, inboundWasVoice);
   }
 
   private async transcribeAttachment(message: TelegramMessage): Promise<string> {


### PR DESCRIPTION
## Summary
- When a Telegram voice message is transcribed, prepend a marker to the text sent to the agent so the LLM knows the turn was spoken
- Marker also reminds the agent that its reply will be converted to speech, so it should respond in plain prose (no markdown, no code blocks, no long lists)

## Why
Session \`telegram:2026-05-17-63b6ff66\` on hermit.heyamiko.com: user sent a voice message, the bridge transcribed it via STT and forwarded the bare text. The agent had no signal that the input was voice and tried to invoke a TTS-style tool to "generate audio" itself, even though \`trySendVoiceReply\` in the bridge was already going to speak its reply.

The outbound voice path (\`trySendVoiceReply\` + \`shouldSpeak\` gate) is unchanged — the bridge still handles TTS automatically when \`inboundWasVoice\` is true.

## Test plan
- [ ] Send a voice message to a Telegram agent on the test deploy
- [ ] Confirm the agent reply is plain prose (no markdown / code) and delivered as a voice message
- [ ] Send a regular text message — confirm no marker is added and behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced voice message handling - agents now respond to voice-transcribed messages with plain prose formatting, avoiding code blocks, markdown, and lengthy lists for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->