### PR TITLE
feat(agent): appendMessage bumps messageCount and lastActivityAt

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1320,7 +1320,14 @@ export class AgentRunner implements SessionRuntime {
       return { appended: false, deduped: true };
     }
 
-    session.updatedAt = new Date().toISOString();
+    // Mirror postMessage: count the appended message toward the session's
+    // activity. Use the message's occurredAt (so real-time backfill from
+    // a channel adapter advances `lastActivityAt`) but never regress the
+    // timestamp when older messages are appended out of order.
+    session.messageCount += 1;
+    if (ts > session.updatedAt) {
+      session.updatedAt = ts;
+    }
     await this.persistSessionIndex(session);
 
     if (role === 'user') {

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -1492,3 +1492,87 @@ test('AgentRunner.appendMessage honours occurredAt as the persisted ts', async (
   assert.ok(entry, 'entry persisted');
   assert.equal(entry!.ts, occurredAt, 'persisted ts should match occurredAt');
 });
+
+test('AgentRunner.appendMessage bumps messageCount and lastActivityAt', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([]),
+  });
+
+  const sessionId = 'cli:append-counters';
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+
+  const before = (await runner.listSessions({ includeInactive: true })).find(
+    (s) => s.sessionId === sessionId,
+  );
+  assert.ok(before, 'session should exist');
+  const beforeCount = before!.messageCount;
+  const beforeActivity = before!.lastActivityAt;
+
+  const occurredAt = '2099-01-02T03:04:05.000Z';
+  const first = await runner.appendMessage(sessionId, {
+    messageId: 'msg-counters-1',
+    text: 'real-time backfill',
+    appendAs: 'user',
+    occurredAt,
+  });
+  assert.deepEqual(first, { appended: true });
+
+  const after = (await runner.listSessions({ includeInactive: true })).find(
+    (s) => s.sessionId === sessionId,
+  );
+  assert.ok(after);
+  assert.equal(after!.messageCount, beforeCount + 1, 'messageCount should bump by 1');
+  assert.equal(after!.lastActivityAt, occurredAt, 'lastActivityAt should advance to occurredAt');
+
+  // A dedup hit should NOT double-count.
+  const second = await runner.appendMessage(sessionId, {
+    messageId: 'msg-counters-1',
+    text: 'real-time backfill',
+    appendAs: 'user',
+    occurredAt,
+  });
+  assert.deepEqual(second, { appended: false, deduped: true });
+
+  const afterDedup = (await runner.listSessions({ includeInactive: true })).find(
+    (s) => s.sessionId === sessionId,
+  );
+  assert.equal(
+    afterDedup!.messageCount,
+    beforeCount + 1,
+    'dedup should not bump messageCount',
+  );
+
+  // An older occurredAt should not regress lastActivityAt.
+  await runner.appendMessage(sessionId, {
+    messageId: 'msg-counters-old',
+    text: 'older backfill',
+    appendAs: 'user',
+    occurredAt: '2000-01-01T00:00:00.000Z',
+  });
+  const afterOld = (await runner.listSessions({ includeInactive: true })).find(
+    (s) => s.sessionId === sessionId,
+  );
+  assert.equal(
+    afterOld!.lastActivityAt,
+    occurredAt,
+    'out-of-order older append should not regress lastActivityAt',
+  );
+  assert.equal(
+    afterOld!.messageCount,
+    beforeCount + 2,
+    'older append still counts toward messageCount',
+  );
+
+  // Suppress unused-variable warning.
+  void beforeActivity;
+});


### PR DESCRIPTION
## Summary

- `appendMessage` now bumps `session.messageCount` and advances `session.updatedAt` (= `lastActivityAt`) from the message's `occurredAt`, mirroring what `postMessage` already does.
- Backfill of older messages (out-of-order `occurredAt` < `session.updatedAt`) does not regress `lastActivityAt`.
- Dedup hits do not double-count.

## Why

Previously `appendMessage` only stamped `session.updatedAt = new Date().toISOString()` — `messageCount` was left untouched. Any session whose growth came exclusively via `appendMessage` (channel backfill, future agent `session_append`-style tools, alternate UI flows) showed `messageCount = 0` and stale `lastActivityAt` in listings, even though the log entries were persisted correctly.

Fixing it at the gateway layer in `AgentRunner.appendMessage` fixes every consumer at once:
- agent tools that list sessions (`session_list`, `session_info`)
- the web UI's session list (`messageCount`, "Last activity")
- anything else reading `session_index`

No caller-side changes are needed.

## Implementation

`apps/agent/src/agent-runner.ts` — after the dedup check passes:

```ts
session.messageCount += 1;
if (ts > session.updatedAt) {
  session.updatedAt = ts;
}
```

`ts` is already the existing `message.occurredAt ?? new Date().toISOString()` derived at the top of the function, so it doubles as the activity timestamp. The `>` guard keeps `lastActivityAt` monotonically increasing under out-of-order backfill.

## Test plan

- [x] Added `AgentRunner.appendMessage bumps messageCount and lastActivityAt` covering: first append advances both, a dedup hit on the same `messageId` does not double-count, an older `occurredAt` does not regress `lastActivityAt` but still counts toward `messageCount`.
- [x] Existing `appendMessage` tests (idempotency, `occurredAt` as persisted ts, assistant-role synthetic) still pass.
- [ ] Spot-check on the test deploy: append via channel backfill, confirm session list shows correct count and activity time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session tracking: message counts now increment correctly and last-activity timestamps reflect actual message chronology, preventing regression when out-of-order messages arrive.

* **Tests**
  * Added test coverage for message deduplication and chronological timestamp handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->