### PR TITLE
chore(cli): bump to 0.9.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Publishes the expanded npm `keywords` from #171 so the npm registry listing and `npm search` reflect the new discovery terms (ai-agents, agent-framework, agent-platform, mcp, self-hosted, etc.).

No functional changes — version bump only.

Release steps after merge: `npm login` then `npm publish -w openhermit` (runs `prepublishOnly` → bundle + copy assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version updated to 0.9.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->