### PR TITLE
feat(admin): POST /api/admin/users/:userId/identities to link an identity

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -1751,6 +1751,51 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     return c.json(identities);
   });
 
+  /**
+   * Attach a `(channel, channelUserId)` identity to an existing user.
+   *
+   * Mirrors the implicit linkIdentity that happens during device-key /
+   * admin-issued token exchange, but lets a back-office caller stitch
+   * identities together explicitly — e.g. when the same human has two
+   * channel logins (Telegram + the web SPA) and you want both pointing
+   * at one canonical user.
+   *
+   * Note: if the `(channel, channelUserId)` pair is already linked to a
+   * different user, `linkIdentity` reassigns it (and prunes the now-orphan
+   * source user). That's the desired merge behavior, but it IS destructive
+   * — only call this from a trusted back-office context.
+   */
+  app.post('/api/admin/users/:userId/identities', async (c) => {
+    requireAdmin(c.req.header('authorization'));
+    if (!userStore) {
+      throw new OpenHermitError('User store is not configured.', 'not_configured', 500);
+    }
+    const userId = c.req.param('userId');
+    const body = await c.req.json().catch(() => ({})) as {
+      channel?: unknown;
+      channelUserId?: unknown;
+    };
+    if (typeof body.channel !== 'string' || body.channel.length === 0) {
+      throw new ValidationError('channel is required.');
+    }
+    if (body.channel === 'admin') {
+      throw new ValidationError('channel "admin" is reserved.');
+    }
+    if (typeof body.channelUserId !== 'string' || body.channelUserId.length === 0) {
+      throw new ValidationError('channelUserId is required.');
+    }
+    if (!(await userStore.get(userId))) {
+      throw new NotFoundError(`User ${userId} not found.`);
+    }
+    await userStore.linkIdentity({
+      userId,
+      channel: body.channel,
+      channelUserId: body.channelUserId,
+      createdAt: new Date().toISOString(),
+    });
+    return c.json({ ok: true });
+  });
+
   app.get('/api/admin/users/:userId/agents', async (c) => {
     requireAdmin(c.req.header('authorization'));
     if (!userStore) return c.json([]);

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -42,6 +42,7 @@ expects a user JWT.
   - `purpose: 'session'` (default) returns a normal 24h credential.
   - `purpose: 'exchange'` returns a single-use short-lived token (≤600s, default 120s) intended for the web `/connect#token=…` deep-link flow.
 - `GatewayClient.exchangeConnectToken({ baseUrl, token })` — swap an `exchange` token for a 24h session JWT. The token is the credential (no admin token needed) and is rejected on a second redemption. Backs the `/connect` SSO flow described below.
+- `GatewayClient.linkUserIdentity({ baseUrl, adminToken, userId, channel, channelUserId })` — admin-only: attach a `(channel, channelUserId)` pair to an existing user. Stitches identities together — e.g. when the same human has logged in via two channels and you want both pointing at one canonical user record. If the pair is already linked to a different user, the gateway reassigns it and prunes the orphan source user.
 
 #### SSO deep link: `/connect#token=…`
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -793,6 +793,68 @@ export class GatewayClient {
     };
   }
 
+  /**
+   * Attach a `(channel, channelUserId)` identity to an existing gateway
+   * user. The canonical use is back-office stitching — e.g. when the same
+   * human has logged in via two channels (Telegram + the web SPA) and you
+   * want both rows pointing at one user record.
+   *
+   * Admin-only. If the `(channel, channelUserId)` pair is already linked
+   * to a different user, the gateway reassigns it to `userId` and prunes
+   * the orphan source user. Treat this as a merge operation.
+   */
+  static async linkUserIdentity(input: {
+    baseUrl: string;
+    adminToken: string;
+    userId: string;
+    channel: string;
+    channelUserId: string;
+    fetch?: FetchLike;
+  }): Promise<{ ok: true }> {
+    const fetchImpl = input.fetch ?? fetch;
+    const url = joinUrl(
+      input.baseUrl,
+      `/api/admin/users/${encodeURIComponent(input.userId)}/identities`,
+    );
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${input.adminToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          channel: input.channel,
+          channelUserId: input.channelUserId,
+        }),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new OpenHermitError(
+        `Gateway API is unavailable at ${url}: ${message}`,
+        'gateway_api_error',
+        500,
+      );
+    }
+    if (!response.ok) {
+      const responseText = await response.text();
+      const statusCode: OpenHermitStatusCode =
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 404 ||
+        response.status === 500
+          ? response.status
+          : 500;
+      throw new OpenHermitError(
+        `linkUserIdentity failed (${response.status}): ${responseText || response.statusText}`,
+        'gateway_api_error',
+        statusCode,
+      );
+    }
+    return (await response.json()) as { ok: true };
+  }
+
   async listAgents(): Promise<AgentInfo[]> {
     return this.getJson(gatewayRoutes.agents);
   }

