### PR TITLE
chore(cli): bump to 0.9.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,7 +242,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.9.0",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",


### PR DESCRIPTION
Ships the **bundled** channel media support in the published `openhermit` CLI:
- Discord attachments (#175)
- Slack attachments (#176)
- Telegram inbound media (#177)

These three channels are `private`/bundled, so they only reach users via a CLI release. The gateway `optionalDependencies` pins are now all `0.3.0`, so this build bundles the updated adapters.

Also syncs the stale `package-lock.json` cli entry (`0.9.0` → `0.9.2`) left behind by the earlier 0.9.1 bump.

Release after merge:
```
npm run build
npm publish -w openhermit
```

Note: WhatsApp (#174) is a separately-published package and is already out as `@openhermit/channel-whatsapp@0.3.0`. Slack media needs `files:read` + `files:write` bot scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI package version updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->