### PR TITLE
Whatsapp channel auth state db

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ hermit config secrets set OPENROUTER_API_KEY sk-... --agent main  # rotate a sec
 - 🚪 **Gateway control plane** — single Hono server. Agents start, attach, detach without orchestration. Admin UI at `/admin/`.
 - 🐘 **Postgres-backed state** — sessions, memories, instructions, skills, MCP, schedules, secrets — durable behind Drizzle.
 - 🐳 **Sandboxed execution** — per-agent sandbox: self-hosted Docker, E2B, or Daytona. Code runs isolated from the gateway, with the same exec interface across backends.
-- 💬 **Channels included** — Telegram, Discord, Slack adapters, plus CLI and Web UI. Enable, disable, reconfigure at runtime.
+- 💬 **Channels included** — Telegram, Discord, Slack adapters, package-installed Signal / WeChat / WhatsApp, plus CLI and Web UI. Enable, disable, reconfigure at runtime.
 - 🛠 **Skills & MCP servers** — install centrally, enable per-agent or fleet-wide, audit from one place.
 - ⏱ **Schedules & automation** — cron and one-shot jobs with timeout, concurrency policy, and error backoff.
 - 👥 **Multi-user with roles** — owner / user / guest. Identity reconciliation across CLI, web, and channels.
@@ -63,7 +63,7 @@ hermit config secrets set OPENROUTER_API_KEY sk-... --agent main  # rotate a sec
 
 - **Admin** — CLI + Web UI for deploying and operating agents.
 - **Client** — Web and CLI for end-users to chat with agents.
-- **Channels** — Telegram, Discord, Slack adapters wired into any agent.
+- **Channels** — Telegram, Discord, Slack, and package-installed adapters such as Signal, WeChat, and WhatsApp wired into any agent.
 - **Gateway** — API, auth, routing, agent lifecycle, schedules.
 - **Agent** — Model loop, tools / skills / MCP, sandboxed workspace (Docker / E2B / Daytona).
 - **Storage** — PostgreSQL for every kind of internal state.

--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ All durable internal state is scoped by `agent_id` where applicable:
 | Skills | Skill library and per-agent/global assignments |
 | MCP servers | External MCP server definitions and assignments |
 | Channels | Built-in and external channel rows with encrypted tokens |
+| Channel credentials | Encrypted channel-owned auth state such as WhatsApp Web / Baileys credentials |
 | Secrets | Per-agent provider/integration secrets, encrypted at rest |
 | Schedules | Cron/once jobs and run history |
 
-Secrets are encrypted with `OPENHERMIT_SECRETS_KEY` (AES-256-GCM); without that key the gateway falls back to per-agent `secrets.json` for local dev. The only per-agent files on disk are the workspace at `~/.openhermit/workspaces/{agentId}/`; enabled skills are synced into each backend's own `<agent_home>/.openhermit/skills/system/` (bind-mounted for docker, uploaded via SDK for e2b/daytona).
+Secrets and channel-owned credentials are encrypted with `OPENHERMIT_SECRETS_KEY` (AES-256-GCM); without that key the gateway falls back to per-agent `secrets.json` for local dev secrets, but DB-backed channel credentials are unavailable. The only per-agent files on disk are the workspace at `~/.openhermit/workspaces/{agentId}/`; enabled skills are synced into each backend's own `<agent_home>/.openhermit/skills/system/` (bind-mounted for docker, uploaded via SDK for e2b/daytona).
 
 ---
 

--- a/apps/agent/test/channel-credential-store.test.ts
+++ b/apps/agent/test/channel-credential-store.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { test } from 'node:test';
+
+import {
+  DbChannelCredentialStore,
+  runMigrations,
+} from '@openhermit/store';
+
+if (!process.env.OPENHERMIT_SECRETS_KEY) {
+  process.env.OPENHERMIT_SECRETS_KEY = randomBytes(32).toString('base64');
+}
+
+async function openStore(t: import('node:test').TestContext) {
+  await runMigrations();
+  const store = await DbChannelCredentialStore.open();
+  t.after(() => store.close());
+  return store;
+}
+
+const uniqueAgent = (): string =>
+  `test-channel-creds-${randomUUID().slice(0, 8)}`;
+
+test('DbChannelCredentialStore: set/get/list/delete round-trips encrypted values', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  await store.set(agentId, 'whatsapp', 'default', 'creds', 'secret-creds');
+  await store.set(agentId, 'whatsapp', 'default', 'key:session:jid', 'secret-session');
+
+  assert.equal(
+    await store.get(agentId, 'whatsapp', 'default', 'creds'),
+    'secret-creds',
+  );
+  assert.deepEqual(await store.list(agentId, 'whatsapp', 'default'), {
+    creds: 'secret-creds',
+    'key:session:jid': 'secret-session',
+  });
+
+  await store.delete(agentId, 'whatsapp', 'default', 'creds');
+  assert.equal(await store.get(agentId, 'whatsapp', 'default', 'creds'), undefined);
+});
+
+test('DbChannelCredentialStore: replace clears stale profile keys', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+
+  await store.set(agentId, 'whatsapp', 'default', 'stale', 'old');
+  await store.replace(agentId, 'whatsapp', 'default', { fresh: 'new' });
+
+  assert.deepEqual(await store.list(agentId, 'whatsapp', 'default'), { fresh: 'new' });
+});
+
+test('DbChannelCredentialStore: scopes by agent, channel type, and profile', async (t) => {
+  const store = await openStore(t);
+  const agentA = uniqueAgent();
+  const agentB = uniqueAgent();
+
+  await store.set(agentA, 'whatsapp', 'default', 'creds', 'a-whatsapp');
+  await store.set(agentA, 'signal', 'default', 'creds', 'a-signal');
+  await store.set(agentA, 'whatsapp', 'setup:1', 'creds', 'a-setup');
+  await store.set(agentB, 'whatsapp', 'default', 'creds', 'b-whatsapp');
+
+  assert.deepEqual(await store.list(agentA, 'whatsapp', 'default'), { creds: 'a-whatsapp' });
+  assert.deepEqual(await store.list(agentA, 'signal', 'default'), { creds: 'a-signal' });
+  assert.deepEqual(await store.list(agentA, 'whatsapp', 'setup:1'), { creds: 'a-setup' });
+  assert.deepEqual(await store.list(agentB, 'whatsapp', 'default'), { creds: 'b-whatsapp' });
+});
+
+test('DbChannelCredentialStore.scoped exposes profile/key-only channel interface', async (t) => {
+  const store = await openStore(t);
+  const agentId = uniqueAgent();
+  const scoped = store.scoped(agentId, 'whatsapp');
+
+  await scoped.set('default', 'creds', 'one');
+  await scoped.replace('setup:1', { creds: 'two' });
+  await scoped.clear('default');
+
+  assert.deepEqual(await scoped.list('default'), {});
+  assert.deepEqual(await scoped.list('setup:1'), { creds: 'two' });
+});

--- a/apps/channels/whatsapp/LICENSE
+++ b/apps/channels/whatsapp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenHermit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/channels/whatsapp/README.md
+++ b/apps/channels/whatsapp/README.md
@@ -1,0 +1,75 @@
+# WhatsApp Channel Adapter
+
+`@openhermit/channel-whatsapp` connects an OpenHermit agent to WhatsApp
+through WhatsApp Web using [Baileys](https://baileys.wiki/). The plugin
+is **not bundled** in the CLI; operators install and load it explicitly.
+
+## v1 scope
+
+- WhatsApp Web / Linked Devices auth through a QR setup wizard.
+- Text inbound and outbound for direct chats and groups.
+- Captions on image / video / document messages are treated as text.
+- Optional allow-lists (`allowed_senders`, `allowed_group_jids`).
+- `/new` starts a fresh OpenHermit session for the current chat.
+- No media delivery, reactions, read receipts, pairing approvals,
+  multi-account routing, or history injection yet.
+
+## Loading the plugin
+
+Add the package name to your gateway config:
+
+```jsonc
+{
+  "channelPackages": ["@openhermit/channel-whatsapp"]
+}
+```
+
+For npm-installed CLI:
+
+```bash
+npm install -g @openhermit/channel-whatsapp
+```
+
+For monorepo development, workspace resolution handles it.
+
+On gateway boot the plugin loader registers the `whatsapp` manifest as
+an external package channel. Owners link it from the Channels panel using
+the generic setup wizard.
+
+## Linking WhatsApp
+
+1. In the admin UI, open **Channels** and choose **WhatsApp**.
+2. Click **Set up**.
+3. Open WhatsApp on your phone, then **Linked devices**.
+4. Scan the QR code shown by OpenHermit.
+5. When linking completes, OpenHermit stores the auth directory in the
+   channel row and enables the channel.
+
+The auth state is stored on the gateway host. Moving the gateway to a
+new machine requires moving the configured `auth_dir` too.
+
+## Stored config
+
+After successful setup, `agent_channels.config` contains:
+
+```jsonc
+{
+  "auth_dir": "~/.openhermit/credentials/whatsapp/main/default",
+  "allowed_senders": ["+15551234567"],          // optional
+  "allowed_group_jids": ["120363000000000@g.us"] // optional; "*" allows all groups
+}
+```
+
+Without `allowed_senders`, direct messages are accepted from anyone.
+Groups are default-deny unless `allowed_group_jids` is set.
+
+## Runtime notes
+
+- Status and broadcast chats are ignored.
+- Own messages from the linked account are ignored to avoid loops.
+- Group messages are recorded only when the group is allowed; they
+  trigger the agent only when the bot is mentioned.
+- Outbound targets accept a raw WhatsApp JID, a `whatsapp:<jid>` value,
+  or an E.164 number such as `+15551234567`.
+- Baileys is not affiliated with WhatsApp. Use a dedicated number when
+  possible and avoid bulk or spam-like behavior.

--- a/apps/channels/whatsapp/README.md
+++ b/apps/channels/whatsapp/README.md
@@ -42,11 +42,13 @@ the generic setup wizard.
 2. Click **Set up**.
 3. Open WhatsApp on your phone, then **Linked devices**.
 4. Scan the QR code shown by OpenHermit.
-5. When linking completes, OpenHermit stores the auth directory in the
-   channel row and enables the channel.
+5. When linking completes, OpenHermit stores `auth_profile` in the
+   channel row and writes the Baileys auth state to encrypted database-backed
+   channel credentials.
 
-The auth state is stored on the gateway host. Moving the gateway to a
-new machine requires moving the configured `auth_dir` too.
+The auth state is internal OpenHermit state. It is stored in PostgreSQL and
+encrypted with `OPENHERMIT_SECRETS_KEY`; moving the gateway no longer requires
+copying a local WhatsApp credential directory.
 
 ## Stored config
 
@@ -54,11 +56,14 @@ After successful setup, `agent_channels.config` contains:
 
 ```jsonc
 {
-  "auth_dir": "~/.openhermit/credentials/whatsapp/main/default",
+  "auth_profile": "default",
   "allowed_senders": ["+15551234567"],          // optional
   "allowed_group_jids": ["120363000000000@g.us"] // optional; "*" allows all groups
 }
 ```
+
+The profile points to encrypted rows in `agent_channel_credentials`; Baileys
+`creds` and signal keys are not stored in `agent_channels.config`.
 
 Without `allowed_senders`, direct messages are accepted from anyone.
 Groups are default-deny unless `allowed_group_jids` is set.
@@ -71,5 +76,8 @@ Groups are default-deny unless `allowed_group_jids` is set.
   trigger the agent only when the bot is mentioned.
 - Outbound targets accept a raw WhatsApp JID, a `whatsapp:<jid>` value,
   or an E.164 number such as `+15551234567`.
+- Legacy `auth_dir` configs are no longer used. If one is found under
+  `~/.openhermit/credentials/whatsapp/`, the adapter best-effort deletes it
+  and requires setup to be run again.
 - Baileys is not affiliated with WhatsApp. Use a dedicated number when
   possible and avoid bulk or spam-like behavior.

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -56,6 +56,6 @@
   "devDependencies": {
     "@openhermit/protocol": "0.2.0",
     "@openhermit/shared": "0.2.0",
-    "tsup": "^8.5.1"
+    "tsup": "8.5.1"
   }
 }

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -49,9 +49,9 @@
     "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "^0.6.0",
-    "baileys": "^6.7.19",
-    "pino": "^9.6.0"
+    "@openhermit/sdk": "0.6.1",
+    "baileys": "7.0.0-rc13",
+    "pino": "10.3.1"
   },
   "devDependencies": {
     "@openhermit/protocol": "0.2.0",

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@openhermit/channel-whatsapp",
+  "version": "0.1.0",
+  "description": "OpenHermit channel plugin for WhatsApp Web via Baileys. Text-only v1.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HCF-STUDIOS/openhermit.git",
+    "directory": "apps/channels/whatsapp"
+  },
+  "homepage": "https://github.com/HCF-STUDIOS/openhermit/tree/main/apps/channels/whatsapp",
+  "bugs": "https://github.com/HCF-STUDIOS/openhermit/issues",
+  "keywords": [
+    "openhermit",
+    "channel",
+    "whatsapp",
+    "baileys",
+    "chatbot"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
+    "test": "node --import tsx --test test/*.test.ts",
+    "prepublishOnly": "npm run build",
+    "prepack": "node scripts/strip-dev-condition.mjs",
+    "postpack": "node scripts/restore-package-json.mjs"
+  },
+  "dependencies": {
+    "@openhermit/sdk": "^0.6.0",
+    "baileys": "^6.7.19",
+    "pino": "^9.6.0"
+  },
+  "devDependencies": {
+    "@openhermit/protocol": "0.2.0",
+    "@openhermit/shared": "0.2.0",
+    "tsup": "^8.5.1"
+  }
+}