--- a/packages/sdk/test/index.test.ts
+++ b/packages/sdk/test/index.test.ts
@@ -138,6 +138,66 @@ test('GatewayClient.exchangeConnectToken posts the token anonymously and parses 
   assert.equal(result.displayName, 'Ada');
 });
 
+test('GatewayClient.linkUserIdentity posts to the admin route with the correct body', async () => {
+  const calls: Array<{ url: string; body: unknown; headers: Record<string, string> }> = [];
+  const result = await GatewayClient.linkUserIdentity({
+    baseUrl: 'https://gateway.example',
+    adminToken: 'admin-secret',
+    userId: 'usr-abc',
+    channel: 'telegram',
+    channelUserId: '12345',
+    fetch: async (input: any, init: any) => {
+      calls.push({
+        url: String(input),
+        body: JSON.parse(init.body),
+        headers: init.headers,
+      });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.url, 'https://gateway.example/api/admin/users/usr-abc/identities');
+  assert.equal(calls[0]!.headers.authorization, 'Bearer admin-secret');
+  assert.deepEqual(calls[0]!.body, { channel: 'telegram', channelUserId: '12345' });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('GatewayClient.linkUserIdentity URL-encodes the userId path segment', async () => {
+  const calls: Array<{ url: string }> = [];
+  await GatewayClient.linkUserIdentity({
+    baseUrl: 'https://gateway.example',
+    adminToken: 'admin-secret',
+    userId: 'usr/with spaces',
+    channel: 'telegram',
+    channelUserId: '12345',
+    fetch: async (input: any) => {
+      calls.push({ url: String(input) });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    },
+  });
+  assert.equal(
+    calls[0]!.url,
+    'https://gateway.example/api/admin/users/usr%2Fwith%20spaces/identities',
+  );
+});
+
+test('GatewayClient.linkUserIdentity surfaces a 404 from the gateway', async () => {
+  await assert.rejects(
+    () => GatewayClient.linkUserIdentity({
+      baseUrl: 'https://gateway.example',
+      adminToken: 'admin-secret',
+      userId: 'usr-missing',
+      channel: 'telegram',
+      channelUserId: '12345',
+      fetch: async () => new Response('User usr-missing not found.', { status: 404 }),
+    }),
+    /linkUserIdentity failed \(404\): User usr-missing not found\./,
+  );
+});
+
 test('GatewayClient.exchangeConnectToken throws with the gateway error body on 401', async () => {
   await assert.rejects(
     () => GatewayClient.exchangeConnectToken({


### PR DESCRIPTION
## Summary

- Adds admin-only `POST /api/admin/users/:userId/identities` to attach a `(channel, channelUserId)` pair to an existing user, mirroring the implicit `linkIdentity` that happens during token exchange.
- 404 if the user doesn't exist; 400 on missing/invalid body; 401 if not admin.
- If the pair is already linked to a different user, `userStore.linkIdentity` reassigns it and prunes the orphan source user — same as the existing identity-merge behavior. Kept intentionally; the route is admin-only and the merge is the desired back-office workflow (e.g. stitching a Telegram identity onto an SPA-created user).

## Test plan

- [x] `npx tsc -b` clean
- [ ] Manual: hit endpoint with admin token, verify 200 + identity appears in `GET /api/admin/users/:userId/identities`
- [ ] Manual: 404 for non-existent userId
- [ ] Manual: 400 for missing channel/channelUserId, and for `channel: "admin"`
- [ ] Manual: 401 without admin token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only API to link an additional channel identity to an existing user; input is validated and access is restricted to admins.
  * SDK client gained a corresponding admin method to call this operation.

* **Documentation**
  * SDK docs updated with usage details for the new admin client capability.

* **Tests**
  * Unit tests added covering request formation, URL encoding, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->