### PR TITLE
feat(skills): add hermit skills sync to refresh SKILL.md from disk

### DIFF
--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -198,16 +198,15 @@ export const registerSkillsCommand = (program: Command): void => {
     });
 
   skills
-    .command('sync <target>')
+    .command('sync [skillId]')
     .description(
       'Re-read SKILL.md from disk and refresh DB + running agents. ' +
-        'Target is a skill ID or "all" for every registered system skill.',
+        'Pass a skill ID to sync one; omit it to sync every registered system skill.',
     )
-    .action(async (target: string) => {
+    .action(async (skillId: string | undefined) => {
       try {
         const gateway = createGateway();
-        const id = target === 'all' ? undefined : target;
-        const { results, agentsRefreshed } = await gateway.syncSkills(id);
+        const { results, agentsRefreshed } = await gateway.syncSkills(skillId);
 
         if (results.length === 0) {
           console.log('No skills to sync.');

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -198,6 +198,63 @@ export const registerSkillsCommand = (program: Command): void => {
     });
 
   skills
+    .command('sync <target>')
+    .description(
+      'Re-read SKILL.md from disk and refresh DB + running agents. ' +
+        'Target is a skill ID or "all" for every registered system skill.',
+    )
+    .action(async (target: string) => {
+      try {
+        const gateway = createGateway();
+        const id = target === 'all' ? undefined : target;
+        const { results, agentsRefreshed } = await gateway.syncSkills(id);
+
+        if (results.length === 0) {
+          console.log('No skills to sync.');
+          return;
+        }
+
+        const formatChanges = (
+          changes?: Record<string, { from: string; to: string }>,
+        ): string => {
+          if (!changes) return '';
+          const parts: string[] = [];
+          for (const [field, { from, to }] of Object.entries(changes)) {
+            const fromShort = from.length > 30 ? from.slice(0, 30) + '…' : from;
+            const toShort = to.length > 30 ? to.slice(0, 30) + '…' : to;
+            parts.push(`${field}: "${fromShort}" → "${toShort}"`);
+          }
+          return parts.join('; ');
+        };
+
+        printTable(
+          results.map((r) => ({
+            id: r.id,
+            action: r.action,
+            changes: formatChanges(r.changes),
+          })),
+          [
+            { key: 'id', label: 'ID' },
+            { key: 'action', label: 'Action', width: 18 },
+            { key: 'changes', label: 'Changes' },
+          ],
+        );
+
+        const updated = results.filter((r) => r.action === 'updated').length;
+        const missing = results.filter((r) => r.action === 'missing_on_disk').length;
+        const summary = [
+          `${updated} updated`,
+          `${results.length - updated - missing} unchanged`,
+        ];
+        if (missing > 0) summary.push(`${missing} missing on disk`);
+        summary.push(`${agentsRefreshed} running agent(s) refreshed`);
+        console.log('\n' + summary.join(', ') + '.');
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  skills
     .command('delete <skillId>')
     .description('Delete a skill from the global registry')
     .action(async (skillId: string) => {

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2231,6 +2231,111 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     return c.json({ ok: true });
   });
 
+  // Re-read SKILL.md frontmatter from `registry/skills/<id>/`, upsert name /
+  // description / path back into the `skills` row, and refresh sandbox file
+  // contents for every running agent that has the skill enabled. Body
+  // shape: `{ id?: string }` — pass an id to sync one skill, omit (or pass
+  // '*') to sync every registered system skill.
+  //
+  // Bridges the gap between "operator edits SKILL.md on disk" and "agents
+  // see the new content + DB description". Only touches `source === 'system'`
+  // rows; user-installed skills are owned by their installers and managed
+  // through the skill-install tool, not by this endpoint.
+  app.post('/api/admin/skills/sync', async (c) => {
+    requireAdmin(c.req.header('authorization'));
+    const store = requireSkillStore();
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const requestedId =
+      typeof body.id === 'string' && body.id !== '' && body.id !== '*'
+        ? body.id
+        : undefined;
+
+    const { parseFrontmatter } = await import('@openhermit/agent/skills');
+    const { readFile } = await import('node:fs/promises');
+
+    const skillsDir = path.join(resolveGatewayDir(), 'registry', 'skills');
+    const all = await store.list();
+    const systemSkills = all.filter((s) => s.source === 'system');
+
+    let targets;
+    if (requestedId) {
+      const match = all.find((s) => s.id === requestedId);
+      if (!match) {
+        return c.json({
+          results: [{ id: requestedId, action: 'not_registered' }],
+          agentsRefreshed: 0,
+        });
+      }
+      if (match.source !== 'system') {
+        throw new ValidationError(
+          `Skill ${requestedId} is a user skill — sync only applies to system skills.`,
+        );
+      }
+      targets = [match];
+    } else {
+      targets = systemSkills;
+    }
+
+    interface SyncResultEntry {
+      id: string;
+      action: 'updated' | 'unchanged' | 'missing_on_disk' | 'not_registered';
+      changes?: Record<string, { from: string; to: string }>;
+    }
+    const results: SyncResultEntry[] = [];
+
+    for (const existing of targets) {
+      const skillPath = path.join(skillsDir, existing.id);
+      const skillMdPath = path.join(skillPath, 'SKILL.md');
+      let content: string;
+      try {
+        content = await readFile(skillMdPath, 'utf8');
+      } catch {
+        results.push({ id: existing.id, action: 'missing_on_disk' });
+        continue;
+      }
+      const fm = parseFrontmatter(content);
+      const newName = fm.name || existing.name;
+      const newDescription = fm.description || existing.description;
+      const newPath = skillPath;
+
+      const changes: Record<string, { from: string; to: string }> = {};
+      if (newName !== existing.name) {
+        changes.name = { from: existing.name, to: newName };
+      }
+      if (newDescription !== existing.description) {
+        changes.description = { from: existing.description, to: newDescription };
+      }
+      if (newPath !== existing.path) {
+        changes.path = { from: existing.path, to: newPath };
+      }
+
+      if (Object.keys(changes).length === 0) {
+        results.push({ id: existing.id, action: 'unchanged' });
+        continue;
+      }
+
+      const now = new Date().toISOString();
+      await store.upsert({
+        ...existing,
+        name: newName,
+        description: newDescription,
+        path: newPath,
+        updatedAt: now,
+      });
+      results.push({ id: existing.id, action: 'updated', changes });
+    }
+
+    // Always re-copy sandbox skill dirs: SKILL.md body and helper scripts
+    // can change without any frontmatter diff, so DB "unchanged" does not
+    // imply "agents already see the latest bytes".
+    await syncAffectedAgentSkillMounts('*', store);
+
+    return c.json({
+      results,
+      agentsRefreshed: instances.getRunningAgentIds().length,
+    });
+  });
+
   app.post('/api/admin/skills/:id/disable', async (c) => {
     requireAdmin(c.req.header('authorization'));
     const store = requireSkillStore();

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1175,6 +1175,29 @@ export class GatewayClient {
     await this.postJson(`/api/admin/skills/${encodeURIComponent(skillId)}/disable`, { agentId });
   }
 
+  /**
+   * Re-read SKILL.md frontmatter from disk and refresh the sandbox of every
+   * running agent that has the skill enabled.
+   *
+   * - Pass a skill id to sync that one skill.
+   * - Pass `'*'` or omit `id` to sync every registered system skill.
+   *
+   * Only system skills are touched; user-installed skills are managed via
+   * the skill-install tool and are not safe to mutate from the operator
+   * side.
+   */
+  async syncSkills(id?: string): Promise<{
+    results: Array<{
+      id: string;
+      action: 'updated' | 'unchanged' | 'missing_on_disk' | 'not_registered';
+      changes?: Record<string, { from: string; to: string }>;
+    }>;
+    agentsRefreshed: number;
+  }> {
+    const body = id && id !== '*' ? { id } : {};
+    return this.postJson(`/api/admin/skills/sync`, body);
+  }
+
   // --- instructions ---
 
   async listInstructions(agentId: string): Promise<Array<{ key: string; content: string; updatedAt: string }>> {


### PR DESCRIPTION
## Summary

Adds `hermit skills sync <skill-id|all>` to close the gap between editing a system skill's `SKILL.md` on disk (under `registry/skills/<id>/`) and having agents pick up the change.

Before this PR, the only way to refresh a registered skill's DB metadata (name/description) and the sandboxed copy held by running agents was: `skills delete` → `skills register` → `skills enable …` per agent. That throws away all assignment rows in between.

- **Gateway** — new `POST /api/admin/skills/sync` endpoint. Re-reads `SKILL.md` frontmatter for the targeted skill(s), upserts name/description/path back into the `skills` row (preserving assignments), and re-copies skill directories into every running agent that has the skill enabled (so `SKILL.md` body and helper scripts always refresh, even when no frontmatter changed).
- **SDK** — `client.syncSkills(id?)` method.
- **CLI** — `hermit skills sync <skill-id>` (one skill) or `hermit skills sync all` (every registered system skill). Prints a per-skill action table (`updated` / `unchanged` / `missing_on_disk` / `not_registered`) with the field-level diff, plus a one-line summary.

Scope: only `source === 'system'` skills are touched. User-installed skills stay owned by the skill-install tool path.

## Test plan

- [ ] Edit `SKILL.md` description for a registered system skill in `<gatewayDir>/registry/skills/<id>/`
- [ ] Run `hermit skills sync <id>` — verify the table shows `updated` with the description diff
- [ ] Run `hermit skills list` — verify the new description is reflected
- [ ] On an agent that has the skill enabled and is running, verify `file_read` against the skill's path returns the new content (sandbox refreshed)
- [ ] Run `hermit skills sync all` against a registry with mixed clean/edited skills — verify mix of `updated` and `unchanged`
- [ ] Delete a skill's directory from disk (but leave the DB row), run `hermit skills sync <id>` — verify `missing_on_disk` is reported and the DB row is left intact
- [ ] Try syncing a user-installed skill — verify rejection with a clear error
- [ ] Try syncing a non-existent skill id — verify `not_registered` is reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New `skills sync` CLI command re-reads skill definitions from disk, updates the database, and refreshes running agents with results displayed in a summary table
  * New admin endpoint for skill synchronization with per-skill status tracking and agent refresh capabilities
  * New SDK method to trigger skill syncs and retrieve structured sync results including refresh counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->