### PR TITLE
docs(skills): document hermit skills sync

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -278,6 +278,7 @@ query time (per the `agent_skills` wildcard pattern).
 | `skills list` | List every skill in the registry. |
 | `skills assignments` | Print which skills are enabled for which agents. |
 | `skills scan` | Scan the gateway's skills directory for new skill manifests. |
+| `skills sync [skillId]` | Re-read `SKILL.md` from disk and refresh the DB row + running agents. Pass a skill id to sync one; omit it to sync every registered system skill. |
 | `skills register <skillId>` | Register a skill (requires `--name`, `--description`, `--path`). |
 | `skills delete <skillId>` | Remove a skill from the registry. |
 | `skills enable <skillId>` | Enable a skill (`--agent <id>` or `--all`). |
@@ -288,6 +289,8 @@ hermit skills scan
 hermit skills enable code-review --all
 hermit skills disable code-review --agent agent_oncall
 hermit skills assignments
+hermit skills sync code-review        # after editing its SKILL.md on disk
+hermit skills sync                    # rescan every registered system skill
 ```
 
 ---

--- a/docs/manual/08-skills.md
+++ b/docs/manual/08-skills.md
@@ -76,6 +76,11 @@ hermit skills scan
 # Register a new skill (reads SKILL.md frontmatter).
 hermit skills register my-skill --path ./skills/my-skill
 
+# Re-read SKILL.md after editing it on disk. Refreshes the description
+# stored in the DB and the copy each running agent sees in its sandbox.
+hermit skills sync my-skill            # one skill
+hermit skills sync                     # every registered system skill
+
 # Enable a skill for one agent.
 hermit skills enable standup-digest --agent main
 
@@ -196,6 +201,24 @@ hermit skills disable old-skill --all
 ```
 
 This does not delete the skill from the registry; it just stops it from being available on the selected agents. To delete entirely: `hermit skills delete old-skill`.
+
+---
+
+### 8.7.5 Edit an already-registered skill
+
+You edited `SKILL.md` (or a helper script) under the gateway's skills directory and want the change to take effect without re-registering:
+
+```bash
+hermit skills sync weekly-retro
+```
+
+`sync` re-reads the frontmatter, updates the description stored in the DB, and re-copies the skill folder into every running agent that has the skill enabled. To rescan every system skill at once, drop the argument:
+
+```bash
+hermit skills sync
+```
+
+The output lists each skill's outcome — `updated` (DB row changed), `unchanged` (DB already matched), `missing_on_disk` (folder gone), or `not_registered` (id not in the registry).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #167 — documents the new `hermit skills sync` command.

- `docs/cli.md` — adds the row to the `hermit skills` subcommand table and two example invocations.
- `docs/manual/08-skills.md` — adds `sync` to the `hermit skills` command list (§8.3) and a new §8.7.5 recipe for editing an already-registered skill in place, including the action outcomes the user sees.

## Test plan

- [ ] Review rendered diff in both files
- [ ] Verify the new manual recipe matches the actual command output (`updated` / `unchanged` / `missing_on_disk` / `not_registered`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented new `hermit skills sync` command for refreshing skill definitions from disk
  * Added usage examples for syncing individual or all system skills
  * Included explanation of command output statuses and how to apply changes to registered skills

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->