### PR TITLE
fix(agent): ephemeral schedule sessions stuck at 'idle' instead of 'inactive'

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -232,7 +232,10 @@ export class AgentRunner implements SessionRuntime {
         await session.backgroundTasks;
         session.status = 'inactive';
         this.clearIdleSummaryTimer(session);
-        this.persistSessionIndex(session);
+        // Await so the inactive row is committed before we drop the
+        // in-memory session. Otherwise a later-resolving 'idle' persist
+        // from the same turn can overwrite us in the DB.
+        await this.persistSessionIndex(session);
         this.sessions.delete(sessionId);
       } else {
         await this.store.sessions.updateStatus(this.scope, sessionId, 'inactive');
@@ -914,7 +917,7 @@ export class AgentRunner implements SessionRuntime {
     // so it no longer shows up in default session listings.
     if (reason === 'new_session') {
       session.status = 'inactive';
-      this.persistSessionIndex(session);
+      await this.persistSessionIndex(session);
     }
 
     return result;
@@ -2910,7 +2913,7 @@ export class AgentRunner implements SessionRuntime {
           const errorMsg = assistantMessage.errorMessage ?? 'Model returned an error.';
           const ts = new Date().toISOString();
           session.updatedAt = ts;
-          void this.persistSessionIndex(session);
+          void this.queueSideEffect(session, () => this.persistSessionIndex(session));
 
           agentErrorsTotal.inc({ agent_id: this.scope.agentId, source: 'model' });
 
@@ -2975,7 +2978,7 @@ export class AgentRunner implements SessionRuntime {
         session.lastMessagePreview = effectiveText;
         const ts = new Date().toISOString();
         session.updatedAt = ts;
-        void this.persistSessionIndex(session);
+        void this.queueSideEffect(session, () => this.persistSessionIndex(session));
 
         if (assistantMessage.usage) {
           const u = assistantMessage.usage;
@@ -3073,7 +3076,10 @@ export class AgentRunner implements SessionRuntime {
           );
           delete session.turnStartMs;
         }
-        void this.persistSessionIndex(session);
+        // Queue rather than fire-and-forget so teardown's
+        // `await session.sideEffects` waits for this row to be written
+        // before flipping status to 'inactive'.
+        void this.queueSideEffect(session, () => this.persistSessionIndex(session));
         this.scheduleIdleSummary(session);
         void this.queueBackgroundTask(session, async () => {
           const config = await this.options.security.readConfig();


### PR DESCRIPTION
## Summary

- Fix a race where ephemeral / one-off schedule firings left the session row in DB as `idle` instead of `inactive`, so the session kept showing up in listings even after teardown dropped it from memory.
- Route `agent_end` (and the two in-turn `message_end` persists) through `queueSideEffect`, and `await` the final persist in teardown / `checkpointSession(new_session)`.

## Why

`runScheduledJob`'s teardown for `type === 'once'` or `sessionMode.kind === 'ephemeral'` does:

```ts
await session.queue;
await session.sideEffects;
await session.backgroundTasks;
session.status = 'inactive';
this.persistSessionIndex(session);   // <-- fire-and-forget
this.sessions.delete(sessionId);
```

But `agent_end`, fired earlier in the same turn, did `session.status = 'idle'` followed by `void this.persistSessionIndex(session)` — also fire-and-forget, and **not** queued through `session.sideEffects`. So `await session.sideEffects` in teardown didn't actually wait for it.

Two upserts then raced. If the `idle` write resolved after the `inactive` write (perfectly plausible under DB latency), the row was left `idle`, even though the in-memory session was already gone.

## Fix

- `agent_end` persist → `queueSideEffect(session, () => persistSessionIndex(session))`. Now it's part of the chain teardown awaits.
- Same treatment for the two `message_end` persists (model-error path and normal assistant message) — consistent and avoids the same class of bug if anything else races them in the future.
- Teardown's final `persistSessionIndex` is now `await`ed.
- `checkpointSession(new_session)` similarly switched to `await` (same shape: status flips to `inactive`, then we drop the session — we want the row committed first).

## Test plan

- [ ] Trigger an ephemeral cron firing on the test deploy; confirm the resulting session row ends as `status = 'inactive'`, not `idle`.
- [ ] Confirm regular (non-scheduled) turns still leave sessions in `idle` and update the row promptly.
- [ ] Confirm `/new` (new_session checkpoint) still marks the previous session inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session persistence sequencing to ensure reliable data integrity and prevent potential state inconsistencies during session transitions and cleanup operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->