### PR TITLE
fix(gateway): close consumedJtiStore on shutdown + doc TTL nit

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -574,6 +574,7 @@ export const main = async (): Promise<void> => {
     await mcpServerStore?.close();
     await sessionStore?.close();
     await attachmentStore?.close();
+    await consumedJtiStore?.close();
 
     server.close(() => {
       logStartup('server closed');

--- a/docs/transport-protocol.md
+++ b/docs/transport-protocol.md
@@ -8,7 +8,7 @@ The gateway exposes agent execution under `/api/agents/{agentId}`. All agent rou
 |------|------------------|-----|
 | Admin bearer | `Authorization: Bearer $GATEWAY_ADMIN_TOKEN` | agent lifecycle, admin APIs, full agent route access |
 | User JWT | `POST /api/auth/token` | browser/web user auth (identifies a person, not an agent) |
-| Admin-minted user JWT | `POST /api/admin/auth/issue-token` | admin-only mint of a user JWT for an external identity (`channel`, `channelUserId`). `purpose: 'session'` (default) returns a normal 24h credential; `purpose: 'exchange'` returns a single-use short-lived token (≤600s) for the `/connect` SSO deep link. |
+| Admin-minted user JWT | `POST /api/admin/auth/issue-token` | admin-only mint of a user JWT for an external identity (`channel`, `channelUserId`). `purpose: 'session'` (default) returns a normal 24h credential; `purpose: 'exchange'` returns a single-use short-lived token (≤600s, default 120s) for the `/connect` SSO deep link. |
 | Connect SSO exchange | `POST /api/auth/exchange` | anonymous: swap an `exchange`-purpose JWT for a normal session JWT. Each `jti` is recorded on success so a replay is rejected with 401. Backs the web `/connect#token=…` deep link. |
 | Channel bearer | generated or configured channel token | built-in/external channel adapters scoped to an agent/channel namespace |
 


### PR DESCRIPTION
## Summary

Follow-up to #158 addressing CodeRabbit's post-merge feedback:

- `consumedJtiStore` was opened in `apps/gateway/src/index.ts` but never closed in the SIGINT/SIGTERM shutdown sequence, leaking its PG pool on graceful exit. Added the missing `await consumedJtiStore?.close()` alongside the other store closes.
- `docs/transport-protocol.md` mentioned only the 600s upper bound for exchange tokens; aligned with `docs/sdk.md` by also calling out the 120s default.

## Test plan

- [x] `npx tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Admin-minted JWT token issuance documentation, specifying how the `purpose` parameter controls token behavior: default `'session'` mode returns standard 24-hour credentials, while `'exchange'` mode returns single-use short-lived tokens for SSO integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->