### PR TITLE
chore(sdk): bump to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11278,7 +11278,7 @@
     },
     "packages/sdk": {
       "name": "@openhermit/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for the OpenHermit gateway and agent APIs.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Bumps `@openhermit/sdk` from 0.6.0 → 0.6.1 to release the attachment-bytes helpers added in #151 (`buildAttachmentBytesUrl`, `downloadAttachmentBytes`). Telegram outbound-attachment delivery depends on `downloadAttachmentBytes`; consumers pinning the published npm version (amiko-openhermit main) need this.

## Test plan
- [ ] CI green
- [ ] After merge, `npm publish` from `packages/sdk`
- [ ] amiko-openhermit main can `npm i @openhermit/sdk@0.6.1` and Telegram attachments work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released SDK patch version update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->