--- a/apps/channels/whatsapp/scripts/restore-package-json.mjs
+++ b/apps/channels/whatsapp/scripts/restore-package-json.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// postpack: restore package.json from the backup written by prepack.
+import { existsSync, renameSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+if (existsSync(backupPath)) {
+  renameSync(backupPath, pkgPath);
+  console.log('[channel-whatsapp] restored package.json after publish');
+}

--- a/apps/channels/whatsapp/scripts/strip-dev-condition.mjs
+++ b/apps/channels/whatsapp/scripts/strip-dev-condition.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// prepack: back up package.json and remove the `development` export
+// condition so the published tarball only exposes built artifacts.
+// Restored by scripts/restore-package-json.mjs in postpack.
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+if (!existsSync(backupPath)) {
+  copyFileSync(pkgPath, backupPath);
+}
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const dot = pkg.exports?.['.'];
+if (dot && typeof dot === 'object' && 'development' in dot) {
+  delete dot.development;
+}
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log('[channel-whatsapp] stripped development export condition for publish');

--- a/apps/channels/whatsapp/src/bot.ts
+++ b/apps/channels/whatsapp/src/bot.ts
@@ -109,7 +109,7 @@ export function isBotMentioned(
   if (extractMentionedJids(message).includes(normalizedBot)) return true;
   const phone = jidToPhone(normalizedBot);
   const digits = phone?.slice(1);
-  return Boolean(digits && text.includes(`@${digits}`));
+  return Boolean(digits && new RegExp(`@${digits}\\b`).test(text));
 }
 
 export function toIncomingMessage(

--- a/apps/channels/whatsapp/src/bot.ts
+++ b/apps/channels/whatsapp/src/bot.ts
@@ -1,0 +1,150 @@
+import type { WhatsAppBridge, WhatsAppIncomingMessage } from './bridge.js';
+import { cleanBotCommandText, isBroadcastJid, isGroupJid, jidToPhone, normalizeJid } from './jid.js';
+import type { RawWhatsAppMessage, WhatsAppApi } from './whatsapp-api.js';
+
+export interface WhatsAppBotOptions {
+  whatsapp: WhatsAppApi;
+  bridge: WhatsAppBridge;
+  logger?: (message: string) => void;
+}
+
+export class WhatsAppBot {
+  private readonly log: (message: string) => void;
+
+  constructor(private readonly options: WhatsAppBotOptions) {
+    this.log = options.logger ?? ((msg) => console.log(`[whatsapp-bot] ${msg}`));
+  }
+
+  async start(): Promise<void> {
+    this.options.whatsapp.onMessage((message) => {
+      void this.handleRawMessage(message);
+    });
+    await this.options.whatsapp.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.options.whatsapp.stop();
+  }
+
+  private async handleRawMessage(message: RawWhatsAppMessage): Promise<void> {
+    try {
+      const event = toIncomingMessage(message, this.options.whatsapp.botJid);
+      if (!event) return;
+      await this.options.bridge.handleIncoming(event);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`error handling message: ${msg}`);
+    }
+  }
+}
+
+function unwrapMessageContent(content: any): any {
+  let current = content;
+  for (let i = 0; i < 4; i += 1) {
+    if (!current || typeof current !== 'object') return current;
+    if (current.ephemeralMessage?.message) {
+      current = current.ephemeralMessage.message;
+      continue;
+    }
+    if (current.viewOnceMessage?.message) {
+      current = current.viewOnceMessage.message;
+      continue;
+    }
+    if (current.viewOnceMessageV2?.message) {
+      current = current.viewOnceMessageV2.message;
+      continue;
+    }
+    if (current.documentWithCaptionMessage?.message) {
+      current = current.documentWithCaptionMessage.message;
+      continue;
+    }
+    return current;
+  }
+  return current;
+}
+
+export function extractText(message: RawWhatsAppMessage): string | undefined {
+  const content = unwrapMessageContent(message.message);
+  const candidates = [
+    content?.conversation,
+    content?.extendedTextMessage?.text,
+    content?.imageMessage?.caption,
+    content?.videoMessage?.caption,
+    content?.documentMessage?.caption,
+    content?.buttonsResponseMessage?.selectedDisplayText,
+    content?.listResponseMessage?.title,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+  return undefined;
+}
+
+export function extractMentionedJids(message: RawWhatsAppMessage): string[] {
+  const content = unwrapMessageContent(message.message);
+  const contexts = [
+    content?.extendedTextMessage?.contextInfo,
+    content?.imageMessage?.contextInfo,
+    content?.videoMessage?.contextInfo,
+    content?.documentMessage?.contextInfo,
+  ];
+  const out: string[] = [];
+  for (const ctx of contexts) {
+    const mentions = ctx?.mentionedJid;
+    if (!Array.isArray(mentions)) continue;
+    for (const jid of mentions) {
+      if (typeof jid === 'string' && jid.trim()) out.push(normalizeJid(jid));
+    }
+  }
+  return out;
+}
+
+export function isBotMentioned(
+  message: RawWhatsAppMessage,
+  botJid: string | undefined,
+  text: string,
+): boolean {
+  if (!botJid) return false;
+  const normalizedBot = normalizeJid(botJid);
+  if (extractMentionedJids(message).includes(normalizedBot)) return true;
+  const phone = jidToPhone(normalizedBot);
+  const digits = phone?.slice(1);
+  return Boolean(digits && text.includes(`@${digits}`));
+}
+
+export function toIncomingMessage(
+  message: RawWhatsAppMessage,
+  botJid: string | undefined,
+): WhatsAppIncomingMessage | undefined {
+  if (message.key?.fromMe === true) return undefined;
+
+  const chatJidRaw = message.key?.remoteJid;
+  if (typeof chatJidRaw !== 'string' || !chatJidRaw.trim()) return undefined;
+  if (isBroadcastJid(chatJidRaw)) return undefined;
+
+  const text = extractText(message);
+  if (!text) return undefined;
+
+  const chatJid = normalizeJid(chatJidRaw);
+  const isGroup = isGroupJid(chatJid);
+  const senderJid = normalizeJid(
+    isGroup && typeof message.key?.participant === 'string'
+      ? message.key.participant
+      : chatJid,
+  );
+  const mentioned = isGroup ? isBotMentioned(message, botJid, text) : true;
+
+  return {
+    chatJid,
+    senderJid,
+    ...(jidToPhone(senderJid) ? { senderNumber: jidToPhone(senderJid)! } : {}),
+    ...(typeof message.pushName === 'string' && message.pushName.trim()
+      ? { senderName: message.pushName.trim() }
+      : {}),
+    ...(typeof message.key?.id === 'string' ? { messageId: message.key.id } : {}),
+    text,
+    isGroup,
+    mentioned,
+    commandText: cleanBotCommandText(text, botJid),
+  };
+}

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -1,0 +1,324 @@
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import type {
+  ChannelMessageAction,
+  ChannelOutbound,
+  ChannelOutboundResult,
+} from '@openhermit/protocol';
+
+import { formatAgentResponse } from './formatting.js';
+import {
+  conversationKey,
+  generateSessionId,
+  groupAllowed,
+  isGroupJid,
+  isNewCommand,
+  jidToPhone,
+  normalizeJid,
+  senderAllowed,
+  targetToJid,
+} from './jid.js';
+import type { WhatsAppApi } from './whatsapp-api.js';
+
+const AGENT_RESPONSE_TIMEOUT_MS = 60_000;
+const NO_REPLY_TAG = '<NO_REPLY>';
+
+export interface WhatsAppIncomingMessage {
+  chatJid: string;
+  senderJid: string;
+  senderNumber?: string;
+  senderName?: string;
+  messageId?: string;
+  text: string;
+  isGroup: boolean;
+  mentioned: boolean;
+  commandText?: string;
+}
+
+export interface WhatsAppBridgeOptions {
+  allowedSenders?: string[];
+  allowedGroupJids?: string[];
+}
+
+interface TurnResult {
+  text: string | undefined;
+  error: string | undefined;
+}
+
+export function shouldAcceptMessage(
+  event: WhatsAppIncomingMessage,
+  options: WhatsAppBridgeOptions,
+): boolean {
+  if (event.isGroup) return groupAllowed(event.chatJid, options.allowedGroupJids);
+  return senderAllowed(event.senderJid, options.allowedSenders);
+}
+
+export class WhatsAppBridge implements ChannelOutbound {
+  readonly channel = 'whatsapp';
+
+  private readonly client: AgentLocalClient;
+  private readonly clientToken: string;
+  private readonly log: (message: string) => void;
+  private readonly lastEventIds = new Map<string, number>();
+  private readonly chatSessions = new Map<string, string>();
+  private readonly chatLocks = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly whatsapp: WhatsAppApi,
+    clientOptions: { baseUrl: string; token: string },
+    private readonly options: WhatsAppBridgeOptions = {},
+    logger?: (message: string) => void,
+  ) {
+    this.client = new AgentLocalClient(clientOptions);
+    this.clientToken = clientOptions.token;
+    this.log = logger ?? ((msg) => console.log(`[whatsapp-bridge] ${msg}`));
+  }
+
+  async send(params: {
+    sessionId: string;
+    to: string;
+    text: string;
+    actions?: ChannelMessageAction[];
+  }): Promise<ChannelOutboundResult> {
+    void params.actions;
+    try {
+      const target = targetToJid(params.to);
+      let lastMessageId: string | undefined;
+      for (const chunk of formatAgentResponse(params.text)) {
+        const sent = await this.whatsapp.sendText(target, chunk);
+        if (sent.messageId) lastMessageId = sent.messageId;
+      }
+      const result: ChannelOutboundResult = { success: true };
+      if (lastMessageId) result.messageId = lastMessageId;
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log(`failed to send WhatsApp message: ${message}`);
+      return { success: false, error: message };
+    }
+  }
+
+  async handleIncoming(event: WhatsAppIncomingMessage): Promise<void> {
+    const key = conversationKey(event.chatJid);
+    const previous = this.chatLocks.get(key) ?? Promise.resolve();
+    const current = previous.then(
+      () => this.handleIncomingInner(event),
+      () => this.handleIncomingInner(event),
+    );
+    this.chatLocks.set(key, current.catch(() => undefined));
+    await current;
+  }
+
+  private async handleIncomingInner(event: WhatsAppIncomingMessage): Promise<void> {
+    if (!shouldAcceptMessage(event, this.options)) {
+      this.log(`dropped message from disallowed WhatsApp chat ${event.chatJid}`);
+      return;
+    }
+
+    const commandText = event.commandText ?? event.text;
+    if ((!event.isGroup || event.mentioned) && isNewCommand(commandText)) {
+      await this.handleNewSession(event.chatJid);
+      return;
+    }
+
+    const sessionId = await this.getSessionId(event.chatJid);
+    await this.ensureSession(sessionId, event);
+
+    const senderChannelUserId = event.senderNumber ?? event.senderJid;
+    const postOpts = event.isGroup ? undefined : { channelUserId: senderChannelUserId };
+    const postResult = await this.client.postMessage(sessionId, {
+      text: event.text,
+      mentioned: event.mentioned,
+      sender: {
+        channel: 'whatsapp',
+        channelUserId: senderChannelUserId,
+        ...(event.senderName ? { displayName: event.senderName } : {}),
+      },
+      metadata: {
+        whatsapp_chat_jid: event.chatJid,
+        whatsapp_sender_jid: event.senderJid,
+        ...(event.senderNumber ? { whatsapp_sender_number: event.senderNumber } : {}),
+      },
+    }, postOpts);
+
+    if (!(postResult as { triggered?: boolean }).triggered) return;
+
+    const result = await this.waitForAgentResponse(sessionId);
+    if (result.error && !result.text) {
+      await this.send({ sessionId, to: event.chatJid, text: `Error: ${result.error}` });
+    } else if (result.text) {
+      await this.send({ sessionId, to: event.chatJid, text: result.text });
+    }
+  }
+
+  async handleNewSession(chatJid: string): Promise<void> {
+    const normalizedChatJid = normalizeJid(chatJid);
+    const oldSessionId = await this.getSessionId(normalizedChatJid);
+    try {
+      await this.client.checkpointSession(oldSessionId, { reason: 'new_session' });
+    } catch {
+      // Session may not exist yet.
+    }
+    this.lastEventIds.delete(oldSessionId);
+    const newSessionId = generateSessionId(isGroupJid(normalizedChatJid));
+    this.chatSessions.set(normalizedChatJid, newSessionId);
+    await this.whatsapp.sendText(normalizedChatJid, 'New conversation started.');
+  }
+
+  private async getSessionId(chatJid: string): Promise<string> {
+    const normalizedChatJid = normalizeJid(chatJid);
+    const cached = this.chatSessions.get(normalizedChatJid);
+    if (cached) return cached;
+
+    try {
+      const sessions = await this.client.listSessions({
+        channel: 'whatsapp',
+        metadata: { whatsapp_chat_jid: normalizedChatJid },
+        limit: 1,
+      });
+      if (sessions.length > 0) {
+        const sessionId = sessions[0]!.sessionId;
+        this.chatSessions.set(normalizedChatJid, sessionId);
+        return sessionId;
+      }
+    } catch {
+      // Server unavailable; fall through to a new session id.
+    }
+
+    const sessionId = generateSessionId(isGroupJid(normalizedChatJid));
+    this.chatSessions.set(normalizedChatJid, sessionId);
+    return sessionId;
+  }
+
+  private async ensureSession(
+    sessionId: string,
+    event: WhatsAppIncomingMessage,
+  ): Promise<void> {
+    const metadata: Record<string, string> = {
+      whatsapp_chat_jid: event.chatJid,
+      whatsapp_sender_jid: event.senderJid,
+    };
+    const senderNumber = event.senderNumber ?? jidToPhone(event.senderJid);
+    if (senderNumber) metadata.whatsapp_sender_number = senderNumber;
+    if (event.isGroup) metadata.whatsapp_group_jid = event.chatJid;
+
+    const senderChannelUserId = senderNumber ?? event.senderJid;
+    const openOpts = event.isGroup ? undefined : { channelUserId: senderChannelUserId };
+    await this.client.openSession({
+      sessionId,
+      source: {
+        kind: 'channel',
+        interactive: true,
+        platform: 'whatsapp',
+        type: event.isGroup ? 'group' : 'direct',
+      },
+      metadata,
+    }, openOpts);
+  }
+
+  private async waitForAgentResponse(sessionId: string): Promise<TurnResult> {
+    const eventsUrl = this.client.buildEventsUrl(sessionId);
+    const lastEventId = this.lastEventIds.get(sessionId) ?? 0;
+    const controller = new AbortController();
+    const timeoutTimer = setTimeout(() => controller.abort(), AGENT_RESPONSE_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(eventsUrl, {
+        headers: { authorization: `Bearer ${this.clientToken}` },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timeoutTimer);
+      const message = err instanceof Error ? err.message : String(err);
+      const reason = controller.signal.aborted
+        ? `agent event stream timed out after ${AGENT_RESPONSE_TIMEOUT_MS}ms`
+        : `Failed to open event stream (${message})`;
+      return { text: undefined, error: reason };
+    }
+    if (!response.ok || !response.body) {
+      clearTimeout(timeoutTimer);
+      return { text: undefined, error: `Failed to open event stream (${response.status})` };
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let nextLastEventId = lastEventId;
+    let sequenceResetChecked = false;
+    let accumulatedText = '';
+    let finalText: string | undefined;
+    let error: string | undefined;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parsed = parseSseFrames(buffer);
+        buffer = parsed.remainder;
+        let sawAgentEnd = false;
+
+        for (const frame of parsed.frames) {
+          if (frame.id !== undefined && frame.id <= nextLastEventId) continue;
+          if (frame.id !== undefined) nextLastEventId = frame.id;
+
+          if (frame.event === 'ready') {
+            if (!sequenceResetChecked) {
+              sequenceResetChecked = true;
+              try {
+                const data = frame.data.length > 0
+                  ? (JSON.parse(frame.data) as { nextEventId?: number })
+                  : {};
+                if (typeof data.nextEventId === 'number' && data.nextEventId <= nextLastEventId) {
+                  nextLastEventId = 0;
+                }
+              } catch {
+                // ignore
+              }
+            }
+            continue;
+          }
+          if (frame.event === 'ping') continue;
+
+          const payload = frame.data.length > 0
+            ? (JSON.parse(frame.data) as Record<string, unknown>)
+            : {};
+
+          if (frame.event === 'text_delta') {
+            accumulatedText += String(payload.text ?? '');
+            continue;
+          }
+          if (frame.event === 'text_final') {
+            finalText = String(payload.text ?? '').trim();
+            continue;
+          }
+          if (frame.event === 'error') {
+            error = String(payload.message ?? 'Unknown error');
+            continue;
+          }
+          if (frame.event === 'agent_end') {
+            sawAgentEnd = true;
+            continue;
+          }
+        }
+        if (sawAgentEnd) break;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (controller.signal.aborted && !error) {
+        error = `agent event stream timed out after ${AGENT_RESPONSE_TIMEOUT_MS}ms`;
+      } else if (!error) {
+        error = message;
+      }
+    } finally {
+      clearTimeout(timeoutTimer);
+      await reader.cancel().catch(() => undefined);
+    }
+
+    this.lastEventIds.set(sessionId, nextLastEventId);
+    const responseText = finalText ?? (accumulatedText.trim() || undefined);
+    if (responseText?.trim() === NO_REPLY_TAG) {
+      return { text: undefined, error };
+    }
+    return { text: responseText, error };
+  }
+}

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -104,8 +104,13 @@ export class WhatsAppBridge implements ChannelOutbound {
       () => this.handleIncomingInner(event),
       () => this.handleIncomingInner(event),
     );
-    this.chatLocks.set(key, current.catch(() => undefined));
-    await current;
+    const queued = current.catch(() => undefined);
+    this.chatLocks.set(key, queued);
+    try {
+      await current;
+    } finally {
+      if (this.chatLocks.get(key) === queued) this.chatLocks.delete(key);
+    }
   }
 
   private async handleIncomingInner(event: WhatsAppIncomingMessage): Promise<void> {

--- a/apps/channels/whatsapp/src/db-auth-state.ts
+++ b/apps/channels/whatsapp/src/db-auth-state.ts
@@ -1,0 +1,77 @@
+import {
+  BufferJSON,
+  initAuthCreds,
+  proto,
+} from 'baileys';
+import type {
+  AuthenticationState,
+  SignalDataSet,
+  SignalDataTypeMap,
+} from 'baileys';
+import type { ChannelCredentialStore } from '@openhermit/protocol';
+
+const CREDS_KEY = 'creds';
+
+const keyName = (type: string, id: string): string =>
+  `key:${type}:${id}`;
+
+export const serializeAuthValue = (value: unknown): string =>
+  JSON.stringify(value, BufferJSON.replacer);
+
+export const deserializeAuthValue = <T = unknown>(value: string): T =>
+  JSON.parse(value, BufferJSON.reviver) as T;
+
+export const useDbAuthState = async (
+  store: ChannelCredentialStore,
+  profile: string,
+): Promise<{ state: AuthenticationState; saveCreds: () => Promise<void> }> => {
+  const storedCreds = await store.get(profile, CREDS_KEY);
+  const creds = storedCreds
+    ? deserializeAuthValue<AuthenticationState['creds']>(storedCreds)
+    : initAuthCreds();
+
+  const state: AuthenticationState = {
+    creds,
+    keys: {
+      get: async <T extends keyof SignalDataTypeMap>(
+        type: T,
+        ids: string[],
+      ): Promise<{ [id: string]: SignalDataTypeMap[T] }> => {
+        const data: Record<string, unknown> = {};
+        await Promise.all(ids.map(async (id) => {
+          const raw = await store.get(profile, keyName(String(type), id));
+          if (raw === undefined) return;
+          let value = deserializeAuthValue(raw);
+          if (type === 'app-state-sync-key' && value) {
+            value = proto.Message.AppStateSyncKeyData.fromObject(value as never);
+          }
+          data[id] = value;
+        }));
+        return data as { [id: string]: SignalDataTypeMap[T] };
+      },
+      set: async (data: SignalDataSet): Promise<void> => {
+        const tasks: Array<Promise<void>> = [];
+        const raw = data as Record<string, Record<string, unknown | null> | undefined>;
+        for (const [category, values] of Object.entries(raw)) {
+          if (!values) continue;
+          for (const [id, value] of Object.entries(values)) {
+            const storageKey = keyName(category, id);
+            tasks.push(
+              value
+                ? store.set(profile, storageKey, serializeAuthValue(value))
+                : store.delete(profile, storageKey),
+            );
+          }
+        }
+        await Promise.all(tasks);
+      },
+    },
+  };
+
+  return {
+    state,
+    saveCreds: async () => {
+      await store.set(profile, CREDS_KEY, serializeAuthValue(creds));
+    },
+  };
+};

--- a/apps/channels/whatsapp/src/formatting.ts
+++ b/apps/channels/whatsapp/src/formatting.ts
@@ -1,0 +1,36 @@
+export const WHATSAPP_MAX_LENGTH = 4000;
+
+export function markdownToWhatsApp(md: string): string {
+  return md
+    .replace(/\*\*(.*?)\*\*/g, '*$1*')
+    .replace(/__(.*?)__/g, '*$1*')
+    .replace(/~~(.*?)~~/g, '~$1~')
+    .replace(/^#{1,6}\s+(.+)$/gm, '*$1*')
+    .replace(/^\s*[-*]\s+/gm, '- ');
+}
+
+export function splitMessage(text: string): string[] {
+  if (text.length <= WHATSAPP_MAX_LENGTH) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= WHATSAPP_MAX_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    let splitIndex = remaining.lastIndexOf('\n\n', WHATSAPP_MAX_LENGTH);
+    if (splitIndex <= 0) splitIndex = remaining.lastIndexOf('\n', WHATSAPP_MAX_LENGTH);
+    if (splitIndex <= 0) splitIndex = remaining.lastIndexOf(' ', WHATSAPP_MAX_LENGTH);
+    if (splitIndex <= 0) splitIndex = WHATSAPP_MAX_LENGTH;
+
+    chunks.push(remaining.slice(0, splitIndex).trimEnd());
+    remaining = remaining.slice(splitIndex).trimStart();
+  }
+  return chunks;
+}
+
+export function formatAgentResponse(text: string): string[] {
+  return splitMessage(markdownToWhatsApp(text));
+}

--- a/apps/channels/whatsapp/src/index.ts
+++ b/apps/channels/whatsapp/src/index.ts
@@ -21,11 +21,18 @@ export {
 export { WhatsAppBridge, shouldAcceptMessage } from './bridge.js';
 export { WhatsAppApi } from './whatsapp-api.js';
 export {
+  DEFAULT_AUTH_PROFILE,
   createWhatsAppSetup,
   defaultAuthDir,
   expandHome,
   collapseHome,
+  removeLegacyAuthDir,
 } from './setup.js';
+export {
+  deserializeAuthValue,
+  serializeAuthValue,
+  useDbAuthState,
+} from './db-auth-state.js';
 export type {
   WhatsAppIncomingMessage,
   WhatsAppBridgeOptions,

--- a/apps/channels/whatsapp/src/index.ts
+++ b/apps/channels/whatsapp/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Public entry point for `@openhermit/channel-whatsapp`.
+ *
+ * The default export is the `ChannelManifest`, consumed by the gateway's
+ * plugin loader. Named exports are provided for tests and ad-hoc tooling.
+ */
+export { WhatsAppBot } from './bot.js';
+export {
+  cleanBotCommandText,
+  conversationKey,
+  generateSessionId,
+  groupAllowed,
+  isBroadcastJid,
+  isGroupJid,
+  jidToPhone,
+  normalizeJid,
+  phoneToJid,
+  senderAllowed,
+  targetToJid,
+} from './jid.js';
+export { WhatsAppBridge, shouldAcceptMessage } from './bridge.js';
+export { WhatsAppApi } from './whatsapp-api.js';
+export {
+  createWhatsAppSetup,
+  defaultAuthDir,
+  expandHome,
+  collapseHome,
+} from './setup.js';
+export type {
+  WhatsAppIncomingMessage,
+  WhatsAppBridgeOptions,
+} from './bridge.js';
+export type {
+  RawWhatsAppMessage,
+  RawWhatsAppMessageHandler,
+} from './whatsapp-api.js';
+export type {
+  WhatsAppLinkSession,
+  WhatsAppLinkSnapshot,
+  StartWhatsAppLinkSession,
+} from './setup.js';
+export type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
+
+export { default } from './manifest.js';

--- a/apps/channels/whatsapp/src/jid.ts
+++ b/apps/channels/whatsapp/src/jid.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+
+export const WHATSAPP_DM_DOMAIN = '@s.whatsapp.net';
+export const WHATSAPP_GROUP_DOMAIN = '@g.us';
+
+const E164 = /^\+[1-9]\d{6,14}$/;
+
+export function normalizeJid(jid: string): string {
+  const trimmed = jid.trim().toLowerCase();
+  const at = trimmed.lastIndexOf('@');
+  if (at === -1) return trimmed;
+  const user = trimmed.slice(0, at).replace(/:\d+$/, '');
+  return `${user}${trimmed.slice(at)}`;
+}
+
+export function isGroupJid(jid: string): boolean {
+  return normalizeJid(jid).endsWith(WHATSAPP_GROUP_DOMAIN);
+}
+
+export function isBroadcastJid(jid: string): boolean {
+  const normalized = normalizeJid(jid);
+  return (
+    normalized === 'status@broadcast' ||
+    normalized.endsWith('@broadcast') ||
+    normalized.endsWith('@newsletter')
+  );
+}
+
+export function jidToPhone(jid: string): string | undefined {
+  const normalized = normalizeJid(jid);
+  if (!normalized.endsWith(WHATSAPP_DM_DOMAIN)) return undefined;
+  const user = normalized.slice(0, -WHATSAPP_DM_DOMAIN.length);
+  if (!/^\d{7,15}$/.test(user)) return undefined;
+  return `+${user}`;
+}
+
+export function phoneToJid(phone: string): string | undefined {
+  const trimmed = phone.trim();
+  if (!E164.test(trimmed)) return undefined;
+  return `${trimmed.slice(1)}${WHATSAPP_DM_DOMAIN}`;
+}
+
+export function targetToJid(target: string): string {
+  const stripped = target.trim().replace(/^whatsapp:/i, '');
+  const byPhone = phoneToJid(stripped);
+  if (byPhone) return byPhone;
+  if (/^\d{7,15}$/.test(stripped)) return `${stripped}${WHATSAPP_DM_DOMAIN}`;
+  return normalizeJid(stripped);
+}
+
+export function conversationKey(chatJid: string): string {
+  const normalized = normalizeJid(chatJid);
+  if (isGroupJid(normalized)) return `whatsapp:group:${normalized}`;
+  return `whatsapp:${jidToPhone(normalized) ?? normalized}`;
+}
+
+export function generateSessionId(isGroup = false): string {
+  const day = new Date().toISOString().slice(0, 10);
+  const suffix = randomUUID().slice(0, 8);
+  return isGroup ? `whatsapp:group:${day}-${suffix}` : `whatsapp:${day}-${suffix}`;
+}
+
+export function senderAllowed(senderJid: string, allowed: string[] | undefined): boolean {
+  if (!allowed || allowed.length === 0) return true;
+  const normalized = normalizeJid(senderJid);
+  const phone = jidToPhone(normalized);
+  return allowed.some((entry) => {
+    const item = entry.trim();
+    if (!item) return false;
+    if (item === '*') return true;
+    if (phone && item === phone) return true;
+    return normalizeJid(item) === normalized;
+  });
+}
+
+export function groupAllowed(groupJid: string, allowed: string[] | undefined): boolean {
+  if (!allowed || allowed.length === 0) return false;
+  const normalized = normalizeJid(groupJid);
+  return allowed.some((entry) => {
+    const item = entry.trim();
+    return item === '*' || normalizeJid(item) === normalized;
+  });
+}
+
+export function cleanBotCommandText(text: string, botJid: string | undefined): string {
+  let cleaned = text.trim();
+  if (botJid) {
+    const phone = jidToPhone(botJid);
+    const digits = phone?.slice(1);
+    if (digits) {
+      cleaned = cleaned.replace(new RegExp(`@${digits}\\b`, 'g'), '').trim();
+    }
+  }
+  return cleaned;
+}
+
+export function isNewCommand(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  return normalized === '/new' || normalized === 'new';
+}

--- a/apps/channels/whatsapp/src/manifest.ts
+++ b/apps/channels/whatsapp/src/manifest.ts
@@ -1,0 +1,93 @@
+/**
+ * Channel plugin manifest for WhatsApp Web (Baileys).
+ *
+ * Loaded by the gateway when `@openhermit/channel-whatsapp` is listed under
+ * `channelPackages` in gateway config. See `docs/channel-plugin-design.md`.
+ */
+import type { ChannelManifest } from '@openhermit/protocol';
+
+import { WhatsAppBot } from './bot.js';
+import { WhatsAppBridge } from './bridge.js';
+import { createWhatsAppSetup, expandHome } from './setup.js';
+import { WhatsAppApi } from './whatsapp-api.js';
+
+interface WhatsAppRuntimeConfig {
+  enabled?: boolean;
+  auth_dir: string;
+  allowed_senders?: string[];
+  allowed_group_jids?: string[];
+}
+
+const manifest: ChannelManifest = {
+  manifestVersion: 1,
+  key: 'whatsapp',
+  namespace: 'whatsapp',
+  displayName: 'WhatsApp',
+  configFields: [
+    {
+      kind: 'text',
+      key: 'auth_dir',
+      label: 'Auth directory',
+      placeholder: '~/.openhermit/credentials/whatsapp/<agent>/default',
+      help: 'Filled by setup. Edit only if you moved the Baileys auth files.',
+    },
+    {
+      kind: 'string_list',
+      key: 'allowed_senders',
+      label: 'Allowed senders (optional)',
+      placeholder: '+15551234567, 15551234567@s.whatsapp.net',
+      help: 'Leave blank to allow direct messages from anyone.',
+    },
+    {
+      kind: 'string_list',
+      key: 'allowed_group_jids',
+      label: 'Allowed group JIDs',
+      placeholder: '120363000000000000@g.us, *',
+      help: 'Groups are ignored unless listed. Use * to allow every group.',
+    },
+  ],
+
+  start: async (rawConfig, context) => {
+    const config = rawConfig as WhatsAppRuntimeConfig;
+    const log = (msg: string): void => context.logger('whatsapp', msg);
+    const authDir = typeof config.auth_dir === 'string' ? config.auth_dir.trim() : '';
+
+    if (!authDir) {
+      log('missing auth_dir - channel disabled until linked via setup');
+      return undefined;
+    }
+
+    const api = new WhatsAppApi({
+      authDir: expandHome(authDir),
+      logger: log,
+      reportRuntimeError: context.reportRuntimeError,
+    });
+
+    const bridgeOptions: { allowedSenders?: string[]; allowedGroupJids?: string[] } = {};
+    if (config.allowed_senders) bridgeOptions.allowedSenders = config.allowed_senders;
+    if (config.allowed_group_jids) bridgeOptions.allowedGroupJids = config.allowed_group_jids;
+
+    const bridge = new WhatsAppBridge(
+      api,
+      {
+        baseUrl: context.agentBaseUrl,
+        token: context.agentTokens['whatsapp'] ?? '',
+      },
+      bridgeOptions,
+      log,
+    );
+
+    const bot = new WhatsAppBot({ whatsapp: api, bridge, logger: log });
+    await bot.start();
+
+    return {
+      name: 'whatsapp',
+      outbound: bridge,
+      stop: () => bot.stop(),
+    };
+  },
+
+  setup: createWhatsAppSetup(),
+};
+
+export default manifest;

--- a/apps/channels/whatsapp/src/manifest.ts
+++ b/apps/channels/whatsapp/src/manifest.ts
@@ -8,12 +8,18 @@ import type { ChannelManifest } from '@openhermit/protocol';
 
 import { WhatsAppBot } from './bot.js';
 import { WhatsAppBridge } from './bridge.js';
-import { createWhatsAppSetup, expandHome } from './setup.js';
+import {
+  DEFAULT_AUTH_PROFILE,
+  createWhatsAppSetup,
+  removeLegacyAuthDir,
+} from './setup.js';
 import { WhatsAppApi } from './whatsapp-api.js';
 
 interface WhatsAppRuntimeConfig {
   enabled?: boolean;
-  auth_dir: string;
+  auth_profile?: string;
+  /** Legacy filesystem auth path. No longer supported; cleaned up on sight. */
+  auth_dir?: string;
   allowed_senders?: string[];
   allowed_group_jids?: string[];
 }
@@ -23,14 +29,8 @@ const manifest: ChannelManifest = {
   key: 'whatsapp',
   namespace: 'whatsapp',
   displayName: 'WhatsApp',
+  defaultConfig: { auth_profile: DEFAULT_AUTH_PROFILE },
   configFields: [
-    {
-      kind: 'text',
-      key: 'auth_dir',
-      label: 'Auth directory',
-      placeholder: '~/.openhermit/credentials/whatsapp/<agent>/default',
-      help: 'Filled by setup. Edit only if you moved the Baileys auth files.',
-    },
     {
       kind: 'string_list',
       key: 'allowed_senders',
@@ -50,15 +50,31 @@ const manifest: ChannelManifest = {
   start: async (rawConfig, context) => {
     const config = rawConfig as WhatsAppRuntimeConfig;
     const log = (msg: string): void => context.logger('whatsapp', msg);
-    const authDir = typeof config.auth_dir === 'string' ? config.auth_dir.trim() : '';
+    const legacyAuthDir = typeof config.auth_dir === 'string' ? config.auth_dir.trim() : '';
 
-    if (!authDir) {
-      log('missing auth_dir - channel disabled until linked via setup');
-      return undefined;
+    if (legacyAuthDir) {
+      const cleanup = await removeLegacyAuthDir(legacyAuthDir);
+      if (cleanup.removed) {
+        log(`removed legacy auth_dir ${cleanup.removed}`);
+      } else if (cleanup.skipped) {
+        log(`legacy auth_dir is outside the managed WhatsApp credentials root; skipped delete: ${cleanup.skipped}`);
+      } else if (cleanup.error) {
+        log(`failed to remove legacy auth_dir: ${cleanup.error}`);
+      }
+      throw new Error('WhatsApp auth_dir is no longer supported; run WhatsApp setup again to store credentials in the database.');
     }
 
+    if (!context.credentialStore) {
+      throw new Error('WhatsApp credentials require DATABASE_URL and OPENHERMIT_SECRETS_KEY. Configure both and restart the gateway.');
+    }
+
+    const authProfile = typeof config.auth_profile === 'string' && config.auth_profile.trim()
+      ? config.auth_profile.trim()
+      : DEFAULT_AUTH_PROFILE;
+
     const api = new WhatsAppApi({
-      authDir: expandHome(authDir),
+      authProfile,
+      credentialStore: context.credentialStore,
       logger: log,
       reportRuntimeError: context.reportRuntimeError,
     });

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -80,7 +80,6 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 
     const sock = makeWASocket({
       auth: state,
-      printQRInTerminal: false,
       logger: pino({ level: 'silent' }),
       markOnlineOnConnect: false,
       getMessage: async () => undefined,

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -29,6 +29,7 @@ export interface WhatsAppLinkSession {
 
 export type StartWhatsAppLinkSession = (opts: {
   authDir: string;
+  agentId: string;
   logger: (message: string) => void;
 }) => Promise<WhatsAppLinkSession>;
 
@@ -68,6 +69,7 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 
   constructor(
     readonly authDir: string,
+    private readonly agentId: string,
     private readonly logger: (message: string) => void,
   ) {}
 
@@ -82,9 +84,10 @@ class BaileysLinkSession implements WhatsAppLinkSession {
       return;
     }
 
+    const deviceName = `OpenHermit · ${this.agentId}`.slice(0, 64);
     const sock = makeWASocket({
       auth: state,
-      browser: ['OpenHermit', 'Desktop', '1.0.0'],
+      browser: [deviceName, 'Desktop', '1.0.0'],
       logger: pino({ level: process.env.WHATSAPP_DEBUG === '1' ? 'debug' : 'silent' }),
       markOnlineOnConnect: false,
       getMessage: async () => undefined,
@@ -153,9 +156,10 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 
 export const startRealWhatsAppLinkSession: StartWhatsAppLinkSession = async ({
   authDir,
+  agentId,
   logger,
 }) => {
-  const session = new BaileysLinkSession(authDir, logger);
+  const session = new BaileysLinkSession(authDir, agentId, logger);
   await session.start();
   return session;
 };
@@ -218,6 +222,7 @@ export const createWhatsAppSetup = (
       const authDir = expandHome(rawAuthDir);
       const link = await startLinkSession({
         authDir,
+        agentId: ctx.agentId,
         logger: (message) => ctx.logger(message),
       });
       sessions.set(sessionId, { createdAt: Date.now(), link });

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -73,14 +73,18 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 
   async start(): Promise<void> {
     const { state, saveCreds } = await useMultiFileAuthState(this.authDir);
-    if ((state.creds as { registered?: boolean }).registered === true) {
+    const credsArePaired = (): boolean => {
+      const creds = state.creds as { me?: { id?: string }; noiseKey?: unknown };
+      return Boolean(creds.me?.id && creds.noiseKey);
+    };
+    if (credsArePaired()) {
       this.done = true;
       return;
     }
 
     const sock = makeWASocket({
       auth: state,
-      logger: pino({ level: 'silent' }),
+      logger: pino({ level: process.env.WHATSAPP_DEBUG === '1' ? 'debug' : 'silent' }),
       markOnlineOnConnect: false,
       getMessage: async () => undefined,
     });
@@ -100,6 +104,11 @@ class BaileysLinkSession implements WhatsAppLinkSession {
           update.lastDisconnect?.error?.statusCode ??
           0,
         );
+        if (statusCode === DisconnectReason.restartRequired && credsArePaired()) {
+          this.done = true;
+          this.logger('WhatsApp QR login confirmed (restart required after pair)');
+          return;
+        }
         if (statusCode === DisconnectReason.loggedOut) {
           this.error = 'WhatsApp login was logged out before linking completed.';
         } else {

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -1,19 +1,24 @@
+import { rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import makeWASocket, {
   DisconnectReason,
-  useMultiFileAuthState,
 } from 'baileys';
 import pino from 'pino';
 import type {
+  ChannelCredentialStore,
   ChannelSetup,
   ChannelSetupContext,
   ChannelSetupState,
 } from '@openhermit/protocol';
 
+import { useDbAuthState } from './db-auth-state.js';
+
 const SESSION_TTL_MS = 10 * 60 * 1000;
+export const DEFAULT_AUTH_PROFILE = 'default';
+const SETUP_PROFILE_PREFIX = 'setup:';
 
 export interface WhatsAppLinkSnapshot {
   kind: 'awaiting' | 'done' | 'error';
@@ -22,13 +27,14 @@ export interface WhatsAppLinkSnapshot {
 }
 
 export interface WhatsAppLinkSession {
-  authDir: string;
+  authProfile: string;
   read(): Promise<WhatsAppLinkSnapshot>;
   cancel(): Promise<void>;
 }
 
 export type StartWhatsAppLinkSession = (opts: {
-  authDir: string;
+  authProfile: string;
+  credentialStore: ChannelCredentialStore;
   agentId: string;
   logger: (message: string) => void;
 }) => Promise<WhatsAppLinkSession>;
@@ -39,6 +45,7 @@ export interface CreateWhatsAppSetupOptions {
 
 interface PendingSession {
   createdAt: number;
+  credentialStore: ChannelCredentialStore;
   link: WhatsAppLinkSession;
 }
 
@@ -61,6 +68,26 @@ export function defaultAuthDir(agentId: string, account = 'default'): string {
   return path.join(os.homedir(), '.openhermit', 'credentials', 'whatsapp', safeAgentId, safeAccount);
 }
 
+const managedLegacyAuthDir = (input: string): string | undefined => {
+  const root = path.resolve(os.homedir(), '.openhermit', 'credentials', 'whatsapp');
+  const target = path.resolve(expandHome(input));
+  if (target === root) return undefined;
+  return target.startsWith(`${root}${path.sep}`) ? target : undefined;
+};
+
+export const removeLegacyAuthDir = async (
+  input: string,
+): Promise<{ removed?: string; skipped?: string; error?: string }> => {
+  const target = managedLegacyAuthDir(input);
+  if (!target) return { skipped: expandHome(input) };
+  try {
+    await rm(target, { recursive: true, force: true });
+    return { removed: target };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+};
+
 class BaileysLinkSession implements WhatsAppLinkSession {
   private sock: any;
   private qrText: string | undefined;
@@ -68,13 +95,14 @@ class BaileysLinkSession implements WhatsAppLinkSession {
   private error: string | undefined;
 
   constructor(
-    readonly authDir: string,
+    readonly authProfile: string,
+    private readonly credentialStore: ChannelCredentialStore,
     private readonly agentId: string,
     private readonly logger: (message: string) => void,
   ) {}
 
   async start(): Promise<void> {
-    const { state, saveCreds } = await useMultiFileAuthState(this.authDir);
+    const { state, saveCreds } = await useDbAuthState(this.credentialStore, this.authProfile);
     const credsArePaired = (): boolean => {
       const creds = state.creds as { me?: { id?: string }; noiseKey?: unknown };
       return Boolean(creds.me?.id && creds.noiseKey);
@@ -155,11 +183,12 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 }
 
 export const startRealWhatsAppLinkSession: StartWhatsAppLinkSession = async ({
-  authDir,
+  authProfile,
+  credentialStore,
   agentId,
   logger,
 }) => {
-  const session = new BaileysLinkSession(authDir, agentId, logger);
+  const session = new BaileysLinkSession(authProfile, credentialStore, agentId, logger);
   await session.start();
   return session;
 };
@@ -176,6 +205,7 @@ export const createWhatsAppSetup = (
   const cleanup = async (sessionId: string, session: PendingSession): Promise<void> => {
     sessions.delete(sessionId);
     await session.link.cancel().catch(() => undefined);
+    await session.credentialStore.clear(session.link.authProfile).catch(() => undefined);
   };
 
   const sweepExpired = async (): Promise<void> => {
@@ -202,12 +232,13 @@ export const createWhatsAppSetup = (
       return { kind: 'error', message: snap.message ?? 'WhatsApp setup failed.' };
     }
     if (snap.kind === 'done') {
-      const authDir = collapseHome(session.link.authDir);
+      const values = await session.credentialStore.list(session.link.authProfile);
+      await session.credentialStore.replace(DEFAULT_AUTH_PROFILE, values);
       await cleanup(sessionId, session);
-      ctx.logger(`WhatsApp linked with auth_dir=${authDir}`);
+      ctx.logger(`WhatsApp linked with auth_profile=${DEFAULT_AUTH_PROFILE}`);
       return {
         kind: 'done',
-        config: { auth_dir: authDir },
+        config: { auth_profile: DEFAULT_AUTH_PROFILE },
       };
     }
 
@@ -222,20 +253,36 @@ export const createWhatsAppSetup = (
   };
 
   return {
-    begin: async (input, ctx) => {
+    begin: async (_input, ctx) => {
       await sweepExpired();
       const sessionId = randomUUID();
-      const rawAuthDir = typeof input.auth_dir === 'string' && input.auth_dir.trim()
-        ? input.auth_dir.trim()
-        : defaultAuthDir(ctx.agentId);
-      const authDir = expandHome(rawAuthDir);
-      const link = await startLinkSession({
-        authDir,
-        agentId: ctx.agentId,
-        logger: (message) => ctx.logger(message),
-      });
-      sessions.set(sessionId, { createdAt: Date.now(), link });
-      return { sessionId, state: await toState(sessionId, ctx) };
+      const credentialStore = ctx.credentialStore;
+      if (!credentialStore) {
+        return {
+          sessionId,
+          state: {
+            kind: 'error',
+            message: 'WhatsApp setup requires database-backed channel credentials. Configure DATABASE_URL and OPENHERMIT_SECRETS_KEY, then restart the gateway.',
+          },
+        };
+      }
+
+      const authProfile = `${SETUP_PROFILE_PREFIX}${sessionId}`;
+      await credentialStore.clear(authProfile).catch(() => undefined);
+      try {
+        const link = await startLinkSession({
+          authProfile,
+          credentialStore,
+          agentId: ctx.agentId,
+          logger: (message) => ctx.logger(message),
+        });
+        sessions.set(sessionId, { createdAt: Date.now(), credentialStore, link });
+        return { sessionId, state: await toState(sessionId, ctx) };
+      } catch (err) {
+        await credentialStore.clear(authProfile).catch(() => undefined);
+        const message = err instanceof Error ? err.message : String(err);
+        return { sessionId, state: { kind: 'error', message } };
+      }
     },
 
     poll: async (sessionId, ctx) => {

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -178,6 +178,14 @@ export const createWhatsAppSetup = (
     await session.link.cancel().catch(() => undefined);
   };
 
+  const sweepExpired = async (): Promise<void> => {
+    const expired: Array<[string, PendingSession]> = [];
+    for (const [id, session] of sessions) {
+      if (isExpired(session)) expired.push([id, session]);
+    }
+    await Promise.all(expired.map(([id, session]) => cleanup(id, session)));
+  };
+
   const toState = async (
     sessionId: string,
     ctx: ChannelSetupContext,
@@ -215,6 +223,7 @@ export const createWhatsAppSetup = (
 
   return {
     begin: async (input, ctx) => {
+      await sweepExpired();
       const sessionId = randomUUID();
       const rawAuthDir = typeof input.auth_dir === 'string' && input.auth_dir.trim()
         ? input.auth_dir.trim()
@@ -229,9 +238,13 @@ export const createWhatsAppSetup = (
       return { sessionId, state: await toState(sessionId, ctx) };
     },
 
-    poll: async (sessionId, ctx) => toState(sessionId, ctx),
+    poll: async (sessionId, ctx) => {
+      await sweepExpired();
+      return toState(sessionId, ctx);
+    },
 
     cancel: async (sessionId) => {
+      await sweepExpired();
       const session = sessions.get(sessionId);
       if (session) await cleanup(sessionId, session);
     },

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -84,6 +84,7 @@ class BaileysLinkSession implements WhatsAppLinkSession {
 
     const sock = makeWASocket({
       auth: state,
+      browser: ['OpenHermit', 'Desktop', '1.0.0'],
       logger: pino({ level: process.env.WHATSAPP_DEBUG === '1' ? 'debug' : 'silent' }),
       markOnlineOnConnect: false,
       getMessage: async () => undefined,

--- a/apps/channels/whatsapp/src/setup.ts
+++ b/apps/channels/whatsapp/src/setup.ts
@@ -1,0 +1,225 @@
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import makeWASocket, {
+  DisconnectReason,
+  useMultiFileAuthState,
+} from 'baileys';
+import pino from 'pino';
+import type {
+  ChannelSetup,
+  ChannelSetupContext,
+  ChannelSetupState,
+} from '@openhermit/protocol';
+
+const SESSION_TTL_MS = 10 * 60 * 1000;
+
+export interface WhatsAppLinkSnapshot {
+  kind: 'awaiting' | 'done' | 'error';
+  qrText?: string;
+  message?: string;
+}
+
+export interface WhatsAppLinkSession {
+  authDir: string;
+  read(): Promise<WhatsAppLinkSnapshot>;
+  cancel(): Promise<void>;
+}
+
+export type StartWhatsAppLinkSession = (opts: {
+  authDir: string;
+  logger: (message: string) => void;
+}) => Promise<WhatsAppLinkSession>;
+
+export interface CreateWhatsAppSetupOptions {
+  startLinkSession?: StartWhatsAppLinkSession;
+}
+
+interface PendingSession {
+  createdAt: number;
+  link: WhatsAppLinkSession;
+}
+
+export function expandHome(input: string): string {
+  if (input === '~') return os.homedir();
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+export function collapseHome(input: string): string {
+  const home = os.homedir();
+  if (input === home) return '~';
+  if (input.startsWith(`${home}${path.sep}`)) return `~/${input.slice(home.length + 1)}`;
+  return input;
+}
+
+export function defaultAuthDir(agentId: string, account = 'default'): string {
+  const safeAgentId = agentId.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  const safeAccount = account.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  return path.join(os.homedir(), '.openhermit', 'credentials', 'whatsapp', safeAgentId, safeAccount);
+}
+
+class BaileysLinkSession implements WhatsAppLinkSession {
+  private sock: any;
+  private qrText: string | undefined;
+  private done = false;
+  private error: string | undefined;
+
+  constructor(
+    readonly authDir: string,
+    private readonly logger: (message: string) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    const { state, saveCreds } = await useMultiFileAuthState(this.authDir);
+    if ((state.creds as { registered?: boolean }).registered === true) {
+      this.done = true;
+      return;
+    }
+
+    const sock = makeWASocket({
+      auth: state,
+      printQRInTerminal: false,
+      logger: pino({ level: 'silent' }),
+      markOnlineOnConnect: false,
+      getMessage: async () => undefined,
+    });
+    this.sock = sock;
+    sock.ev.on('creds.update', saveCreds);
+    sock.ev.on('connection.update', (update: Record<string, any>) => {
+      if (typeof update.qr === 'string' && update.qr.length > 0) {
+        this.qrText = update.qr;
+      }
+      if (update.connection === 'open') {
+        this.done = true;
+        this.logger('WhatsApp QR login confirmed');
+      }
+      if (update.connection === 'close' && !this.done) {
+        const statusCode = Number(
+          update.lastDisconnect?.error?.output?.statusCode ??
+          update.lastDisconnect?.error?.statusCode ??
+          0,
+        );
+        if (statusCode === DisconnectReason.loggedOut) {
+          this.error = 'WhatsApp login was logged out before linking completed.';
+        } else {
+          const message = update.lastDisconnect?.error instanceof Error
+            ? update.lastDisconnect.error.message
+            : String(update.lastDisconnect?.error ?? 'connection closed');
+          this.error = `WhatsApp linking connection closed: ${message}`;
+        }
+      }
+    });
+  }
+
+  async read(): Promise<WhatsAppLinkSnapshot> {
+    if (this.error) return { kind: 'error', message: this.error };
+    if (this.done) return { kind: 'done' };
+    return this.qrText
+      ? { kind: 'awaiting', qrText: this.qrText }
+      : { kind: 'awaiting' };
+  }
+
+  async cancel(): Promise<void> {
+    const sock = this.sock;
+    this.sock = undefined;
+    if (!sock) return;
+    try {
+      sock.ev?.removeAllListeners?.();
+    } catch {
+      // ignore
+    }
+    try {
+      sock.end?.(undefined);
+    } catch {
+      try {
+        sock.ws?.close?.();
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+export const startRealWhatsAppLinkSession: StartWhatsAppLinkSession = async ({
+  authDir,
+  logger,
+}) => {
+  const session = new BaileysLinkSession(authDir, logger);
+  await session.start();
+  return session;
+};
+
+export const createWhatsAppSetup = (
+  opts: CreateWhatsAppSetupOptions = {},
+): ChannelSetup => {
+  const sessions = new Map<string, PendingSession>();
+  const startLinkSession = opts.startLinkSession ?? startRealWhatsAppLinkSession;
+
+  const isExpired = (s: PendingSession): boolean =>
+    Date.now() - s.createdAt > SESSION_TTL_MS;
+
+  const cleanup = async (sessionId: string, session: PendingSession): Promise<void> => {
+    sessions.delete(sessionId);
+    await session.link.cancel().catch(() => undefined);
+  };
+
+  const toState = async (
+    sessionId: string,
+    ctx: ChannelSetupContext,
+  ): Promise<ChannelSetupState> => {
+    const session = sessions.get(sessionId);
+    if (!session || isExpired(session)) {
+      if (session) await cleanup(sessionId, session);
+      return { kind: 'error', message: 'WhatsApp setup session not found or expired.' };
+    }
+
+    const snap = await session.link.read();
+    if (snap.kind === 'error') {
+      await cleanup(sessionId, session);
+      return { kind: 'error', message: snap.message ?? 'WhatsApp setup failed.' };
+    }
+    if (snap.kind === 'done') {
+      const authDir = collapseHome(session.link.authDir);
+      await cleanup(sessionId, session);
+      ctx.logger(`WhatsApp linked with auth_dir=${authDir}`);
+      return {
+        kind: 'done',
+        config: { auth_dir: authDir },
+      };
+    }
+
+    return {
+      kind: 'awaiting_external',
+      instructions: snap.qrText
+        ? 'Open WhatsApp on your phone and scan this QR from Linked devices.'
+        : 'Starting WhatsApp linking session...',
+      ...(snap.qrText ? { qrText: snap.qrText } : {}),
+      pollIntervalMs: 1500,
+    };
+  };
+
+  return {
+    begin: async (input, ctx) => {
+      const sessionId = randomUUID();
+      const rawAuthDir = typeof input.auth_dir === 'string' && input.auth_dir.trim()
+        ? input.auth_dir.trim()
+        : defaultAuthDir(ctx.agentId);
+      const authDir = expandHome(rawAuthDir);
+      const link = await startLinkSession({
+        authDir,
+        logger: (message) => ctx.logger(message),
+      });
+      sessions.set(sessionId, { createdAt: Date.now(), link });
+      return { sessionId, state: await toState(sessionId, ctx) };
+    },
+
+    poll: async (sessionId, ctx) => toState(sessionId, ctx),
+
+    cancel: async (sessionId) => {
+      const session = sessions.get(sessionId);
+      if (session) await cleanup(sessionId, session);
+    },
+  };
+};

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -69,7 +69,6 @@ export class WhatsAppApi {
 
     const sock = makeWASocket({
       auth: state,
-      printQRInTerminal: false,
       logger: pino({ level: 'silent' }),
       markOnlineOnConnect: false,
       getMessage: async () => undefined,

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -1,16 +1,18 @@
 import makeWASocket, {
   DisconnectReason,
-  useMultiFileAuthState,
 } from 'baileys';
+import type { ChannelCredentialStore } from '@openhermit/protocol';
 import pino from 'pino';
 
 import { normalizeJid, targetToJid } from './jid.js';
+import { useDbAuthState } from './db-auth-state.js';
 
 export type RawWhatsAppMessage = Record<string, any>;
 export type RawWhatsAppMessageHandler = (message: RawWhatsAppMessage) => void | Promise<void>;
 
 export interface WhatsAppApiOptions {
-  authDir: string;
+  authProfile: string;
+  credentialStore: ChannelCredentialStore;
   logger?: (message: string) => void;
   reportRuntimeError?: (error: string | null) => void;
   reconnectDelayMs?: number;
@@ -66,7 +68,10 @@ export class WhatsAppApi {
   }
 
   private async connect(): Promise<void> {
-    const { state, saveCreds } = await useMultiFileAuthState(this.options.authDir);
+    const { state, saveCreds } = await useDbAuthState(
+      this.options.credentialStore,
+      this.options.authProfile,
+    );
     const creds = state.creds as { me?: { id?: string }; noiseKey?: unknown };
     if (!creds.me?.id || !creds.noiseKey) {
       this.running = false;

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -62,7 +62,8 @@ export class WhatsAppApi {
 
   private async connect(): Promise<void> {
     const { state, saveCreds } = await useMultiFileAuthState(this.options.authDir);
-    if ((state.creds as { registered?: boolean }).registered !== true) {
+    const creds = state.creds as { me?: { id?: string }; noiseKey?: unknown };
+    if (!creds.me?.id || !creds.noiseKey) {
       this.running = false;
       throw new Error('WhatsApp auth is not linked; run channel setup first.');
     }

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -39,7 +39,12 @@ export class WhatsAppApi {
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    await this.connect();
+    try {
+      await this.connect();
+    } catch (err) {
+      this.running = false;
+      throw err;
+    }
   }
 
   async stop(): Promise<void> {

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -1,0 +1,159 @@
+import makeWASocket, {
+  DisconnectReason,
+  useMultiFileAuthState,
+} from 'baileys';
+import pino from 'pino';
+
+import { normalizeJid, targetToJid } from './jid.js';
+
+export type RawWhatsAppMessage = Record<string, any>;
+export type RawWhatsAppMessageHandler = (message: RawWhatsAppMessage) => void | Promise<void>;
+
+export interface WhatsAppApiOptions {
+  authDir: string;
+  logger?: (message: string) => void;
+  reportRuntimeError?: (error: string | null) => void;
+  reconnectDelayMs?: number;
+}
+
+export class WhatsAppApi {
+  private readonly log: (message: string) => void;
+  private readonly reportRuntimeError: (error: string | null) => void;
+  private readonly reconnectDelayMs: number;
+  private sock: any;
+  private running = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private messageHandler: RawWhatsAppMessageHandler | undefined;
+  botJid: string | undefined;
+
+  constructor(private readonly options: WhatsAppApiOptions) {
+    this.log = options.logger ?? ((msg) => console.log(`[whatsapp-api] ${msg}`));
+    this.reportRuntimeError = options.reportRuntimeError ?? (() => undefined);
+    this.reconnectDelayMs = options.reconnectDelayMs ?? 3000;
+  }
+
+  onMessage(handler: RawWhatsAppMessageHandler): void {
+    this.messageHandler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    await this.connect();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    await this.closeSocket();
+    this.log('socket stopped');
+  }
+
+  async sendText(target: string, text: string): Promise<{ messageId?: string }> {
+    if (!this.sock) throw new Error('WhatsApp socket is not connected');
+    const jid = targetToJid(target);
+    const sent = await this.sock.sendMessage(jid, { text });
+    const messageId = sent?.key?.id;
+    return typeof messageId === 'string' ? { messageId } : {};
+  }
+
+  private async connect(): Promise<void> {
+    const { state, saveCreds } = await useMultiFileAuthState(this.options.authDir);
+    if ((state.creds as { registered?: boolean }).registered !== true) {
+      this.running = false;
+      throw new Error('WhatsApp auth is not linked; run channel setup first.');
+    }
+
+    const sock = makeWASocket({
+      auth: state,
+      printQRInTerminal: false,
+      logger: pino({ level: 'silent' }),
+      markOnlineOnConnect: false,
+      getMessage: async () => undefined,
+    });
+
+    this.sock = sock;
+    if (sock.user?.id) this.botJid = normalizeJid(String(sock.user.id));
+
+    sock.ev.on('creds.update', saveCreds);
+    sock.ev.on('connection.update', (update: Record<string, any>) => {
+      this.handleConnectionUpdate(update);
+    });
+    sock.ev.on('messages.upsert', (update: Record<string, any>) => {
+      const messages = Array.isArray(update.messages) ? update.messages : [];
+      for (const message of messages) {
+        void this.messageHandler?.(message);
+      }
+    });
+  }
+
+  private handleConnectionUpdate(update: Record<string, any>): void {
+    if (update.connection === 'open') {
+      if (this.sock?.user?.id) this.botJid = normalizeJid(String(this.sock.user.id));
+      this.reportRuntimeError(null);
+      this.log(`connected${this.botJid ? ` as ${this.botJid}` : ''}`);
+      return;
+    }
+
+    if (update.connection !== 'close') return;
+
+    const statusCode = Number(
+      update.lastDisconnect?.error?.output?.statusCode ??
+      update.lastDisconnect?.error?.statusCode ??
+      0,
+    );
+    const message = update.lastDisconnect?.error instanceof Error
+      ? update.lastDisconnect.error.message
+      : String(update.lastDisconnect?.error ?? 'connection closed');
+
+    if (statusCode === DisconnectReason.loggedOut) {
+      this.running = false;
+      this.reportRuntimeError('WhatsApp logged out; run channel setup again.');
+      this.log('logged out; setup is required before reconnecting');
+      return;
+    }
+
+    if (!this.running) return;
+    this.reportRuntimeError(`WhatsApp connection closed: ${message}`);
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (!this.running) return;
+      void this.closeSocket()
+        .then(() => this.connect())
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.reportRuntimeError(`WhatsApp reconnect failed: ${message}`);
+          this.log(`reconnect failed: ${message}`);
+          if (this.running) this.scheduleReconnect();
+        });
+    }, this.reconnectDelayMs);
+  }
+
+  private async closeSocket(): Promise<void> {
+    const sock = this.sock;
+    this.sock = undefined;
+    if (!sock) return;
+    try {
+      sock.ev?.removeAllListeners?.();
+    } catch {
+      // ignore
+    }
+    try {
+      sock.end?.(undefined);
+    } catch {
+      try {
+        sock.ws?.close?.();
+      } catch {
+        // ignore
+      }
+    }
+  }
+}

--- a/apps/channels/whatsapp/test/bot.test.ts
+++ b/apps/channels/whatsapp/test/bot.test.ts
@@ -41,6 +41,14 @@ test('isBotMentioned supports structured mentions and text fallback', () => {
     isBotMentioned({ message: { conversation: '@15551234567 hi' } }, '15551234567@s.whatsapp.net', '@15551234567 hi'),
     true,
   );
+  assert.equal(
+    isBotMentioned({ message: { conversation: '@155512345678 hi' } }, '15551234567@s.whatsapp.net', '@155512345678 hi'),
+    false,
+  );
+  assert.equal(
+    isBotMentioned({ message: { conversation: 'hey @15551234567 there' } }, '15551234567@s.whatsapp.net', 'hey @15551234567 there'),
+    true,
+  );
 });
 
 test('toIncomingMessage drops self and broadcast messages', () => {

--- a/apps/channels/whatsapp/test/bot.test.ts
+++ b/apps/channels/whatsapp/test/bot.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  extractMentionedJids,
+  extractText,
+  isBotMentioned,
+  toIncomingMessage,
+} from '../src/bot.js';
+
+test('extractText reads plain and caption text', () => {
+  assert.equal(extractText({ message: { conversation: 'hello' } }), 'hello');
+  assert.equal(extractText({ message: { imageMessage: { caption: 'photo caption' } } }), 'photo caption');
+});
+
+test('extractMentionedJids reads extended message context', () => {
+  const mentions = extractMentionedJids({
+    message: {
+      extendedTextMessage: {
+        text: '@15551234567 hi',
+        contextInfo: { mentionedJid: ['15551234567@s.whatsapp.net'] },
+      },
+    },
+  });
+  assert.deepEqual(mentions, ['15551234567@s.whatsapp.net']);
+});
+
+test('isBotMentioned supports structured mentions and text fallback', () => {
+  assert.equal(
+    isBotMentioned({
+      message: {
+        extendedTextMessage: {
+          text: '@15551234567 hi',
+          contextInfo: { mentionedJid: ['15551234567@s.whatsapp.net'] },
+        },
+      },
+    }, '15551234567@s.whatsapp.net', '@15551234567 hi'),
+    true,
+  );
+  assert.equal(
+    isBotMentioned({ message: { conversation: '@15551234567 hi' } }, '15551234567@s.whatsapp.net', '@15551234567 hi'),
+    true,
+  );
+});
+
+test('toIncomingMessage drops self and broadcast messages', () => {
+  assert.equal(toIncomingMessage({ key: { fromMe: true } }, '1555@s.whatsapp.net'), undefined);
+  assert.equal(
+    toIncomingMessage({
+      key: { remoteJid: 'status@broadcast' },
+      message: { conversation: 'hello' },
+    }, '1555@s.whatsapp.net'),
+    undefined,
+  );
+});
+
+test('toIncomingMessage builds group event with mention state', () => {
+  const event = toIncomingMessage({
+    key: {
+      id: 'm1',
+      remoteJid: '120363@g.us',
+      participant: '15550000000@s.whatsapp.net',
+    },
+    pushName: 'Alice',
+    message: {
+      extendedTextMessage: {
+        text: '@15551234567 hi',
+        contextInfo: { mentionedJid: ['15551234567@s.whatsapp.net'] },
+      },
+    },
+  }, '15551234567@s.whatsapp.net');
+
+  assert.ok(event);
+  assert.equal(event.isGroup, true);
+  assert.equal(event.mentioned, true);
+  assert.equal(event.senderNumber, '+15550000000');
+  assert.equal(event.senderName, 'Alice');
+});

--- a/apps/channels/whatsapp/test/bridge.test.ts
+++ b/apps/channels/whatsapp/test/bridge.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { shouldAcceptMessage, type WhatsAppIncomingMessage } from '../src/bridge.js';
+
+const base: WhatsAppIncomingMessage = {
+  chatJid: '15551234567@s.whatsapp.net',
+  senderJid: '15551234567@s.whatsapp.net',
+  senderNumber: '+15551234567',
+  text: 'hello',
+  isGroup: false,
+  mentioned: true,
+};
+
+test('shouldAcceptMessage accepts DMs by default', () => {
+  assert.equal(shouldAcceptMessage(base, {}), true);
+});
+
+test('shouldAcceptMessage applies sender allow-list to DMs', () => {
+  assert.equal(shouldAcceptMessage(base, { allowedSenders: ['+15551234567'] }), true);
+  assert.equal(shouldAcceptMessage(base, { allowedSenders: ['+15550000000'] }), false);
+});
+
+test('shouldAcceptMessage denies groups unless configured', () => {
+  const group: WhatsAppIncomingMessage = {
+    ...base,
+    chatJid: '120363@g.us',
+    isGroup: true,
+    mentioned: false,
+  };
+  assert.equal(shouldAcceptMessage(group, {}), false);
+  assert.equal(shouldAcceptMessage(group, { allowedGroupJids: ['120363@g.us'] }), true);
+  assert.equal(shouldAcceptMessage(group, { allowedGroupJids: ['*'] }), true);
+});

--- a/apps/channels/whatsapp/test/db-auth-state.test.ts
+++ b/apps/channels/whatsapp/test/db-auth-state.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { proto } from 'baileys';
+import type { ChannelCredentialStore } from '@openhermit/protocol';
+
+import { useDbAuthState } from '../src/db-auth-state.js';
+
+class MemoryCredentialStore implements ChannelCredentialStore {
+  private profiles = new Map<string, Map<string, string>>();
+
+  private profile(name: string): Map<string, string> {
+    let values = this.profiles.get(name);
+    if (!values) {
+      values = new Map<string, string>();
+      this.profiles.set(name, values);
+    }
+    return values;
+  }
+
+  async get(profile: string, key: string): Promise<string | undefined> {
+    return this.profiles.get(profile)?.get(key);
+  }
+
+  async list(profile: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.profiles.get(profile)?.entries() ?? []);
+  }
+
+  async set(profile: string, key: string, value: string): Promise<void> {
+    this.profile(profile).set(key, value);
+  }
+
+  async delete(profile: string, key: string): Promise<void> {
+    this.profiles.get(profile)?.delete(key);
+  }
+
+  async replace(profile: string, values: Record<string, string>): Promise<void> {
+    this.profiles.set(profile, new Map(Object.entries(values)));
+  }
+
+  async clear(profile: string): Promise<void> {
+    this.profiles.delete(profile);
+  }
+}
+
+
+test('useDbAuthState persists and reloads creds through BufferJSON', async () => {
+  const store = new MemoryCredentialStore();
+  const first = await useDbAuthState(store, 'default');
+  first.state.creds.me = { id: '15551234567:1@s.whatsapp.net' } as never;
+  await first.saveCreds();
+
+  const second = await useDbAuthState(store, 'default');
+  assert.equal(second.state.creds.me?.id, '15551234567:1@s.whatsapp.net');
+  assert.ok(second.state.creds.noiseKey, 'initAuthCreds fields should survive serialization');
+});
+
+test('useDbAuthState stores, reads, and deletes signal keys', async () => {
+  const store = new MemoryCredentialStore();
+  const { state } = await useDbAuthState(store, 'default');
+
+  await state.keys.set({
+    session: { 'jid-1': Uint8Array.from([1, 2, 3]) },
+  });
+
+  let sessions = await state.keys.get('session', ['jid-1', 'missing']);
+  assert.deepEqual(Array.from(sessions['jid-1'] as Uint8Array), [1, 2, 3]);
+  assert.equal(sessions['missing'], undefined);
+
+  await state.keys.set({ session: { 'jid-1': null } } as never);
+  sessions = await state.keys.get('session', ['jid-1']);
+  assert.equal(sessions['jid-1'], undefined);
+});
+
+test('useDbAuthState rehydrates app-state-sync-key values as protobuf objects', async () => {
+  const store = new MemoryCredentialStore();
+  const { state } = await useDbAuthState(store, 'default');
+  await state.keys.set({
+    'app-state-sync-key': {
+      app: {
+        keyData: Uint8Array.from([7, 8]),
+        timestamp: '123',
+      },
+    },
+  } as never);
+
+  const keys = await state.keys.get('app-state-sync-key', ['app']);
+  assert.ok(keys['app'] instanceof proto.Message.AppStateSyncKeyData);
+  assert.deepEqual(Array.from(keys['app']!.keyData ?? []), [7, 8]);
+});

--- a/apps/channels/whatsapp/test/jid.test.ts
+++ b/apps/channels/whatsapp/test/jid.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  cleanBotCommandText,
+  conversationKey,
+  generateSessionId,
+  groupAllowed,
+  isBroadcastJid,
+  jidToPhone,
+  normalizeJid,
+  phoneToJid,
+  senderAllowed,
+  targetToJid,
+} from '../src/jid.js';
+
+test('normalizeJid strips device suffixes before the domain', () => {
+  assert.equal(
+    normalizeJid('15551234567:12@s.whatsapp.net'),
+    '15551234567@s.whatsapp.net',
+  );
+});
+
+test('phone and target helpers normalize E.164 direct chats', () => {
+  assert.equal(phoneToJid('+15551234567'), '15551234567@s.whatsapp.net');
+  assert.equal(targetToJid('whatsapp:+15551234567'), '15551234567@s.whatsapp.net');
+  assert.equal(jidToPhone('15551234567@s.whatsapp.net'), '+15551234567');
+});
+
+test('conversationKey separates DMs and groups', () => {
+  assert.equal(conversationKey('15551234567@s.whatsapp.net'), 'whatsapp:+15551234567');
+  assert.equal(
+    conversationKey('120363000000000000@g.us'),
+    'whatsapp:group:120363000000000000@g.us',
+  );
+});
+
+test('generateSessionId uses WhatsApp prefixes', () => {
+  assert.match(generateSessionId(), /^whatsapp:\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$/);
+  assert.match(generateSessionId(true), /^whatsapp:group:\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$/);
+});
+
+test('sender allow-list accepts phone or raw jid', () => {
+  assert.equal(senderAllowed('15551234567@s.whatsapp.net', undefined), true);
+  assert.equal(senderAllowed('15551234567@s.whatsapp.net', ['+15551234567']), true);
+  assert.equal(senderAllowed('15551234567@s.whatsapp.net', ['15551234567@s.whatsapp.net']), true);
+  assert.equal(senderAllowed('15551234567@s.whatsapp.net', ['+15550000000']), false);
+});
+
+test('group allow-list is default-deny and supports wildcard', () => {
+  assert.equal(groupAllowed('120363@g.us', undefined), false);
+  assert.equal(groupAllowed('120363@g.us', []), false);
+  assert.equal(groupAllowed('120363@g.us', ['*']), true);
+  assert.equal(groupAllowed('120363@g.us', ['120363@g.us']), true);
+});
+
+test('broadcast chats are skipped', () => {
+  assert.equal(isBroadcastJid('status@broadcast'), true);
+  assert.equal(isBroadcastJid('abc@broadcast'), true);
+  assert.equal(isBroadcastJid('15551234567@s.whatsapp.net'), false);
+});
+
+test('cleanBotCommandText removes mention token for command parsing', () => {
+  assert.equal(
+    cleanBotCommandText('@15551234567 /new', '15551234567@s.whatsapp.net'),
+    '/new',
+  );
+});

--- a/apps/channels/whatsapp/test/manifest.test.ts
+++ b/apps/channels/whatsapp/test/manifest.test.ts
@@ -1,7 +1,59 @@
 import assert from 'node:assert/strict';
+import { mkdir, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { test } from 'node:test';
+import type { ChannelCredentialStore } from '@openhermit/protocol';
 
 import manifest from '../src/manifest.js';
+
+class MemoryCredentialStore implements ChannelCredentialStore {
+  private profiles = new Map<string, Map<string, string>>();
+
+  private profile(name: string): Map<string, string> {
+    let values = this.profiles.get(name);
+    if (!values) {
+      values = new Map<string, string>();
+      this.profiles.set(name, values);
+    }
+    return values;
+  }
+
+  async get(profile: string, key: string): Promise<string | undefined> {
+    return this.profiles.get(profile)?.get(key);
+  }
+
+  async list(profile: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.profiles.get(profile)?.entries() ?? []);
+  }
+
+  async set(profile: string, key: string, value: string): Promise<void> {
+    this.profile(profile).set(key, value);
+  }
+
+  async delete(profile: string, key: string): Promise<void> {
+    this.profiles.get(profile)?.delete(key);
+  }
+
+  async replace(profile: string, values: Record<string, string>): Promise<void> {
+    this.profiles.set(profile, new Map(Object.entries(values)));
+  }
+
+  async clear(profile: string): Promise<void> {
+    this.profiles.delete(profile);
+  }
+}
+
+
+const context = (overrides: Record<string, unknown> = {}) => ({
+  agentBaseUrl: 'http://gateway/api/agents/x',
+  publicAgentBaseUrl: 'http://gateway/api/agents/x',
+  agentTokens: { whatsapp: 'tok' },
+  logger: () => undefined,
+  reportRuntimeError: () => undefined,
+  ...overrides,
+} as never);
 
 test('manifest exposes the required plugin contract', () => {
   assert.equal(manifest.manifestVersion, 1);
@@ -10,20 +62,49 @@ test('manifest exposes the required plugin contract', () => {
   assert.equal(manifest.displayName, 'WhatsApp');
   assert.equal(typeof manifest.start, 'function');
   assert.ok(manifest.setup, 'manifest must expose ChannelSetup');
+  assert.deepEqual(manifest.defaultConfig, { auth_profile: 'default' });
+  assert.equal(
+    manifest.configFields?.some((field) => 'key' in field && field.key === 'auth_dir'),
+    false,
+  );
 });
 
-test('start() without auth_dir returns undefined', async () => {
-  const log: string[] = [];
-  const handle = await manifest.start(
-    { enabled: true },
-    {
-      agentBaseUrl: 'http://gateway/api/agents/x',
-      publicAgentBaseUrl: 'http://gateway/api/agents/x',
-      agentTokens: { whatsapp: 'tok' },
-      logger: (_ch, msg) => log.push(msg),
-      reportRuntimeError: () => undefined,
-    },
+test('start() without credentialStore reports DB credential requirement', async () => {
+  await assert.rejects(
+    () => manifest.start({ enabled: true }, context()),
+    /DATABASE_URL and OPENHERMIT_SECRETS_KEY/,
   );
-  assert.equal(handle, undefined);
-  assert.ok(log.some((m) => m.includes('auth_dir')));
+});
+
+test('start() with DB store but no linked auth asks for setup', async () => {
+  await assert.rejects(
+    () => manifest.start(
+      { enabled: true, auth_profile: 'default' },
+      context({ credentialStore: new MemoryCredentialStore() }),
+    ),
+    /run channel setup first/,
+  );
+});
+
+test('start() rejects and deletes managed legacy auth_dir folders', async (t) => {
+  const root = path.join(
+    os.homedir(),
+    '.openhermit',
+    'credentials',
+    'whatsapp',
+    `test-${randomUUID()}`,
+  );
+  const authDir = path.join(root, 'default');
+  await mkdir(authDir, { recursive: true });
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => manifest.start(
+      { enabled: true, auth_dir: authDir },
+      context({ credentialStore: new MemoryCredentialStore() }),
+    ),
+    /auth_dir is no longer supported/,
+  );
+
+  await assert.rejects(() => mkdir(path.join(authDir, 'probe')), /ENOENT/);
 });

--- a/apps/channels/whatsapp/test/manifest.test.ts
+++ b/apps/channels/whatsapp/test/manifest.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import manifest from '../src/manifest.js';
+
+test('manifest exposes the required plugin contract', () => {
+  assert.equal(manifest.manifestVersion, 1);
+  assert.equal(manifest.key, 'whatsapp');
+  assert.equal(manifest.namespace, 'whatsapp');
+  assert.equal(manifest.displayName, 'WhatsApp');
+  assert.equal(typeof manifest.start, 'function');
+  assert.ok(manifest.setup, 'manifest must expose ChannelSetup');
+});
+
+test('start() without auth_dir returns undefined', async () => {
+  const log: string[] = [];
+  const handle = await manifest.start(
+    { enabled: true },
+    {
+      agentBaseUrl: 'http://gateway/api/agents/x',
+      publicAgentBaseUrl: 'http://gateway/api/agents/x',
+      agentTokens: { whatsapp: 'tok' },
+      logger: (_ch, msg) => log.push(msg),
+      reportRuntimeError: () => undefined,
+    },
+  );
+  assert.equal(handle, undefined);
+  assert.ok(log.some((m) => m.includes('auth_dir')));
+});

--- a/apps/channels/whatsapp/test/setup.test.ts
+++ b/apps/channels/whatsapp/test/setup.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { ChannelSetupContext } from '@openhermit/protocol';
+
+import {
+  createWhatsAppSetup,
+  type StartWhatsAppLinkSession,
+  type WhatsAppLinkSnapshot,
+} from '../src/setup.js';
+
+const ctx: ChannelSetupContext = { agentId: 'agent-1', logger: () => {} };
+
+function fakeStarter(snapshots: WhatsAppLinkSnapshot[]): StartWhatsAppLinkSession {
+  return async ({ authDir }) => {
+    let idx = 0;
+    let cancelled = false;
+    return {
+      authDir,
+      async read() {
+        return snapshots[Math.min(idx++, snapshots.length - 1)]!;
+      },
+      async cancel() {
+        cancelled = true;
+      },
+      get cancelled() {
+        return cancelled;
+      },
+    };
+  };
+}
+
+test('begin() returns awaiting_external for QR setup', async () => {
+  const setup = createWhatsAppSetup({
+    startLinkSession: fakeStarter([{ kind: 'awaiting', qrText: 'qr-code-text' }]),
+  });
+  const { sessionId, state } = await setup.begin({}, ctx);
+  assert.ok(sessionId);
+  assert.equal(state.kind, 'awaiting_external');
+  if (state.kind !== 'awaiting_external') return;
+  assert.equal(state.qrText, 'qr-code-text');
+  assert.equal(state.pollIntervalMs, 1500);
+});
+
+test('poll() returns done with auth_dir when linking completes', async () => {
+  const setup = createWhatsAppSetup({
+    startLinkSession: fakeStarter([
+      { kind: 'awaiting', qrText: 'qr-code-text' },
+      { kind: 'done' },
+    ]),
+  });
+  const { sessionId } = await setup.begin({ auth_dir: '/tmp/openhermit-wa' }, ctx);
+  const state = await setup.poll(sessionId, ctx);
+  assert.equal(state.kind, 'done');
+  if (state.kind !== 'done') return;
+  assert.deepEqual(state.config, { auth_dir: '/tmp/openhermit-wa' });
+});
+
+test('poll() surfaces link errors', async () => {
+  const setup = createWhatsAppSetup({
+    startLinkSession: fakeStarter([{ kind: 'error', message: 'boom' }]),
+  });
+  const { state } = await setup.begin({}, ctx);
+  assert.equal(state.kind, 'error');
+});
+
+test('cancel() drops the setup session', async () => {
+  const setup = createWhatsAppSetup({
+    startLinkSession: fakeStarter([{ kind: 'awaiting', qrText: 'qr-code-text' }]),
+  });
+  const { sessionId } = await setup.begin({}, ctx);
+  await setup.cancel!(sessionId, ctx);
+  const state = await setup.poll(sessionId, ctx);
+  assert.equal(state.kind, 'error');
+});

--- a/apps/channels/whatsapp/test/setup.test.ts
+++ b/apps/channels/whatsapp/test/setup.test.ts
@@ -1,23 +1,75 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { ChannelSetupContext } from '@openhermit/protocol';
+import type { ChannelCredentialStore, ChannelSetupContext } from '@openhermit/protocol';
 
 import {
+  DEFAULT_AUTH_PROFILE,
   createWhatsAppSetup,
   type StartWhatsAppLinkSession,
   type WhatsAppLinkSnapshot,
 } from '../src/setup.js';
 
-const ctx: ChannelSetupContext = { agentId: 'agent-1', logger: () => {} };
+class MemoryCredentialStore implements ChannelCredentialStore {
+  private profiles = new Map<string, Map<string, string>>();
 
-function fakeStarter(snapshots: WhatsAppLinkSnapshot[]): StartWhatsAppLinkSession {
-  return async ({ authDir }) => {
+  private profile(name: string): Map<string, string> {
+    let values = this.profiles.get(name);
+    if (!values) {
+      values = new Map<string, string>();
+      this.profiles.set(name, values);
+    }
+    return values;
+  }
+
+  async get(profile: string, key: string): Promise<string | undefined> {
+    return this.profiles.get(profile)?.get(key);
+  }
+
+  async list(profile: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.profiles.get(profile)?.entries() ?? []);
+  }
+
+  async set(profile: string, key: string, value: string): Promise<void> {
+    this.profile(profile).set(key, value);
+  }
+
+  async delete(profile: string, key: string): Promise<void> {
+    this.profiles.get(profile)?.delete(key);
+  }
+
+  async replace(profile: string, values: Record<string, string>): Promise<void> {
+    this.profiles.set(profile, new Map(Object.entries(values)));
+  }
+
+  async clear(profile: string): Promise<void> {
+    this.profiles.delete(profile);
+  }
+}
+
+
+const ctx = (credentialStore = new MemoryCredentialStore()): ChannelSetupContext => ({
+  agentId: 'agent-1',
+  logger: () => {},
+  credentialStore,
+});
+
+function fakeStarter(
+  snapshots: WhatsAppLinkSnapshot[],
+  captures: string[] = [],
+): StartWhatsAppLinkSession {
+  return async ({ authProfile, credentialStore }) => {
     let idx = 0;
     let cancelled = false;
+    captures.push(authProfile);
     return {
-      authDir,
+      authProfile,
       async read() {
-        return snapshots[Math.min(idx++, snapshots.length - 1)]!;
+        const snap = snapshots[Math.min(idx++, snapshots.length - 1)]!;
+        if (snap.kind === 'done') {
+          await credentialStore.set(authProfile, 'creds', 'linked-creds');
+          await credentialStore.set(authProfile, 'key:session:jid', 'linked-session');
+        }
+        return snap;
       },
       async cancel() {
         cancelled = true;
@@ -33,7 +85,7 @@ test('begin() returns awaiting_external for QR setup', async () => {
   const setup = createWhatsAppSetup({
     startLinkSession: fakeStarter([{ kind: 'awaiting', qrText: 'qr-code-text' }]),
   });
-  const { sessionId, state } = await setup.begin({}, ctx);
+  const { sessionId, state } = await setup.begin({}, ctx());
   assert.ok(sessionId);
   assert.equal(state.kind, 'awaiting_external');
   if (state.kind !== 'awaiting_external') return;
@@ -41,49 +93,94 @@ test('begin() returns awaiting_external for QR setup', async () => {
   assert.equal(state.pollIntervalMs, 1500);
 });
 
-test('poll() returns done with auth_dir when linking completes', async () => {
+test('begin() returns error when credential store is unavailable', async () => {
+  const setup = createWhatsAppSetup({
+    startLinkSession: fakeStarter([{ kind: 'awaiting', qrText: 'qr-code-text' }]),
+  });
+  const { state } = await setup.begin({}, { agentId: 'agent-1', logger: () => {} });
+  assert.equal(state.kind, 'error');
+  if (state.kind !== 'error') return;
+  assert.match(state.message, /database-backed channel credentials/i);
+});
+
+test('poll() promotes setup credentials into the default auth profile', async () => {
+  const store = new MemoryCredentialStore();
+  const setupProfiles: string[] = [];
   const setup = createWhatsAppSetup({
     startLinkSession: fakeStarter([
       { kind: 'awaiting', qrText: 'qr-code-text' },
       { kind: 'done' },
-    ]),
+    ], setupProfiles),
   });
-  const { sessionId } = await setup.begin({ auth_dir: '/tmp/openhermit-wa' }, ctx);
-  const state = await setup.poll(sessionId, ctx);
+  const { sessionId } = await setup.begin({}, ctx(store));
+  const state = await setup.poll(sessionId, ctx(store));
   assert.equal(state.kind, 'done');
   if (state.kind !== 'done') return;
-  assert.deepEqual(state.config, { auth_dir: '/tmp/openhermit-wa' });
-});
-
-test('poll() surfaces link errors', async () => {
-  const setup = createWhatsAppSetup({
-    startLinkSession: fakeStarter([{ kind: 'error', message: 'boom' }]),
+  assert.deepEqual(state.config, { auth_profile: DEFAULT_AUTH_PROFILE });
+  assert.deepEqual(await store.list(DEFAULT_AUTH_PROFILE), {
+    creds: 'linked-creds',
+    'key:session:jid': 'linked-session',
   });
-  const { state } = await setup.begin({}, ctx);
-  assert.equal(state.kind, 'error');
+  assert.deepEqual(await store.list(setupProfiles[0]!), {});
 });
 
-test('cancel() drops the setup session', async () => {
-  const setup = createWhatsAppSetup({
-    startLinkSession: fakeStarter([{ kind: 'awaiting', qrText: 'qr-code-text' }]),
-  });
-  const { sessionId } = await setup.begin({}, ctx);
-  await setup.cancel!(sessionId, ctx);
-  const state = await setup.poll(sessionId, ctx);
+test('poll() surfaces link errors and clears temporary credentials', async () => {
+  const store = new MemoryCredentialStore();
+  const setupProfiles: string[] = [];
+  const starter: StartWhatsAppLinkSession = async ({ authProfile, credentialStore }) => {
+    setupProfiles.push(authProfile);
+    await credentialStore.set(authProfile, 'creds', 'temporary');
+    return {
+      authProfile,
+      async read() {
+        return { kind: 'error', message: 'boom' };
+      },
+      async cancel() {},
+    };
+  };
+  const setup = createWhatsAppSetup({ startLinkSession: starter });
+  const { state } = await setup.begin({}, ctx(store));
   assert.equal(state.kind, 'error');
+  assert.deepEqual(await store.list(setupProfiles[0]!), {});
 });
 
-test('abandoned sessions are swept and cancelled on next setup action', async () => {
+test('cancel() drops the setup session and clears temporary credentials', async () => {
+  const store = new MemoryCredentialStore();
+  const setupProfiles: string[] = [];
+  const starter: StartWhatsAppLinkSession = async ({ authProfile, credentialStore }) => {
+    setupProfiles.push(authProfile);
+    await credentialStore.set(authProfile, 'creds', 'temporary');
+    return {
+      authProfile,
+      async read() {
+        return { kind: 'awaiting', qrText: 'qr-code-text' };
+      },
+      async cancel() {},
+    };
+  };
+  const setup = createWhatsAppSetup({ startLinkSession: starter });
+  const { sessionId } = await setup.begin({}, ctx(store));
+  await setup.cancel!(sessionId, ctx(store));
+  const state = await setup.poll(sessionId, ctx(store));
+  assert.equal(state.kind, 'error');
+  assert.deepEqual(await store.list(setupProfiles[0]!), {});
+});
+
+test('abandoned sessions are swept, cancelled, and cleared on next setup action', async () => {
+  const store = new MemoryCredentialStore();
   const cancellations: string[] = [];
-  const starter: StartWhatsAppLinkSession = async ({ authDir }) => ({
-    authDir,
-    async read() {
-      return { kind: 'awaiting', qrText: 'qr' };
-    },
-    async cancel() {
-      cancellations.push(authDir);
-    },
-  });
+  const starter: StartWhatsAppLinkSession = async ({ authProfile, credentialStore }) => {
+    await credentialStore.set(authProfile, 'creds', 'temporary');
+    return {
+      authProfile,
+      async read() {
+        return { kind: 'awaiting', qrText: 'qr' };
+      },
+      async cancel() {
+        cancellations.push(authProfile);
+      },
+    };
+  };
 
   const setup = createWhatsAppSetup({ startLinkSession: starter });
   const originalNow = Date.now;
@@ -91,15 +188,16 @@ test('abandoned sessions are swept and cancelled on next setup action', async ()
     let now = 1_000_000;
     Date.now = () => now;
 
-    const { sessionId: abandoned } = await setup.begin({ auth_dir: '/tmp/abandoned' }, ctx);
+    const { sessionId: abandoned } = await setup.begin({}, ctx(store));
     assert.equal(cancellations.length, 0);
 
     now += 11 * 60 * 1000;
 
-    await setup.begin({ auth_dir: '/tmp/fresh' }, ctx);
-    assert.deepEqual(cancellations, ['/tmp/abandoned']);
+    await setup.begin({}, ctx(store));
+    assert.equal(cancellations.length, 1);
+    assert.deepEqual(await store.list(cancellations[0]!), {});
 
-    const state = await setup.poll(abandoned, ctx);
+    const state = await setup.poll(abandoned, ctx(store));
     assert.equal(state.kind, 'error');
   } finally {
     Date.now = originalNow;

--- a/apps/channels/whatsapp/test/setup.test.ts
+++ b/apps/channels/whatsapp/test/setup.test.ts
@@ -72,3 +72,36 @@ test('cancel() drops the setup session', async () => {
   const state = await setup.poll(sessionId, ctx);
   assert.equal(state.kind, 'error');
 });
+
+test('abandoned sessions are swept and cancelled on next setup action', async () => {
+  const cancellations: string[] = [];
+  const starter: StartWhatsAppLinkSession = async ({ authDir }) => ({
+    authDir,
+    async read() {
+      return { kind: 'awaiting', qrText: 'qr' };
+    },
+    async cancel() {
+      cancellations.push(authDir);
+    },
+  });
+
+  const setup = createWhatsAppSetup({ startLinkSession: starter });
+  const originalNow = Date.now;
+  try {
+    let now = 1_000_000;
+    Date.now = () => now;
+
+    const { sessionId: abandoned } = await setup.begin({ auth_dir: '/tmp/abandoned' }, ctx);
+    assert.equal(cancellations.length, 0);
+
+    now += 11 * 60 * 1000;
+
+    await setup.begin({ auth_dir: '/tmp/fresh' }, ctx);
+    assert.deepEqual(cancellations, ['/tmp/abandoned']);
+
+    const state = await setup.poll(abandoned, ctx);
+    assert.equal(state.kind, 'error');
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/apps/channels/whatsapp/tsconfig.build.json
+++ b/apps/channels/whatsapp/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "outDir": "dist",
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../../../packages/protocol/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/whatsapp/tsconfig.json
+++ b/apps/channels/whatsapp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../../../packages/sdk" }
+  ],
+  "include": [
+    "src"
+  ]
+}

--- a/apps/channels/whatsapp/tsconfig.typecheck.json
+++ b/apps/channels/whatsapp/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "noEmit": true,
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "test",
+    "../../../packages/protocol/src",
+    "../../../packages/sdk/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/whatsapp/tsup.config.ts
+++ b/apps/channels/whatsapp/tsup.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tsup';
+
+// Workspace packages that are `private: true` and therefore unreachable
+// for an external `npm install`. Bundle them into the published artifact
+// so consumers don't need to resolve them at runtime or compile time.
+const internalPackages = [
+  '@openhermit/protocol',
+  '@openhermit/shared',
+];
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  platform: 'node',
+  outDir: 'dist',
+  clean: true,
+  splitting: false,
+  tsconfig: 'tsconfig.build.json',
+  dts: { resolve: true },
+  sourcemap: true,
+  noExternal: internalPackages,
+  esbuildOptions(options) {
+    options.conditions = ['development'];
+  },
+});

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -33,6 +33,7 @@ import type {
   DbSkillStore,
   DbUserStore,
   DbAgentChannelStore,
+  DbChannelCredentialStore,
   SandboxStore,
   AttachmentStorage,
 } from '@openhermit/store';
@@ -228,6 +229,7 @@ export interface GatewayAppOptions {
   userStore?: DbUserStore | undefined;
   configStore?: DbAgentConfigStore | undefined;
   agentChannelStore?: DbAgentChannelStore | undefined;
+  channelCredentialStore?: DbChannelCredentialStore | undefined;
   instructionStore?: import('@openhermit/store').DbInstructionStore | undefined;
   sandboxStore?: SandboxStore | undefined;
   policyStore?: DbPolicyStore | undefined;
@@ -2715,6 +2717,9 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
   ): ChannelSetupContext => ({
     agentId,
     logger: (msg) => log(`[${agentId}] [${channelType}/setup] ${msg}`),
+    ...(options.channelCredentialStore
+      ? { credentialStore: options.channelCredentialStore.scoped(agentId, channelType) }
+      : {}),
   });
 
   app.post('/api/agents/:agentId/channels/:channelType/setup/begin', async (c) => {

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -27,6 +27,7 @@ import type {
   AgentConfigStore,
   AgentStore,
   DbAgentChannelStore,
+  DbChannelCredentialStore,
   SecretStore,
 } from '@openhermit/store';
 
@@ -35,6 +36,7 @@ import type { ChannelRegistry } from './auth.js';
 export interface ChannelPoolOptions {
   agentStore: AgentStore;
   channelStore: DbAgentChannelStore;
+  channelCredentialStore?: DbChannelCredentialStore | undefined;
   configStore: AgentConfigStore;
   secretStore: SecretStore;
   channelRegistry: ChannelRegistry;
@@ -187,6 +189,9 @@ export class ChannelPool {
         logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
         reportRuntimeError: (error) =>
           void this.handleRuntimeError(agentId, row.channelType, row.id, error),
+        ...(this.opts.channelCredentialStore
+          ? { credentialStore: this.opts.channelCredentialStore.scoped(agentId, row.channelType) }
+          : {}),
       });
       if (handle) startedHandles.push(handle);
       startedStatuses.push(status);
@@ -316,6 +321,9 @@ export class ChannelPool {
       logger: (channel, msg) => this.opts.log(`[${agentId}] [${channel}] ${msg}`),
       reportRuntimeError: (error) =>
         void this.handleRuntimeError(agentId, channelName, row.id, error),
+      ...(this.opts.channelCredentialStore
+        ? { credentialStore: this.opts.channelCredentialStore.scoped(agentId, channelName) }
+        : {}),
     });
 
     if (handle) {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -23,6 +23,7 @@ import {
   FileSecretStore,
   DbSecretStore,
   DbAgentChannelStore,
+  DbChannelCredentialStore,
   DbMetaStore,
   LocalAttachmentStorage,
   S3AttachmentStorage,
@@ -179,6 +180,7 @@ export const main = async (): Promise<void> => {
   let userStore: DbUserStore | undefined;
   let configStore: DbAgentConfigStore | undefined;
   let agentChannelStore: DbAgentChannelStore | undefined;
+  let channelCredentialStore: DbChannelCredentialStore | undefined;
   let instructionStore: DbInstructionStore | undefined;
   let sandboxStore: DbSandboxStore | undefined;
   let policyStore: DbPolicyStore | undefined;
@@ -205,6 +207,7 @@ export const main = async (): Promise<void> => {
       sessionStore = await DbSessionStore.open();
       if (process.env.OPENHERMIT_SECRETS_KEY) {
         agentChannelStore = await DbAgentChannelStore.open();
+        channelCredentialStore = await DbChannelCredentialStore.open();
       }
       logStartup('agent store connected');
     } catch (error) {
@@ -426,6 +429,7 @@ export const main = async (): Promise<void> => {
     ...(userStore ? { userStore } : {}),
     ...(configStore ? { configStore } : {}),
     ...(agentChannelStore ? { agentChannelStore } : {}),
+    ...(channelCredentialStore ? { channelCredentialStore } : {}),
     ...(instructionStore ? { instructionStore } : {}),
     ...(sandboxStore ? { sandboxStore } : {}),
     ...(policyStore ? { policyStore } : {}),
@@ -512,6 +516,7 @@ export const main = async (): Promise<void> => {
       channelPool = new ChannelPool({
         agentStore,
         channelStore: agentChannelStore,
+        ...(channelCredentialStore ? { channelCredentialStore } : {}),
         configStore,
         secretStore,
         channelRegistry: channels,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ OpenHermit keeps internal runtime state separate from external task state.
 - schedules and schedule runs
 - per-agent runtime config and security policy (`agents.config_json` / `agents.security_json` columns)
 - per-agent secrets (encrypted in the `agent_secrets` table when `OPENHERMIT_SECRETS_KEY` is set; falls back to per-agent `secrets.json` only when no key is configured)
-- channel rows with encrypted tokens (`agent_channels`)
+- channel rows with encrypted tokens (`agent_channels`) and encrypted channel-owned auth state (`agent_channel_credentials`)
 
 **External state** is the user's work surface:
 
@@ -62,7 +62,7 @@ OpenHermit keeps internal runtime state separate from external task state.
 
 ## Per-Agent State
 
-Runtime config, security policy, and per-agent secrets are stored in PostgreSQL (`agents.config_json`, `agents.security_json`, `agent_secrets`) and managed through the admin UI, REST API, or `hermit config ... / hermit security ...`. Channels live in `agent_channels` with encrypted tokens, managed through `/api/agents/{agentId}/channels/...`. Secrets are encrypted at rest with `OPENHERMIT_SECRETS_KEY`; if no key is configured the gateway falls back to a plaintext `secrets.json` per agent (local-dev only — `hermit setup` enables the encrypted DB store).
+Runtime config, security policy, per-agent secrets, and channel-owned credentials are stored in PostgreSQL (`agents.config_json`, `agents.security_json`, `agent_secrets`, `agent_channel_credentials`) and managed through the admin UI, REST API, or `hermit config ... / hermit security ...`. Channels live in `agent_channels` with encrypted tokens, managed through `/api/agents/{agentId}/channels/...`. Secrets and channel credential rows are encrypted at rest with `OPENHERMIT_SECRETS_KEY`; if no key is configured the gateway falls back to a plaintext `secrets.json` per agent for local-dev secrets only.
 
 Per-agent state lives in Postgres; the only per-agent artifact on disk is the workspace:
 

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -22,6 +22,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 |----------|---------|------------|
 | Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard |
 | WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
+| WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text-only v1 |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
 
@@ -35,6 +36,7 @@ Adapters keep a current session per external conversation and recover it by list
 | Discord | `discord:` | `discord_channel_id` |
 | Slack | `slack:` | `slack_channel_id`, optional `slack_thread_ts` |
 | Signal | `signal:` (DMs by uuid or E.164) / `signal:group:` | `signal_source`, optional `signal_group_id` |
+| WhatsApp | `whatsapp:` / `whatsapp:group:` | `whatsapp_chat_jid`, optional `whatsapp_group_jid` |
 
 `/new` creates a new generated session ID after checkpointing the previous session with reason `new_session`.
 
@@ -177,3 +179,12 @@ WeChat (external plugin):
 - QR-link setup wizard exchanges scan+confirmation for `bot_token` + IDC-pinned `base_url`; both persist on the channel row
 - text-only v0 (no media, no group filtering)
 - `errcode === -14` from `getUpdates` is treated as long-poll cursor reset, **not** auth failure
+
+WhatsApp (external plugin):
+
+- WhatsApp Web / Linked Devices through Baileys; no Twilio or WhatsApp Cloud API path
+- QR setup wizard persists `auth_dir` on the channel row
+- text-only v1; captions are treated as text, media-only messages are ignored
+- DMs are open by default unless `allowed_senders` is configured
+- groups are default-deny unless `allowed_group_jids` is configured; allowed group turns trigger only on mention
+- status, broadcast, and own linked-account messages are ignored

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -66,10 +66,11 @@ Adapters register `ChannelOutbound` implementations. The `session_send` tool can
 
 ## Configuration
 
-Channels are stored in the `agent_channels` table and managed through the admin UI (*Manage → Channels*) or the REST routes below. The row has two distinct credential slots:
+Channels are stored in the `agent_channels` table and managed through the admin UI (*Manage → Channels*) or the REST routes below. Channel rows and related credentials use three storage slots:
 
-- **`config` (jsonb, plaintext)** — adapter-specific credentials the channel uses to reach the *upstream* platform (Telegram bot token, Slack bot/app tokens, WeChat `bot_token` + `base_url` from iLink, etc.). These are stored as plaintext jsonb today; treat the database itself as the security boundary.
+- **`config` (jsonb, plaintext)** — non-secret adapter settings and setup-produced pointers. Some existing adapters still store upstream tokens here (for example WeChat `bot_token` + `base_url`); treat the database itself as the security boundary for those rows.
 - **`token_ciphertext` (text, AES-256-GCM)** — the bearer token OpenHermit *issues* to that channel, used by webhook ingress (`POST /api/agents/.../channels/.../webhook`) and by adapters calling back into the gateway API. Encrypted at rest with `OPENHERMIT_SECRETS_KEY` and decrypted only when an adapter starts.
+- **`agent_channel_credentials` (AES-256-GCM values)** — mutable channel-owned auth material such as WhatsApp Web / Baileys credentials. Plugins receive this as a scoped credential store; values are not exposed through channel config.
 
 To install or remove gateway-wide channel plugins (npm packages contributing new channel types), use:
 
@@ -111,7 +112,7 @@ The UI switch-renders on `state.kind`:
 - `done` — the UI takes `state.config` and POSTs / PATCHes it onto the channel row via the existing CRUD API (the setup contract itself does **not** write to the DB)
 - `error` — display `message` verbatim
 
-Session state lives in-process inside the plugin (`Map<sessionId, ...>`); the gateway is stateless. Sessions are bounded by a plugin-chosen TTL (WeChat: 5 min; Signal: 10 min). On gateway restart, in-flight setup sessions are lost — the UI restarts the wizard. **Completed setups survive restart** because the durable credentials live on the channel row, not in the setup session: WeChat's `bot_token` (and any equivalent long-lived credential a setup flow produces) is reloaded from `agent_channels.config` and used to re-establish the upstream connection without re-scanning.
+Session state lives in-process inside the plugin (`Map<sessionId, ...>`); the gateway is stateless. Sessions are bounded by a plugin-chosen TTL (WeChat: 5 min; Signal/WhatsApp: 10 min). On gateway restart, in-flight setup sessions are lost — the UI restarts the wizard. **Completed setups survive restart** because durable setup output lives either on the channel row (`agent_channels.config`) or in scoped encrypted channel credentials (`agent_channel_credentials`), then the adapter reloads that state on start.
 
 
 
@@ -183,7 +184,7 @@ WeChat (external plugin):
 WhatsApp (external plugin):
 
 - WhatsApp Web / Linked Devices through Baileys; no Twilio or WhatsApp Cloud API path
-- QR setup wizard persists `auth_dir` on the channel row
+- QR setup wizard stores Baileys credentials in encrypted DB channel credentials and persists `auth_profile` on the channel row
 - text-only v1; captions are treated as text, media-only messages are ignored
 - DMs are open by default unless `allowed_senders` is configured
 - groups are default-deny unless `allowed_group_jids` is configured; allowed group turns trigger only on mention

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -25,8 +25,9 @@ A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, 
 **Installable as npm packages** (add via `hermit channel install`):
 
 - **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text-only v0.
+- **WhatsApp** — `@openhermit/channel-whatsapp`. Link a WhatsApp account through WhatsApp Web / Linked Devices using a QR-scan wizard. Text-only v1.
 
-Each non-CLI channel needs a credential (a bot token or app secret). Credentials are stored as secrets — see [Chapter 18](18-secrets.md).
+Each non-CLI channel needs a credential (a bot token, app secret, or linked-device auth state). Operator-entered tokens are stored as secrets — see [Chapter 18](18-secrets.md). Channel-owned auth state, such as WhatsApp Web credentials, is stored in encrypted channel credential rows.
 
 Newer adapters may exist (e.g., Signal); the *Manage → Channels* tab is the source of truth for which adapters your gateway has.
 
@@ -73,6 +74,13 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Pair the bot through *Manage → Channels → Add channel → WeChat*: the UI renders a QR code that you scan with the WeChat mobile app and confirm. The setup wizard exchanges the scan + confirmation for a long-lived `bot_token` and IDC-pinned `base_url`, which the gateway stores on the channel row.
 - Restarts preserve the login: the gateway reloads `bot_token` from the channel row and resumes the iLink long-poll without re-scanning. You only need to re-pair if you unlink the bot from inside the WeChat client.
 - Text-only in v0 — no attachments, no group filtering.
+
+### WhatsApp (external plugin)
+
+- Install with `hermit channel install @openhermit/channel-whatsapp`, then restart the gateway.
+- Pair through *Manage → Channels → Add channel → WhatsApp*: scan the QR code from WhatsApp → Linked devices.
+- Baileys auth state is stored in encrypted DB channel credentials; the channel row keeps only `auth_profile` plus allow-list settings. Legacy `auth_dir` folders are no longer used.
+- Text-only in v1 — captions are treated as text, media-only messages are ignored.
 
 ### Web / CLI
 

--- a/docs/storage-model.md
+++ b/docs/storage-model.md
@@ -28,6 +28,7 @@ Agent-scoped tables:
 - `agent_skills`
 - `agent_mcp_servers`
 - `agent_channels`
+- `agent_channel_credentials`
 - `agent_secrets`
 - `schedules`
 - `schedule_runs`
@@ -50,6 +51,7 @@ Agent-scoped tables:
 | `mcp_servers` | Registered external MCP HTTP servers |
 | `agent_mcp_servers` | Global (`*`) and per-agent MCP assignments |
 | `agent_channels` | Built-in and external channel rows with encrypted bearer tokens |
+| `agent_channel_credentials` | Encrypted channel-owned auth state such as WhatsApp Web / Baileys credentials |
 | `agent_secrets` | Per-agent provider/integration secrets, encrypted with `OPENHERMIT_SECRETS_KEY` |
 | `schedules` | Cron and one-shot schedule definitions |
 | `schedule_runs` | Schedule execution history |
@@ -113,7 +115,7 @@ gateway's `POST /agents` flow seeds these columns with the default
 template; `PUT /api/agents/:id/config` and `PUT /api/agents/:id/secrets`
 also write through the stores.
 
-## Per-Agent Secrets
+## Per-Agent Secrets And Channel Credentials
 
 Secrets are stored in the `agent_secrets` table, encrypted at rest with
 `OPENHERMIT_SECRETS_KEY` (AES-GCM). The `DbSecretStore` is the default
@@ -127,6 +129,12 @@ Secrets are accessed exclusively through `SecretStore`. Config
 interpolation (`${{SECRET_NAME}}`), channel-token resolution, and the
 admin/owner APIs all go through the same interface — values are never
 returned to clients in plaintext after they are written.
+
+Channel-owned auth state that is too large or mutable for `agent_channels.config`
+lives in `agent_channel_credentials`, also encrypted with
+`OPENHERMIT_SECRETS_KEY`. Channel plugins receive a scoped credential store for
+the current `(agent_id, channel_type)` and address only profiles and keys.
+WhatsApp uses this for Baileys `creds` and signal key material.
 
 ## Per-Agent Files
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,9 +133,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@openhermit/sdk": "^0.6.0",
-        "baileys": "^6.7.19",
-        "pino": "^9.6.0"
+        "@openhermit/sdk": "0.6.1",
+        "baileys": "7.0.0-rc13",
+        "pino": "10.3.1"
       },
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",
@@ -145,6 +145,55 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "apps/channels/whatsapp/node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "apps/channels/whatsapp/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "apps/channels/whatsapp/node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/channels/whatsapp/node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "apps/cli": {
       "name": "openhermit",
@@ -6147,20 +6196,22 @@
       }
     },
     "node_modules/baileys": {
-      "version": "6.7.23",
-      "resolved": "https://registry.npmjs.org/baileys/-/baileys-6.7.23.tgz",
-      "integrity": "sha512-y/qGIdZyIdVBD76uHX9YnYcqEywJSmPgIYG40YcLBoo1uuoQS+MU2IpfP6ZFodv5girKbhvp4+ID9J59QtQN3g==",
+      "version": "7.0.0-rc13",
+      "resolved": "https://registry.npmjs.org/baileys/-/baileys-7.0.0-rc13.tgz",
+      "integrity": "sha512-v8k74K8B5R7WNYGa26MyJAYEu3Wc4BSuK01QaK8lr30lhE8Nga31nWNu8KN0NDDt+Fsvkq4SQFFI8Q13ghjKmA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
         "async-mutex": "^0.5.0",
-        "axios": "^1.6.0",
-        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
-        "music-metadata": "^11.7.0",
+        "libsignal": "^6.0.0",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.12.3",
+        "p-queue": "^9.0.0",
         "pino": "^9.6",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.4",
         "ws": "^8.13.0"
       },
       "engines": {
@@ -6168,7 +6219,7 @@
       },
       "peerDependencies": {
         "audio-decode": "^2.1.3",
-        "jimp": "^1.6.0",
+        "jimp": "^1.6.1",
         "link-preview-js": "^3.0.0",
         "sharp": "*"
       },
@@ -6182,6 +6233,43 @@
         "link-preview-js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/baileys/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/baileys/node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/baileys/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/balanced-match": {
@@ -12143,6 +12231,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/whatsapp-rust-bridge": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.4.tgz",
+      "integrity": "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==",
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,24 @@
         "node": ">=20"
       }
     },
+    "apps/channels/whatsapp": {
+      "name": "@openhermit/channel-whatsapp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@openhermit/sdk": "^0.6.0",
+        "baileys": "^6.7.19",
+        "pino": "^9.6.0"
+      },
+      "devDependencies": {
+        "@openhermit/protocol": "0.2.0",
+        "@openhermit/shared": "0.2.0",
+        "tsup": "^8.5.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/cli": {
       "name": "openhermit",
       "version": "0.9.0",
@@ -548,7 +566,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
       "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1335,7 +1352,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1606,19 +1622,63 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.1",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
+      "integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.1",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -1717,7 +1777,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1740,7 +1799,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1949,6 +2007,17 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -2882,6 +2951,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -2899,6 +2983,544 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
@@ -2980,6 +3602,28 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
     },
     "node_modules/@mariozechner/pi-agent-core": {
       "version": "0.70.6",
@@ -3167,6 +3811,10 @@
       "resolved": "apps/channels/wechat",
       "link": true
     },
+    "node_modules/@openhermit/channel-whatsapp": {
+      "resolved": "apps/channels/whatsapp",
+      "link": true
+    },
     "node_modules/@openhermit/gateway": {
       "resolved": "apps/gateway",
       "link": true
@@ -3200,7 +3848,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3873,6 +4520,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -5112,6 +5765,29 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -5198,7 +5874,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -5231,7 +5906,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5327,7 +6001,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5429,11 +6102,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.15.2",
@@ -5453,6 +6144,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/baileys": {
+      "version": "6.7.23",
+      "resolved": "https://registry.npmjs.org/baileys/-/baileys-6.7.23.tgz",
+      "integrity": "sha512-y/qGIdZyIdVBD76uHX9YnYcqEywJSmPgIYG40YcLBoo1uuoQS+MU2IpfP6ZFodv5girKbhvp4+ID9J59QtQN3g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/node-cache": "^1.4.0",
+        "@hapi/boom": "^9.1.3",
+        "async-mutex": "^0.5.0",
+        "axios": "^1.6.0",
+        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
+        "music-metadata": "^11.7.0",
+        "pino": "^9.6",
+        "protobufjs": "^7.2.4",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "audio-decode": "^2.1.3",
+        "jimp": "^1.6.0",
+        "link-preview-js": "^3.0.0",
+        "sharp": "*"
+      },
+      "peerDependenciesMeta": {
+        "audio-decode": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        },
+        "link-preview-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/balanced-match": {
@@ -5611,7 +6340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5693,6 +6421,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -5989,6 +6730,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
+      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -6093,6 +6840,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dijkstrajs": {
@@ -6941,7 +7698,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7106,7 +7862,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7291,6 +8046,24 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -7717,6 +8490,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -7746,10 +8531,15 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -8007,7 +8797,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -8155,6 +8944,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/koffi": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
@@ -8188,6 +8986,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/libsignal": {
+      "version": "6.0.0",
+      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#bcea72df9ec34d9d9140ab30619cf479c7c144c7",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "curve25519-js": "^0.0.4",
+        "protobufjs": "^7.5.5"
       }
     },
     "node_modules/lilconfig": {
@@ -8472,6 +9279,37 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/music-metadata": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
+      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.1",
+        "media-typer": "^1.1.0",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -8600,6 +9438,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -8908,7 +9755,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9012,6 +9858,43 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -9158,6 +10041,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prom-client": {
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -9253,6 +10152,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.4",
@@ -9378,6 +10295,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9423,7 +10346,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9476,6 +10398,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/remend": {
@@ -9676,6 +10607,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9766,6 +10706,64 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9931,6 +10929,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10045,6 +11052,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -10151,6 +11174,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -10187,6 +11219,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -10327,7 +11377,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10378,7 +11427,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10393,6 +11441,18 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undici": {
       "version": "7.25.0",
@@ -10489,7 +11549,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11141,6 +12200,12 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
     },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -11169,7 +12234,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11258,7 +12322,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -321,6 +321,22 @@ export interface ChannelOutbound {
   }): Promise<ChannelOutboundResult>;
 }
 
+/**
+ * Per-agent, per-channel credential storage exposed to channel manifests.
+ *
+ * The gateway scopes implementations to one `(agentId, channelType)` before
+ * handing them to plugins, so plugins only address profiles and keys. Values
+ * are opaque strings; the backing store decides encryption and persistence.
+ */
+export interface ChannelCredentialStore {
+  get(profile: string, key: string): Promise<string | undefined>;
+  list(profile: string): Promise<Record<string, string>>;
+  set(profile: string, key: string, value: string): Promise<void>;
+  delete(profile: string, key: string): Promise<void>;
+  replace(profile: string, values: Record<string, string>): Promise<void>;
+  clear(profile: string): Promise<void>;
+}
+
 // ── Channel Plugin Contract ───────────────────────────────────────────
 //
 // The types below define the stable contract a channel plugin package
@@ -354,6 +370,12 @@ export interface ChannelContext {
    * value is cheap — the gateway dedupes.
    */
   reportRuntimeError: (error: string | null) => void;
+  /**
+   * Optional durable credential storage for channel-owned auth state
+   * (for example Baileys signal keys). Available only when the gateway has
+   * DB-backed encrypted credential storage configured.
+   */
+  credentialStore?: ChannelCredentialStore;
 }
 
 /**
@@ -569,6 +591,12 @@ export interface ChannelSetupContext {
   agentId: string;
   /** Per-session logger (prefixed with channel key + agent id by caller). */
   logger: (message: string) => void;
+  /**
+   * Optional durable credential storage scoped to this setup's channel.
+   * Setup flows may write temporary profiles and return a final config that
+   * references the promoted profile.
+   */
+  credentialStore?: ChannelCredentialStore;
 }
 
 /**

--- a/packages/store/drizzle/0031_channel_credentials.sql
+++ b/packages/store/drizzle/0031_channel_credentials.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "agent_channel_credentials" (
+  "agent_id" text NOT NULL,
+  "channel_type" text NOT NULL,
+  "profile" text NOT NULL,
+  "key" text NOT NULL,
+  "value_ciphertext" text NOT NULL,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL,
+  CONSTRAINT "agent_channel_credentials_agent_id_channel_type_profile_key_pk"
+    PRIMARY KEY("agent_id", "channel_type", "profile", "key")
+);
+
+CREATE INDEX "idx_agent_channel_credentials_agent_channel"
+  ON "agent_channel_credentials" ("agent_id", "channel_type");

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1779800000000,
       "tag": "0030_skill_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1779900000000,
+      "tag": "0031_channel_credentials",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/channel-credential-store.ts
+++ b/packages/store/src/impl/channel-credential-store.ts
@@ -1,0 +1,190 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { and, asc, eq } from 'drizzle-orm';
+import type { ChannelCredentialStore } from '@openhermit/protocol';
+import pg from 'pg';
+
+import * as schema from '../schema.js';
+import { agentChannelCredentials } from '../schema.js';
+import {
+  decryptString as decrypt,
+  encryptString as encrypt,
+  secretsKeyFromEnv,
+} from './secret-crypto.js';
+import type { DrizzleDb } from './index.js';
+
+export class DbChannelCredentialStore {
+  private pool?: pg.Pool;
+
+  private constructor(
+    private readonly db: DrizzleDb,
+    private readonly key: Buffer,
+  ) {}
+
+  static async open(databaseUrl?: string): Promise<DbChannelCredentialStore> {
+    const url = databaseUrl ?? process.env.DATABASE_URL;
+    if (!url) throw new Error('DATABASE_URL environment variable is required');
+    const pool = new pg.Pool({ connectionString: url });
+    await pool.query('SELECT 1');
+    const db = drizzle(pool, { schema });
+    const store = new DbChannelCredentialStore(db, secretsKeyFromEnv());
+    store.pool = pool;
+    return store;
+  }
+
+  static withDb(db: DrizzleDb): DbChannelCredentialStore {
+    return new DbChannelCredentialStore(db, secretsKeyFromEnv());
+  }
+
+  async close(): Promise<void> {
+    await this.pool?.end();
+  }
+
+  scoped(agentId: string, channelType: string): ChannelCredentialStore {
+    return {
+      get: (profile: string, key: string) =>
+        this.get(agentId, channelType, profile, key),
+      list: (profile: string) =>
+        this.list(agentId, channelType, profile),
+      set: (profile: string, key: string, value: string) =>
+        this.set(agentId, channelType, profile, key, value),
+      delete: (profile: string, key: string) =>
+        this.delete(agentId, channelType, profile, key),
+      replace: (profile: string, values: Record<string, string>) =>
+        this.replace(agentId, channelType, profile, values),
+      clear: (profile: string) =>
+        this.clear(agentId, channelType, profile),
+    };
+  }
+
+  async get(
+    agentId: string,
+    channelType: string,
+    profile: string,
+    key: string,
+  ): Promise<string | undefined> {
+    const [row] = await this.db.select().from(agentChannelCredentials)
+      .where(and(
+        eq(agentChannelCredentials.agentId, agentId),
+        eq(agentChannelCredentials.channelType, channelType),
+        eq(agentChannelCredentials.profile, profile),
+        eq(agentChannelCredentials.key, key),
+      ));
+    if (!row) return undefined;
+    try {
+      return decrypt(this.key, row.valueCiphertext);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async list(
+    agentId: string,
+    channelType: string,
+    profile: string,
+  ): Promise<Record<string, string>> {
+    const rows = await this.db.select().from(agentChannelCredentials)
+      .where(and(
+        eq(agentChannelCredentials.agentId, agentId),
+        eq(agentChannelCredentials.channelType, channelType),
+        eq(agentChannelCredentials.profile, profile),
+      ))
+      .orderBy(asc(agentChannelCredentials.key));
+    const out: Record<string, string> = {};
+    for (const row of rows) {
+      try {
+        out[row.key] = decrypt(this.key, row.valueCiphertext);
+      } catch {
+        // Skip entries encrypted with a different key so callers can relink.
+      }
+    }
+    return out;
+  }
+
+  async set(
+    agentId: string,
+    channelType: string,
+    profile: string,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const valueCiphertext = encrypt(this.key, value);
+    await this.db.insert(agentChannelCredentials)
+      .values({
+        agentId,
+        channelType,
+        profile,
+        key,
+        valueCiphertext,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          agentChannelCredentials.agentId,
+          agentChannelCredentials.channelType,
+          agentChannelCredentials.profile,
+          agentChannelCredentials.key,
+        ],
+        set: { valueCiphertext, updatedAt: now },
+      });
+  }
+
+  async delete(
+    agentId: string,
+    channelType: string,
+    profile: string,
+    key: string,
+  ): Promise<void> {
+    await this.db.delete(agentChannelCredentials)
+      .where(and(
+        eq(agentChannelCredentials.agentId, agentId),
+        eq(agentChannelCredentials.channelType, channelType),
+        eq(agentChannelCredentials.profile, profile),
+        eq(agentChannelCredentials.key, key),
+      ));
+  }
+
+  async replace(
+    agentId: string,
+    channelType: string,
+    profile: string,
+    values: Record<string, string>,
+  ): Promise<void> {
+    const entries = Object.entries(values);
+    const now = new Date().toISOString();
+    await this.db.transaction(async (tx) => {
+      await tx.delete(agentChannelCredentials)
+        .where(and(
+          eq(agentChannelCredentials.agentId, agentId),
+          eq(agentChannelCredentials.channelType, channelType),
+          eq(agentChannelCredentials.profile, profile),
+        ));
+      if (entries.length === 0) return;
+      await tx.insert(agentChannelCredentials).values(
+        entries.map(([key, value]) => ({
+          agentId,
+          channelType,
+          profile,
+          key,
+          valueCiphertext: encrypt(this.key, value),
+          createdAt: now,
+          updatedAt: now,
+        })),
+      );
+    });
+  }
+
+  async clear(
+    agentId: string,
+    channelType: string,
+    profile: string,
+  ): Promise<void> {
+    await this.db.delete(agentChannelCredentials)
+      .where(and(
+        eq(agentChannelCredentials.agentId, agentId),
+        eq(agentChannelCredentials.channelType, channelType),
+        eq(agentChannelCredentials.profile, profile),
+      ));
+  }
+}

--- a/packages/store/src/impl/index.ts
+++ b/packages/store/src/impl/index.ts
@@ -88,5 +88,6 @@ export {
   type CreatedAgentChannel,
   type AgentChannelLoaded,
 } from './db-agent-channel-store.js';
+export { DbChannelCredentialStore } from './channel-credential-store.js';
 export { runMigrations } from './migrator.js';
 export { DbMetaStore } from './meta-store.js';

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -103,6 +103,7 @@ export {
   FileSecretStore,
   DbSecretStore,
   DbAgentChannelStore,
+  DbChannelCredentialStore,
   DbSandboxStore,
   DbPolicyStore,
   DbApprovalRequestStore,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -125,6 +125,26 @@ export const agentChannels = pgTable('agent_channels', {
 ]);
 
 /**
+ * Encrypted channel-owned credential state. This is for durable upstream
+ * adapter state that is not a simple operator-entered secret, such as
+ * WhatsApp Web / Baileys auth keys. Rows are scoped to one agent, one
+ * channel type, and one profile so setup flows can write temporary profiles
+ * before promoting them to a runtime profile like `default`.
+ */
+export const agentChannelCredentials = pgTable('agent_channel_credentials', {
+  agentId: text('agent_id').notNull(),
+  channelType: text('channel_type').notNull(),
+  profile: text('profile').notNull(),
+  key: text('key').notNull(),
+  valueCiphertext: text('value_ciphertext').notNull(),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.agentId, table.channelType, table.profile, table.key] }),
+  index('idx_agent_channel_credentials_agent_channel').on(table.agentId, table.channelType),
+]);
+
+/**
  * Per-agent secrets, encrypted at rest with AES-256-GCM. The wire format
  * stored in `value_ciphertext` is `iv:authTag:ciphertext` (base64), and
  * the encryption key comes from the OPENHERMIT_SECRETS_KEY env var (32


### PR DESCRIPTION
  This change moves WhatsApp Web auth state out of the local ~/.openhermit/credentials/whatsapp/... folder and into encrypted PostgreSQL-backed channel credentials.

  What changed:

  - Added a DB-backed credential store for channel-owned auth material.
  - Wired channel manifests so WhatsApp can read/write scoped credentials through the gateway.
  - Replaced Baileys useMultiFileAuthState() with a DB auth adapter.
  - WhatsApp setup now stores a durable auth_profile on the channel row instead of an auth_dir path.
  - Legacy auth_dir configs are no longer supported; if one is present, the adapter best-effort deletes the old folder and requires setup again.

  Why:

  - This matches OpenHermit’s storage model: durable internal state belongs in the database, not on a host-local folder.
  - It makes WhatsApp credentials portable across gateway restarts and avoids depending on filesystem state.

  I also updated the WhatsApp docs and storage docs to reflect the new model.

<img width="720" height="266" alt="image" src="https://github.com/user-attachments/assets/1b9f28c6-38ca-4f43-b9cd-f3905fee65cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WhatsApp channel adapter now available as an external plugin; supports QR-based linking, text messaging, group chats, and sender/group allowlists.
  * Encrypted credential store for durable channel authentication state; enables linked-device credentials to persist across restarts.

* **Documentation**
  * Updated architecture and channel documentation to reflect WhatsApp support and encrypted credential storage model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->