### PR TITLE
chore(whatsapp): bump to 0.2.0

### DIFF
--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-whatsapp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenHermit channel plugin for WhatsApp Web via Baileys. Text-only v1.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Publishes the DB-backed auth-state rewrite from #162 as `@openhermit/channel-whatsapp@0.2.0`.

**Breaking change** (hence minor bump pre-1.0):
- Filesystem `auth_dir` is no longer supported (legacy folders are best-effort deleted on start).
- The channel now requires a gateway with DB-backed channel credentials: `openhermit >= 0.9.1`, plus `DATABASE_URL` and `OPENHERMIT_SECRETS_KEY`.
- Existing WhatsApp channels must re-link via QR.

**Publish order matters:** ship `openhermit@0.9.1` (which carries the gateway `credentialStore` wiring) *before* this, or the channel will error on start against an older gateway.

Release after merge: `npm publish -w @openhermit/channel-whatsapp` (publishConfig.access is already `public`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * WhatsApp channel package version updated to 0.2.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->