### PR TITLE
feat(whatsapp): inbound + outbound media attachments

### DIFF
--- a/apps/channels/whatsapp/README.md
+++ b/apps/channels/whatsapp/README.md
@@ -4,15 +4,22 @@
 through WhatsApp Web using [Baileys](https://baileys.wiki/). The plugin
 is **not bundled** in the CLI; operators install and load it explicitly.
 
-## v1 scope
+## Scope
 
 - WhatsApp Web / Linked Devices auth through a QR setup wizard.
 - Text inbound and outbound for direct chats and groups.
-- Captions on image / video / document messages are treated as text.
+- **Media inbound**: image / video / document attachments are downloaded and
+  uploaded to the agent as attachments (images are available as vision input);
+  captions ride along as text. Voice / audio notes are transcribed via the
+  agent's STT, and replies to a voice note are spoken back as a voice note when
+  the agent's TTS is configured.
+- **Media outbound**: the agent's `attachment_send` deliveries are routed to the
+  matching WhatsApp send (image / video / document / voice note).
 - Optional allow-lists (`allowed_senders`, `allowed_group_jids`).
 - `/new` starts a fresh OpenHermit session for the current chat.
-- No media delivery, reactions, read receipts, pairing approvals,
-  multi-account routing, or history injection yet.
+- Media larger than the 25 MiB attachment cap is skipped.
+- No reactions, read receipts, pairing approvals, multi-account routing, or
+  history injection yet.
 
 ## Loading the plugin
 

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openhermit/channel-whatsapp",
   "version": "0.3.0",
-  "description": "OpenHermit channel plugin for WhatsApp Web via Baileys. Text-only v1.",
+  "description": "OpenHermit channel plugin for WhatsApp Web via Baileys with text, media, and voice-note support.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-whatsapp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenHermit channel plugin for WhatsApp Web via Baileys. Text-only v1.",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/whatsapp/src/bot.ts
+++ b/apps/channels/whatsapp/src/bot.ts
@@ -1,6 +1,9 @@
-import type { WhatsAppBridge, WhatsAppIncomingMessage } from './bridge.js';
+import type { WhatsAppBridge, WhatsAppIncomingMedia, WhatsAppIncomingMessage } from './bridge.js';
 import { cleanBotCommandText, isBroadcastJid, isGroupJid, jidToPhone, normalizeJid } from './jid.js';
 import type { RawWhatsAppMessage, WhatsAppApi } from './whatsapp-api.js';
+
+/** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
 
 export interface WhatsAppBotOptions {
   whatsapp: WhatsAppApi;
@@ -30,12 +33,86 @@ export class WhatsAppBot {
     try {
       const event = toIncomingMessage(message, this.options.whatsapp.botJid);
       if (!event) return;
+      // Download media bytes here (transport layer); the bridge handles the
+      // agent-side upload / transcription.
+      if (event.media) {
+        try {
+          const bytes = await this.options.whatsapp.downloadMedia(message);
+          if (bytes.length > MAX_MEDIA_BYTES) {
+            this.log(`dropping oversized media (${bytes.length} bytes) from ${event.chatJid}`);
+            delete event.media;
+          } else {
+            event.media.bytes = bytes;
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log(`media download failed for ${event.chatJid}: ${msg}`);
+          delete event.media;
+        }
+        // Media-only message whose download failed: nothing to forward.
+        if (!event.media && !event.text) return;
+      }
       await this.options.bridge.handleIncoming(event);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(`error handling message: ${msg}`);
     }
   }
+}
+
+/** Map a MIME type to a coarse attachment kind for routing. */
+function mediaKindFromMime(mime: string): WhatsAppIncomingMedia['kind'] {
+  if (mime.startsWith('image/')) return 'image';
+  if (mime.startsWith('video/')) return 'video';
+  if (mime.startsWith('audio/')) return 'audio';
+  return 'document';
+}
+
+/** Best-effort filename for media that lacks one, derived from the MIME type. */
+function synthFilename(kind: WhatsAppIncomingMedia['kind'], mime: string): string {
+  const ext = mime.split(';')[0]?.split('/')[1]?.replace(/[^a-z0-9]+/gi, '') || 'bin';
+  return `${kind}.${ext}`;
+}
+
+/**
+ * Detect an inbound media node (image/video/document/audio) and return its
+ * metadata. Bytes are downloaded later by the bot. Returns undefined for
+ * text-only messages.
+ */
+export function extractMedia(message: RawWhatsAppMessage): WhatsAppIncomingMedia | undefined {
+  const content = unwrapMessageContent(message.message);
+  if (!content || typeof content !== 'object') return undefined;
+
+  const image = content.imageMessage;
+  if (image) {
+    const mime = typeof image.mimetype === 'string' ? image.mimetype : 'image/jpeg';
+    return { kind: 'image', mimeType: mime, filename: synthFilename('image', mime), isVoice: false };
+  }
+  const video = content.videoMessage;
+  if (video) {
+    const mime = typeof video.mimetype === 'string' ? video.mimetype : 'video/mp4';
+    return { kind: 'video', mimeType: mime, filename: synthFilename('video', mime), isVoice: false };
+  }
+  const audio = content.audioMessage;
+  if (audio) {
+    const mime = typeof audio.mimetype === 'string' ? audio.mimetype : 'audio/ogg';
+    return {
+      kind: 'audio',
+      mimeType: mime,
+      filename: synthFilename('audio', mime),
+      isVoice: audio.ptt === true,
+    };
+  }
+  const doc = content.documentMessage;
+  if (doc) {
+    const mime = typeof doc.mimetype === 'string' ? doc.mimetype : 'application/octet-stream';
+    const filename =
+      typeof doc.fileName === 'string' && doc.fileName.trim()
+        ? doc.fileName.trim()
+        : synthFilename('document', mime);
+    return { kind: mediaKindFromMime(mime), mimeType: mime, filename, isVoice: false };
+  }
+  return undefined;
 }
 
 function unwrapMessageContent(content: any): any {
@@ -123,7 +200,9 @@ export function toIncomingMessage(
   if (isBroadcastJid(chatJidRaw)) return undefined;
 
   const text = extractText(message);
-  if (!text) return undefined;
+  const media = extractMedia(message);
+  // Forward only if there's text/caption or a media attachment to download.
+  if (!text && !media) return undefined;
 
   const chatJid = normalizeJid(chatJidRaw);
   const isGroup = isGroupJid(chatJid);
@@ -132,7 +211,8 @@ export function toIncomingMessage(
       ? message.key.participant
       : chatJid,
   );
-  const mentioned = isGroup ? isBotMentioned(message, botJid, text) : true;
+  // Mention detection runs over the caption text (empty for media-only).
+  const mentioned = isGroup ? isBotMentioned(message, botJid, text ?? '') : true;
 
   return {
     chatJid,
@@ -142,9 +222,10 @@ export function toIncomingMessage(
       ? { senderName: message.pushName.trim() }
       : {}),
     ...(typeof message.key?.id === 'string' ? { messageId: message.key.id } : {}),
-    text,
+    text: text ?? '',
     isGroup,
     mentioned,
-    commandText: cleanBotCommandText(text, botJid),
+    commandText: cleanBotCommandText(text ?? '', botJid),
+    ...(media ? { media } : {}),
   };
 }

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -22,6 +22,30 @@ import type { WhatsAppApi } from './whatsapp-api.js';
 
 const AGENT_RESPONSE_TIMEOUT_MS = 60_000;
 
+/** Hard cap on TTS input length. Above this, fall back to text. */
+const VOICE_MAX_TEXT_LENGTH = 1500;
+
+/**
+ * Decide whether a reply is fit for voice delivery — short, prose-like
+ * text only. Code blocks and huge volumes are awkward to listen to.
+ */
+const shouldSpeak = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > VOICE_MAX_TEXT_LENGTH) return false;
+  if (trimmed.includes('```')) return false;
+  return true;
+};
+
+/** Inbound media attached to a WhatsApp message; bytes filled in by the bot. */
+export interface WhatsAppIncomingMedia {
+  kind: 'image' | 'audio' | 'video' | 'document';
+  mimeType: string;
+  filename: string;
+  isVoice: boolean;
+  bytes?: Uint8Array;
+}
+
 export interface WhatsAppIncomingMessage {
   chatJid: string;
   senderJid: string;
@@ -32,6 +56,7 @@ export interface WhatsAppIncomingMessage {
   isGroup: boolean;
   mentioned: boolean;
   commandText?: string;
+  media?: WhatsAppIncomingMedia;
 }
 
 export interface WhatsAppBridgeOptions {
@@ -128,11 +153,52 @@ export class WhatsAppBridge implements ChannelOutbound {
     const sessionId = await this.getSessionId(event.chatJid);
     await this.ensureSession(sessionId, event);
 
+    // Resolve media: inbound voice/audio is transcribed via STT; other media
+    // is uploaded as a durable attachment so the agent can read/see it.
+    let postText = event.text;
+    let attachments: { type: 'file'; id: string }[] | undefined;
+    let inboundWasVoice = false;
+    if (event.media?.bytes) {
+      if (event.media.kind === 'audio') {
+        try {
+          const { text } = await this.client.transcribeAudio({
+            bytes: event.media.bytes,
+            mimeType: event.media.mimeType,
+          });
+          const transcript = text.trim();
+          if (transcript) {
+            inboundWasVoice = true;
+            postText = `[Voice message, transcribed. Your reply will be converted to speech, so respond in plain prose without code blocks, markdown formatting, or long lists.]\n\n${transcript}`;
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log(`stt failed for chat ${event.chatJid}: ${msg}`);
+          await this.send({ sessionId, to: event.chatJid, text: `Voice transcription failed: ${msg}` });
+          return;
+        }
+      } else {
+        try {
+          const blob = new Blob([event.media.bytes as unknown as BlobPart], {
+            type: event.media.mimeType,
+          });
+          const att = await this.client.uploadAttachment(sessionId, blob, event.media.filename);
+          attachments = [{ type: 'file', id: att.id! }];
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log(`attachment upload failed for chat ${event.chatJid}: ${msg}`);
+        }
+      }
+    }
+
+    // Nothing usable extracted (e.g. media-only message whose upload failed).
+    if (!postText && !attachments) return;
+
     const senderChannelUserId = event.senderNumber ?? event.senderJid;
     const postOpts = event.isGroup ? undefined : { channelUserId: senderChannelUserId };
     const postResult = await this.client.postMessage(sessionId, {
-      text: event.text,
+      text: postText,
       mentioned: event.mentioned,
+      ...(attachments ? { attachments } : {}),
       sender: {
         channel: 'whatsapp',
         channelUserId: senderChannelUserId,
@@ -147,12 +213,77 @@ export class WhatsAppBridge implements ChannelOutbound {
 
     if (!(postResult as { triggered?: boolean }).triggered) return;
 
-    const result = await this.waitForAgentResponse(sessionId);
+    const result = await this.waitForAgentResponse(sessionId, event.chatJid);
     if (result.error && !result.text) {
       await this.send({ sessionId, to: event.chatJid, text: `Error: ${result.error}` });
     } else if (result.text) {
+      if (inboundWasVoice && (await this.trySendVoiceReply(event.chatJid, result.text))) {
+        return;
+      }
       await this.send({ sessionId, to: event.chatJid, text: result.text });
     }
+  }
+
+  /**
+   * Attempt to deliver `text` as a WhatsApp voice note via the agent's TTS.
+   * Returns `true` on success; callers fall back to text on `false`.
+   */
+  private async trySendVoiceReply(chatJid: string, text: string): Promise<boolean> {
+    if (!shouldSpeak(text)) return false;
+    try {
+      const result = await this.client.synthesizeAudio({ text, outputMimeType: 'audio/ogg' });
+      await this.whatsapp.sendMedia(chatJid, {
+        bytes: result.bytes,
+        mimeType: 'audio/ogg',
+        kind: 'audio',
+        filename: 'reply.ogg',
+      });
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`tts failed for chat ${chatJid}: ${msg}`);
+      return false;
+    }
+  }
+
+  /**
+   * Translate an outbound `attachment` SSE event into a WhatsApp media send.
+   * Bytes are pulled lazily from the agent-local API so they never ride the
+   * SSE channel inline.
+   */
+  private async deliverAttachment(
+    target: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const sessionId = String(payload.sessionId ?? '');
+    const attachmentId = String(payload.attachmentId ?? '');
+    if (!sessionId || !attachmentId) {
+      this.log('attachment event missing sessionId/attachmentId');
+      return;
+    }
+    const caption =
+      typeof payload.caption === 'string' && payload.caption.length > 0
+        ? payload.caption
+        : undefined;
+    const hintedKind = String(payload.kind ?? '');
+    const hintedName =
+      typeof payload.name === 'string' && payload.name.length > 0 ? payload.name : undefined;
+
+    const { bytes, mimeType, filename, kind: resolvedKind } =
+      await this.client.downloadAttachmentBytes(sessionId, attachmentId);
+    const kind = (hintedKind || resolvedKind || 'document') as
+      | 'image'
+      | 'audio'
+      | 'video'
+      | 'document';
+
+    await this.whatsapp.sendMedia(target, {
+      bytes,
+      mimeType,
+      kind,
+      filename: hintedName ?? filename ?? 'attachment',
+      ...(caption ? { caption } : {}),
+    });
   }
 
   async handleNewSession(chatJid: string): Promise<void> {
@@ -220,7 +351,7 @@ export class WhatsAppBridge implements ChannelOutbound {
     }, openOpts);
   }
 
-  private async waitForAgentResponse(sessionId: string): Promise<TurnResult> {
+  private async waitForAgentResponse(sessionId: string, target: string): Promise<TurnResult> {
     const eventsUrl = this.client.buildEventsUrl(sessionId);
     const lastEventId = this.lastEventIds.get(sessionId) ?? 0;
     const controller = new AbortController();
@@ -298,6 +429,16 @@ export class WhatsAppBridge implements ChannelOutbound {
           }
           if (frame.event === 'error') {
             error = String(payload.message ?? 'Unknown error');
+            continue;
+          }
+          if (frame.event === 'attachment') {
+            try {
+              await this.deliverAttachment(target, payload);
+            } catch (err) {
+              this.log(
+                `attachment delivery failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
             continue;
           }
           if (frame.event === 'agent_end') {

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -173,7 +173,11 @@ export class WhatsAppBridge implements ChannelOutbound {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           this.log(`stt failed for chat ${event.chatJid}: ${msg}`);
-          await this.send({ sessionId, to: event.chatJid, text: `Voice transcription failed: ${msg}` });
+          await this.send({
+            sessionId,
+            to: event.chatJid,
+            text: "Sorry, I couldn't transcribe that voice message. Please try again or send text.",
+          });
           return;
         }
       } else {

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -1,5 +1,6 @@
 import makeWASocket, {
   DisconnectReason,
+  downloadMediaMessage,
 } from 'baileys';
 import type { ChannelCredentialStore } from '@openhermit/protocol';
 import pino from 'pino';
@@ -9,6 +10,15 @@ import { useDbAuthState } from './db-auth-state.js';
 
 export type RawWhatsAppMessage = Record<string, any>;
 export type RawWhatsAppMessageHandler = (message: RawWhatsAppMessage) => void | Promise<void>;
+
+/** Outbound media payload routed to the right Baileys message content. */
+export interface WhatsAppOutboundMedia {
+  bytes: Uint8Array;
+  mimeType: string;
+  kind: 'image' | 'audio' | 'video' | 'document';
+  filename: string;
+  caption?: string;
+}
 
 export interface WhatsAppApiOptions {
   authProfile: string;
@@ -65,6 +75,57 @@ export class WhatsAppApi {
     const sent = await this.sock.sendMessage(jid, { text });
     const messageId = sent?.key?.id;
     return typeof messageId === 'string' ? { messageId } : {};
+  }
+
+  /**
+   * Send a media attachment. The `kind` picks the Baileys content shape
+   * (image/video/document/audio). ogg/opus audio is sent as a push-to-talk
+   * voice note; WhatsApp audio messages do not carry captions.
+   */
+  async sendMedia(target: string, media: WhatsAppOutboundMedia): Promise<{ messageId?: string }> {
+    if (!this.sock) throw new Error('WhatsApp socket is not connected');
+    const jid = targetToJid(target);
+    const buffer = Buffer.from(media.bytes);
+    const caption = media.caption && media.caption.length > 0 ? media.caption : undefined;
+
+    let content: Record<string, unknown>;
+    if (media.kind === 'image') {
+      content = { image: buffer, mimetype: media.mimeType, ...(caption ? { caption } : {}) };
+    } else if (media.kind === 'video') {
+      content = { video: buffer, mimetype: media.mimeType, ...(caption ? { caption } : {}) };
+    } else if (media.kind === 'audio') {
+      const ptt = media.mimeType === 'audio/ogg' || media.mimeType === 'audio/opus';
+      content = { audio: buffer, mimetype: media.mimeType, ...(ptt ? { ptt: true } : {}) };
+    } else {
+      content = {
+        document: buffer,
+        mimetype: media.mimeType,
+        fileName: media.filename,
+        ...(caption ? { caption } : {}),
+      };
+    }
+
+    const sent = await this.sock.sendMessage(jid, content);
+    const messageId = sent?.key?.id;
+    return typeof messageId === 'string' ? { messageId } : {};
+  }
+
+  /**
+   * Download the media bytes for an inbound message via Baileys. `rawMessage`
+   * must be the full `WAMessage` (key + message) delivered by `messages.upsert`.
+   */
+  async downloadMedia(rawMessage: RawWhatsAppMessage): Promise<Buffer> {
+    if (!this.sock) throw new Error('WhatsApp socket is not connected');
+    const buffer = await downloadMediaMessage(
+      rawMessage as never,
+      'buffer',
+      {},
+      {
+        logger: pino({ level: 'silent' }) as never,
+        reuploadRequest: this.sock.updateMediaMessage,
+      },
+    );
+    return buffer;
   }
 
   private async connect(): Promise<void> {

--- a/apps/channels/whatsapp/src/whatsapp-api.ts
+++ b/apps/channels/whatsapp/src/whatsapp-api.ts
@@ -94,7 +94,9 @@ export class WhatsAppApi {
     } else if (media.kind === 'video') {
       content = { video: buffer, mimetype: media.mimeType, ...(caption ? { caption } : {}) };
     } else if (media.kind === 'audio') {
-      const ptt = media.mimeType === 'audio/ogg' || media.mimeType === 'audio/opus';
+      // Strip MIME parameters (e.g. `audio/ogg; codecs=opus`) before matching.
+      const baseMime = media.mimeType.split(';', 1)[0]!.trim().toLowerCase();
+      const ptt = baseMime === 'audio/ogg' || baseMime === 'audio/opus';
       content = { audio: buffer, mimetype: media.mimeType, ...(ptt ? { ptt: true } : {}) };
     } else {
       content = {

--- a/apps/channels/whatsapp/test/bot.test.ts
+++ b/apps/channels/whatsapp/test/bot.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  extractMedia,
   extractMentionedJids,
   extractText,
   isBotMentioned,
@@ -60,6 +61,60 @@ test('toIncomingMessage drops self and broadcast messages', () => {
     }, '1555@s.whatsapp.net'),
     undefined,
   );
+});
+
+test('extractMedia detects image, video, voice, and document nodes', () => {
+  assert.deepEqual(extractMedia({ message: { imageMessage: { mimetype: 'image/png' } } }), {
+    kind: 'image',
+    mimeType: 'image/png',
+    filename: 'image.png',
+    isVoice: false,
+  });
+  assert.deepEqual(extractMedia({ message: { videoMessage: { mimetype: 'video/mp4' } } }), {
+    kind: 'video',
+    mimeType: 'video/mp4',
+    filename: 'video.mp4',
+    isVoice: false,
+  });
+  assert.deepEqual(extractMedia({ message: { audioMessage: { mimetype: 'audio/ogg', ptt: true } } }), {
+    kind: 'audio',
+    mimeType: 'audio/ogg',
+    filename: 'audio.ogg',
+    isVoice: true,
+  });
+  assert.deepEqual(
+    extractMedia({ message: { documentMessage: { mimetype: 'application/pdf', fileName: 'report.pdf' } } }),
+    { kind: 'document', mimeType: 'application/pdf', filename: 'report.pdf', isVoice: false },
+  );
+  assert.equal(extractMedia({ message: { conversation: 'hi' } }), undefined);
+});
+
+test('toIncomingMessage forwards a media-only message with empty text', () => {
+  const event = toIncomingMessage({
+    key: { id: 'm1', remoteJid: '15551234567@s.whatsapp.net' },
+    message: { imageMessage: { mimetype: 'image/jpeg' } },
+  }, '1555@s.whatsapp.net');
+
+  assert.ok(event);
+  assert.equal(event.text, '');
+  assert.equal(event.mentioned, true);
+  assert.deepEqual(event.media, {
+    kind: 'image',
+    mimeType: 'image/jpeg',
+    filename: 'image.jpeg',
+    isVoice: false,
+  });
+});
+
+test('toIncomingMessage attaches media alongside a caption', () => {
+  const event = toIncomingMessage({
+    key: { id: 'm2', remoteJid: '15551234567@s.whatsapp.net' },
+    message: { imageMessage: { mimetype: 'image/jpeg', caption: 'look at this' } },
+  }, '1555@s.whatsapp.net');
+
+  assert.ok(event);
+  assert.equal(event.text, 'look at this');
+  assert.equal(event.media?.kind, 'image');
 });
 
 test('toIncomingMessage builds group event with mention state', () => {

--- a/apps/channels/whatsapp/test/whatsapp-api.test.ts
+++ b/apps/channels/whatsapp/test/whatsapp-api.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { WhatsAppApi } from '../src/whatsapp-api.js';
+
+/**
+ * Build a WhatsAppApi with a stubbed socket so we can assert the Baileys
+ * message content `sendMedia` produces for each kind without a real connection.
+ */
+function apiWithFakeSock(): { api: WhatsAppApi; sends: Array<{ jid: string; content: any }> } {
+  const sends: Array<{ jid: string; content: any }> = [];
+  const api = new WhatsAppApi({
+    authProfile: 'default',
+    credentialStore: {
+      get: async () => undefined,
+      list: async () => ({}),
+      set: async () => undefined,
+      delete: async () => undefined,
+      replace: async () => undefined,
+      clear: async () => undefined,
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (api as any).sock = {
+    sendMessage: async (jid: string, content: any) => {
+      sends.push({ jid, content });
+      return { key: { id: 'mid-1' } };
+    },
+  };
+  return { api, sends };
+}
+
+const bytes = Uint8Array.from([1, 2, 3]);
+
+test('sendMedia routes image with caption', async () => {
+  const { api, sends } = apiWithFakeSock();
+  await api.sendMedia('15551234567@s.whatsapp.net', {
+    bytes,
+    mimeType: 'image/png',
+    kind: 'image',
+    filename: 'pic.png',
+    caption: 'hi',
+  });
+  assert.equal(sends.length, 1);
+  assert.equal(sends[0]!.content.mimetype, 'image/png');
+  assert.equal(sends[0]!.content.caption, 'hi');
+  assert.ok(sends[0]!.content.image);
+});
+
+test('sendMedia sends ogg audio as a push-to-talk voice note without caption', async () => {
+  const { api, sends } = apiWithFakeSock();
+  await api.sendMedia('15551234567@s.whatsapp.net', {
+    bytes,
+    mimeType: 'audio/ogg',
+    kind: 'audio',
+    filename: 'reply.ogg',
+    caption: 'ignored',
+  });
+  assert.equal(sends[0]!.content.ptt, true);
+  assert.ok(sends[0]!.content.audio);
+  assert.equal(sends[0]!.content.caption, undefined);
+});
+
+test('sendMedia sends document with fileName', async () => {
+  const { api, sends } = apiWithFakeSock();
+  await api.sendMedia('15551234567@s.whatsapp.net', {
+    bytes,
+    mimeType: 'application/pdf',
+    kind: 'document',
+    filename: 'report.pdf',
+  });
+  assert.equal(sends[0]!.content.fileName, 'report.pdf');
+  assert.ok(sends[0]!.content.document);
+});

--- a/apps/channels/whatsapp/test/whatsapp-api.test.ts
+++ b/apps/channels/whatsapp/test/whatsapp-api.test.ts
@@ -61,6 +61,17 @@ test('sendMedia sends ogg audio as a push-to-talk voice note without caption', a
   assert.equal(sends[0]!.content.caption, undefined);
 });
 
+test('sendMedia treats ogg/opus with MIME params as a voice note', async () => {
+  const { api, sends } = apiWithFakeSock();
+  await api.sendMedia('15551234567@s.whatsapp.net', {
+    bytes,
+    mimeType: 'audio/ogg; codecs=opus',
+    kind: 'audio',
+    filename: 'note.ogg',
+  });
+  assert.equal(sends[0]!.content.ptt, true);
+});
+
 test('sendMedia sends document with fileName', async () => {
   const { api, sends } = apiWithFakeSock();
   await api.sendMedia('15551234567@s.whatsapp.net', {

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -22,7 +22,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 |----------|---------|------------|
 | Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard |
 | WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
-| WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text-only v1 |
+| WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text + media (image/video/document/voice) |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
 
@@ -185,7 +185,7 @@ WhatsApp (external plugin):
 
 - WhatsApp Web / Linked Devices through Baileys; no Twilio or WhatsApp Cloud API path
 - QR setup wizard stores Baileys credentials in encrypted DB channel credentials and persists `auth_profile` on the channel row
-- text-only v1; captions are treated as text, media-only messages are ignored
+- media inbound (image/video/document uploaded as attachments, captions kept as text) and outbound (`attachment_send` → image/video/document/voice note); voice notes are transcribed via STT and replies spoken via TTS when configured; media over the 25 MiB cap is skipped
 - DMs are open by default unless `allowed_senders` is configured
 - groups are default-deny unless `allowed_group_jids` is configured; allowed group turns trigger only on mention
 - status, broadcast, and own linked-account messages are ignored

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -25,7 +25,7 @@ A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, 
 **Installable as npm packages** (add via `hermit channel install`):
 
 - **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text-only v0.
-- **WhatsApp** — `@openhermit/channel-whatsapp`. Link a WhatsApp account through WhatsApp Web / Linked Devices using a QR-scan wizard. Text-only v1.
+- **WhatsApp** — `@openhermit/channel-whatsapp`. Link a WhatsApp account through WhatsApp Web / Linked Devices using a QR-scan wizard. Supports text plus media (images/video/documents as attachments; voice notes transcribed).
 
 Each non-CLI channel needs a credential (a bot token, app secret, or linked-device auth state). Operator-entered tokens are stored as secrets — see [Chapter 18](18-secrets.md). Channel-owned auth state, such as WhatsApp Web credentials, is stored in encrypted channel credential rows.
 
@@ -80,7 +80,7 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Install with `hermit channel install @openhermit/channel-whatsapp`, then restart the gateway.
 - Pair through *Manage → Channels → Add channel → WhatsApp*: scan the QR code from WhatsApp → Linked devices.
 - Baileys auth state is stored in encrypted DB channel credentials; the channel row keeps only `auth_profile` plus allow-list settings. Legacy `auth_dir` folders are no longer used.
-- Text-only in v1 — captions are treated as text, media-only messages are ignored.
+- Media: inbound images/video/documents are uploaded as attachments (images become vision input) with captions kept as text; voice notes are transcribed via STT and replies spoken via TTS when voice is configured. The agent can send media back via `attachment_send`. Attachments over 25 MiB are skipped.
 
 ### Web / CLI
 


### PR DESCRIPTION
First channel in the attachment-support rollout (plan: WhatsApp → Discord → Slack → Telegram inbound).

WhatsApp was text-only — inbound media was dropped (only captions kept) and the agent couldn't send files. This wires the channel to the **already-complete** core attachment infrastructure in both directions. No core/protocol/gateway changes.

## Inbound (WhatsApp → agent)
- Images / video / documents → downloaded via Baileys `downloadMediaMessage`, uploaded as session attachments (images become **vision input** automatically), captions kept as text.
- Voice / audio notes → transcribed via `client.transcribeAudio`; replies to a voice note are spoken back as a native WhatsApp voice note via `client.synthesizeAudio` when TTS is configured (mirrors Telegram).
- **Media-only messages now trigger the agent** instead of being silently dropped.
- Media over the 25 MiB attachment cap is skipped (logged).

## Outbound (agent → WhatsApp)
- The agent's `attachment_send` deliveries (SSE `attachment` event) are routed to the matching Baileys send: image / video / document, and `ogg`/`opus` audio as a push-to-talk voice note.

## Implementation
- `whatsapp-api.ts`: new `sendMedia` (outbound routing) + `downloadMedia` (Baileys download).
- `bot.ts`: new `extractMedia`; downloads bytes; forwards media-only messages.
- `bridge.ts`: STT/TTS path, `uploadAttachment` + `postMessage({attachments})`, and an `attachment` case in the SSE loop.
- Reuses SDK `uploadAttachment`, `postMessage({attachments})`, `downloadAttachmentBytes`, `transcribeAudio`, `synthesizeAudio`.

## Tests
35 unit tests pass (added `extractMedia`, media-only `toIncomingMessage`, and `sendMedia` routing coverage).

Bumps `@openhermit/channel-whatsapp` 0.2.0 → 0.3.0. Docs updated (README, channel-adapter, manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp channel supports media attachments (images, video, documents) with captions preserved; images are available as vision inputs.
  * Voice notes are transcribed to text and agent replies can be sent back as voice (when TTS is enabled).
  * Outbound attachment sends route to WhatsApp, and media-only messages are suppressed if download fails.

* **Documentation**
  * Updated docs and README to describe media/voice support, 25 MiB attachment cap, fresh-session `/new`, optional allow-list, and unsupported platform features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->