### PR TITLE
chore(npm): expand keywords for discovery

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,10 +13,22 @@
   },
   "keywords": [
     "ai",
+    "ai-agents",
     "agent",
+    "agent-framework",
+    "agent-platform",
+    "agent-infrastructure",
+    "autonomous-agents",
+    "multi-agent",
+    "multi-agent-systems",
     "llm",
-    "cli",
-    "multi-agent"
+    "mcp",
+    "model-context-protocol",
+    "self-hosted",
+    "sandbox",
+    "postgres",
+    "typescript",
+    "cli"
   ],
   "bin": {
     "openhermit": "dist/cli.js",


### PR DESCRIPTION
Mirrors the newly-expanded GitHub repo topics into the published `openhermit` package's `keywords` array, so npm search (separate from GitHub search) surfaces the project for category terms people actually type.

Before: `ai, agent, llm, cli, multi-agent` (5)
After: adds `ai-agents`, `agent-framework`, `agent-platform`, `agent-infrastructure`, `autonomous-agents`, `multi-agent-systems`, `mcp`, `model-context-protocol`, `self-hosted`, `sandbox`, `postgres`, `typescript`.

Part of a repo-discovery pass — GitHub repo Topics and About/Website are already updated directly (not git-tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata keywords to enhance discoverability and better reflect the package's alignment with AI and agent framework technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->