### PR TITLE
feat(channels): clear last_error on success + track recovery state

### DIFF
--- a/apps/channels/telegram/src/bot.ts
+++ b/apps/channels/telegram/src/bot.ts
@@ -153,6 +153,12 @@ export class TelegramBot {
       return { status: 400, body: 'invalid json' };
     }
 
+    // A delivered webhook is the same recovery signal as a successful poll:
+    // it proves the bot token is good and Telegram is actually routing to
+    // us. Clear any stale `last_error` so the UI stops showing an error
+    // that's already been resolved.
+    this.options.reportRuntimeError?.(null);
+
     // Dispatch asynchronously so we ack Telegram immediately.
     void this.handleUpdate(update);
     return { status: 200, body: '{"ok":true}', headers: { 'content-type': 'application/json' } };

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -91,7 +91,7 @@ export class ChannelPool {
       }
     }
 
-    await this.persistError(rowId, error);
+    await this.persistRuntime(rowId, error);
   }
 
   /**
@@ -176,7 +176,7 @@ export class ChannelPool {
         const errMsg = `no manifest registered for channel "${row.channelType}"`;
         this.opts.log(`[${agentId}] [${row.channelType}] ${errMsg} — skipping`);
         startedStatuses.push({ name: row.channelType, status: 'error', error: errMsg });
-        await this.persistError(row.id, errMsg);
+        await this.persistRuntime(row.id, errMsg);
         continue;
       }
       const resolved = await security.expandSecrets({ ...row.config, enabled: true });
@@ -192,7 +192,7 @@ export class ChannelPool {
       startedStatuses.push(status);
       const startErr = status.status === 'error' ? status.error ?? 'unknown error' : null;
       this.lastReportedError.set(row.id, startErr);
-      await this.persistError(row.id, startErr);
+      await this.persistRuntime(row.id, startErr);
     }
 
     if (startedHandles.length > 0) this.handles.set(agentId, startedHandles);
@@ -204,12 +204,24 @@ export class ChannelPool {
     }
   }
 
-  private async persistError(channelId: string, error: string | null): Promise<void> {
+  /**
+   * Persist a runtime report (success or failure) from a bot. `null` is a
+   * success signal that clears `last_error` and bumps `last_success_at`;
+   * a non-null string records a failure and increments the counters.
+   *
+   * `disableChannel` uses `clearError` directly instead of routing through
+   * here — disabling is not a success.
+   */
+  private async persistRuntime(channelId: string, error: string | null): Promise<void> {
     try {
-      await this.opts.channelStore.recordError(channelId, error);
+      if (error === null) {
+        await this.opts.channelStore.recordSuccess(channelId);
+      } else {
+        await this.opts.channelStore.recordError(channelId, error);
+      }
     } catch (err) {
       this.opts.log(
-        `failed to persist channel error for ${channelId}: ${err instanceof Error ? err.message : String(err)}`,
+        `failed to persist channel state for ${channelId}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
@@ -301,7 +313,7 @@ export class ChannelPool {
       if (existingIdx !== -1) statuses[existingIdx] = errorStatus;
       else statuses.push(errorStatus);
       this.statuses.set(agentId, statuses);
-      await this.persistError(row.id, errorStatus.error ?? 'no manifest');
+      await this.persistRuntime(row.id, errorStatus.error ?? 'no manifest');
       return errorStatus;
     }
 
@@ -335,7 +347,7 @@ export class ChannelPool {
 
     const startErr = status.status === 'error' ? status.error ?? 'unknown error' : null;
     this.lastReportedError.set(row.id, startErr);
-    await this.persistError(row.id, startErr);
+    await this.persistRuntime(row.id, startErr);
 
     return status;
   }
@@ -372,10 +384,18 @@ export class ChannelPool {
 
     // Disabling is a deliberate user action — clear the stale error so
     // the UI doesn't keep showing it after the user has acknowledged it.
+    // Use clearError (not recordSuccess): we have no proof the channel
+    // actually worked, just that the operator no longer cares.
     const row = await this.opts.channelStore.findBuiltin(agentId, channelName);
     if (row) {
       this.lastReportedError.delete(row.id);
-      await this.persistError(row.id, null);
+      try {
+        await this.opts.channelStore.clearError(row.id);
+      } catch (err) {
+        this.opts.log(
+          `failed to clear channel error for ${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     this.opts.log(`[${agentId}] pool stopped channel: ${channelName}`);

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -79,7 +79,6 @@ export class ChannelPool {
     error: string | null,
   ): Promise<void> {
     if (this.lastReportedError.get(rowId) === error) return;
-    this.lastReportedError.set(rowId, error);
 
     const statuses = this.statuses.get(agentId);
     if (statuses) {
@@ -91,7 +90,9 @@ export class ChannelPool {
       }
     }
 
-    await this.persistRuntime(rowId, error);
+    if (await this.persistRuntime(rowId, error)) {
+      this.lastReportedError.set(rowId, error);
+    }
   }
 
   /**
@@ -191,8 +192,9 @@ export class ChannelPool {
       if (handle) startedHandles.push(handle);
       startedStatuses.push(status);
       const startErr = status.status === 'error' ? status.error ?? 'unknown error' : null;
-      this.lastReportedError.set(row.id, startErr);
-      await this.persistRuntime(row.id, startErr);
+      if (await this.persistRuntime(row.id, startErr)) {
+        this.lastReportedError.set(row.id, startErr);
+      }
     }
 
     if (startedHandles.length > 0) this.handles.set(agentId, startedHandles);
@@ -212,17 +214,19 @@ export class ChannelPool {
    * `disableChannel` uses `clearError` directly instead of routing through
    * here — disabling is not a success.
    */
-  private async persistRuntime(channelId: string, error: string | null): Promise<void> {
+  private async persistRuntime(channelId: string, error: string | null): Promise<boolean> {
     try {
       if (error === null) {
         await this.opts.channelStore.recordSuccess(channelId);
       } else {
         await this.opts.channelStore.recordError(channelId, error);
       }
+      return true;
     } catch (err) {
       this.opts.log(
         `failed to persist channel state for ${channelId}: ${err instanceof Error ? err.message : String(err)}`,
       );
+      return false;
     }
   }
 
@@ -346,8 +350,9 @@ export class ChannelPool {
     this.statuses.set(agentId, statuses);
 
     const startErr = status.status === 'error' ? status.error ?? 'unknown error' : null;
-    this.lastReportedError.set(row.id, startErr);
-    await this.persistRuntime(row.id, startErr);
+    if (await this.persistRuntime(row.id, startErr)) {
+      this.lastReportedError.set(row.id, startErr);
+    }
 
     return status;
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -589,6 +589,15 @@ export interface AgentChannel {
   updatedAt: string;
   lastUsedAt: string | null;
   revokedAt: string | null;
+  /** Last persisted runtime error from the bridge (null when healthy). */
+  lastError?: string | null;
+  lastErrorAt?: string | null;
+  /** ISO timestamp of the most recent successful upstream interaction. */
+  lastSuccessAt?: string | null;
+  /** Failures since the last success — resets to 0 on recovery. */
+  consecutiveFailureCount?: number;
+  /** Monotonic lifetime failure count — never reset. */
+  totalFailureCount?: number;
 }
 
 /** Provider/model catalog entry returned by GET /api/providers. */

--- a/packages/store/drizzle/0032_agent_channels_success_counters.sql
+++ b/packages/store/drizzle/0032_agent_channels_success_counters.sql
@@ -1,0 +1,8 @@
+-- Track channel-success state alongside the existing last_error columns so
+-- the UI can distinguish "errored and never recovered" from "errored once,
+-- working again". Counters survive last_error being cleared so postmortems
+-- can still answer "how many failures preceded the recovery?".
+ALTER TABLE "agent_channels"
+  ADD COLUMN IF NOT EXISTS "last_success_at" TEXT,
+  ADD COLUMN IF NOT EXISTS "consecutive_failure_count" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "total_failure_count" INTEGER NOT NULL DEFAULT 0;

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1779900000000,
       "tag": "0031_consumed_jtis",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1780000000000,
+      "tag": "0032_agent_channels_success_counters",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/db-agent-channel-store.ts
+++ b/packages/store/src/impl/db-agent-channel-store.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { and, asc, eq, isNull } from 'drizzle-orm';
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 import pg from 'pg';
 
 import * as schema from '../schema.js';
@@ -41,6 +41,12 @@ export interface AgentChannelRow {
   revokedAt: string | null;
   lastError: string | null;
   lastErrorAt: string | null;
+  /** ISO timestamp of the most recent successful upstream interaction. */
+  lastSuccessAt: string | null;
+  /** Consecutive failures since the last recorded success. */
+  consecutiveFailureCount: number;
+  /** Monotonic total failures — never reset. */
+  totalFailureCount: number;
 }
 
 export interface CreatedAgentChannel extends AgentChannelRow {
@@ -184,6 +190,9 @@ export class DbAgentChannelStore {
       revokedAt: null,
       lastError: null,
       lastErrorAt: null,
+      lastSuccessAt: null,
+      consecutiveFailureCount: 0,
+      totalFailureCount: 0,
       token,
     };
   }
@@ -234,16 +243,50 @@ export class DbAgentChannelStore {
   }
 
   /**
-   * Record the last bridge-start error so it persists across gateway
-   * restarts and is visible in the channels list. Pass `null` to clear
-   * after a successful start.
+   * Record a runtime error for the channel. Sets `last_error` /
+   * `last_error_at` and bumps the failure counters. The channel keeps any
+   * existing `last_success_at` — counters and success timestamps live
+   * independently so postmortems can answer "how many failures preceded
+   * the last recovery?".
    */
-  async recordError(id: string, error: string | null): Promise<void> {
+  async recordError(id: string, error: string): Promise<void> {
     await this.db.update(agentChannels)
       .set({
         lastError: error,
-        lastErrorAt: error ? new Date().toISOString() : null,
+        lastErrorAt: new Date().toISOString(),
+        consecutiveFailureCount: sql`${agentChannels.consecutiveFailureCount} + 1`,
+        totalFailureCount: sql`${agentChannels.totalFailureCount} + 1`,
       })
+      .where(eq(agentChannels.id, id));
+  }
+
+  /**
+   * Record a successful upstream interaction (poll-success, webhook
+   * delivery accepted, connection re-opened, …). Clears `last_error` /
+   * `last_error_at`, resets `consecutive_failure_count`, and stamps
+   * `last_success_at`. Cheap to call on every iteration — the gateway's
+   * channel pool already dedupes consecutive identical reports before
+   * reaching this layer.
+   */
+  async recordSuccess(id: string): Promise<void> {
+    await this.db.update(agentChannels)
+      .set({
+        lastError: null,
+        lastErrorAt: null,
+        lastSuccessAt: new Date().toISOString(),
+        consecutiveFailureCount: 0,
+      })
+      .where(eq(agentChannels.id, id));
+  }
+
+  /**
+   * Clear `last_error` without claiming a success. Used when the
+   * operator/user disables or removes the channel — the stored error is no
+   * longer actionable, but we have no reason to advance `last_success_at`.
+   */
+  async clearError(id: string): Promise<void> {
+    await this.db.update(agentChannels)
+      .set({ lastError: null, lastErrorAt: null })
       .where(eq(agentChannels.id, id));
   }
 
@@ -306,4 +349,7 @@ const rowToPublic = (row: typeof agentChannels.$inferSelect): AgentChannelRow =>
   revokedAt: row.revokedAt,
   lastError: row.lastError,
   lastErrorAt: row.lastErrorAt,
+  lastSuccessAt: row.lastSuccessAt,
+  consecutiveFailureCount: row.consecutiveFailureCount,
+  totalFailureCount: row.totalFailureCount,
 });

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -120,6 +120,17 @@ export const agentChannels = pgTable('agent_channels', {
   /** Last bridge-start error, surfaced in the channels list UI. */
   lastError: text('last_error'),
   lastErrorAt: text('last_error_at'),
+  /**
+   * Timestamp of the most recent successful upstream interaction
+   * (poll-200, webhook delivery, connection-open, …). Cleared independently
+   * of `last_error` so the UI can distinguish "errored and never recovered"
+   * from "errored briefly, working again".
+   */
+  lastSuccessAt: text('last_success_at'),
+  /** Consecutive failures since the last success; resets to 0 on success. */
+  consecutiveFailureCount: integer('consecutive_failure_count').default(0).notNull(),
+  /** Monotonic total — never reset; powers postmortem queries. */
+  totalFailureCount: integer('total_failure_count').default(0).notNull(),
 }, (table) => [
   index('idx_agent_channels_agent').on(table.agentId),
 ]);


### PR DESCRIPTION
## Summary

Fixes the case where a channel keeps advertising a stale `last_error` after the upstream condition has cleared — canonical example: a Telegram polling `409 Conflict` that ended when the other poller stopped, but the channel UI kept showing the error because nothing wrote the cleared state back.

Splits `DbAgentChannelStore` into three semantically distinct verbs:

- `recordSuccess(id)` — clears `last_error` + `last_error_at`, stamps `last_success_at`, resets `consecutive_failure_count`.
- `recordError(id, message)` — sets `last_error` + `last_error_at`, increments `consecutive_failure_count` and `total_failure_count`.
- `clearError(id)` — clears `last_error` without claiming a success. Used when the operator disables a channel (we have no proof the bridge worked, just that the operator no longer cares).

`ChannelPool.handleRuntimeError` dispatches by null/not-null. Every existing path that already calls `reportRuntimeError(null)` — Telegram polling (every `getUpdates` 200), WeChat polling (every healthy `getUpdates`), WhatsApp `connection: 'open'` — automatically gets the new clear-on-success behavior. Added the same call on Telegram **webhook** delivery so webhook-mode channels also recover visibly.

Migration `0032_agent_channels_success_counters` adds `last_success_at`, `consecutive_failure_count`, `total_failure_count`. The SDK's `AgentChannel` type surfaces the new fields so dashboards can render "recovered N min ago after K consecutive failures" without confusing the current health signal.

## Out of scope

- **Rule 2 (rate-limited auto-retry / exponential backoff)** — Telegram already retries every 1s in the polling loop and the dedup map prevents DB hammering. The proposal explicitly calls this a nice-to-have; deferring.
- **Outbound `sendMessage` success reporting** — that path lives off the pool's runtime-error callback chain and would need a separate plumbing change. Not blocking the core fix.

## Test plan

- [x] `npm run typecheck -w @openhermit/store @openhermit/gateway @openhermit/sdk @openhermit/channel-telegram @openhermit/channel-wechat @openhermit/channel-whatsapp @openhermit/protocol` — all clean.
- [x] `npm run test` — same 359 pass / 63 fail as main (all pre-existing, unrelated to channels).
- [x] `npm run build -w @openhermit/store` — confirms the new methods are exported in `dist/`.
- [ ] After merge: deploy to `test.openhermit.ai`, run migration 0032, induce a Telegram 409 (start a second poller against the same token, stop it), confirm the channel's `last_error` clears within one poll cycle and `last_success_at` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channels now track upstream interaction health with persistent metrics: last successful interaction timestamp, consecutive failure count since last success, and total lifetime failure count
  * SDK surfaces these runtime health fields for channels

* **Improvements**
  * Telegram webhook delivery now clears any reported runtime errors when updates are successfully received

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->