### PR TITLE
feat(signal): inbound + outbound media attachments

### DIFF
--- a/apps/channels/signal/README.md
+++ b/apps/channels/signal/README.md
@@ -5,9 +5,14 @@ account via [`bbernhard/signal-cli-rest-api`](https://github.com/bbernhard/signa
 The plugin is **not bundled** in the CLI — operators install it
 explicitly when they want Signal support.
 
-## v1 scope
+## Scope
 
-- Text inbound and outbound (no media)
+- Text inbound and outbound
+- **Media**: inbound attachments are downloaded via `GET /v1/attachments/{id}`
+  and uploaded to the agent (images become vision input); audio attachments
+  are transcribed via the agent's STT. Outbound `attachment_send` deliveries
+  go out as `base64_attachments` on `/v2/send`. Attachments over the 25 MiB
+  cap are skipped.
 - DMs and group messages
 - QR-link wizard via `ChannelSetup`
 - Optional allow-lists (`allowed_senders`, `allowed_group_ids`)

--- a/apps/channels/signal/package.json
+++ b/apps/channels/signal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openhermit/channel-signal",
-  "version": "0.1.1",
-  "description": "OpenHermit channel plugin for Signal via signal-cli-rest-api (json-rpc receive WS + QR-link setup wizard).",
+  "version": "0.2.0",
+  "description": "OpenHermit channel plugin for Signal via signal-cli-rest-api (json-rpc receive WS + QR-link setup wizard) with text, media, and voice transcription.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -17,6 +17,16 @@ const AGENT_RESPONSE_TIMEOUT_MS = 60_000;
 /** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
 
+export function buildSignalBase64AttachmentDataUri(
+  mimeType: string,
+  filename: string,
+  bytes: Uint8Array,
+): string {
+  const safeFilename = encodeURIComponent(filename);
+  const b64 = Buffer.from(bytes).toString('base64');
+  return `data:${mimeType};filename=${safeFilename};base64,${b64}`;
+}
+
 export interface ConversationKeyInput {
   sourceUuid?: string;
   sourceNumber?: string;
@@ -255,8 +265,7 @@ export class SignalBridge implements ChannelOutbound {
 
     const { bytes, mimeType, filename } = await this.client.downloadAttachmentBytes(sessionId, attachmentId);
     const name = hintedName ?? filename ?? 'attachment';
-    const b64 = Buffer.from(bytes).toString('base64');
-    const dataUri = `data:${mimeType};filename=${name};base64,${b64}`;
+    const dataUri = buildSignalBase64AttachmentDataUri(mimeType, name, bytes);
     await this.sendChunkToTarget(target, caption, { base64Attachments: [dataUri] });
   }
 

--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -8,11 +8,14 @@ import type {
 } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
-import type { SignalApi, SignalIncomingMessage } from './signal-api.js';
+import type { SendOptions, SignalApi, SignalIncomingMessage } from './signal-api.js';
 import { formatAgentResponse } from './formatting.js';
 import { redactId, redactTarget } from './redact.js';
 
 const AGENT_RESPONSE_TIMEOUT_MS = 60_000;
+
+/** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
 
 export interface ConversationKeyInput {
   sourceUuid?: string;
@@ -52,6 +55,12 @@ export function shouldAcceptSender(
 interface TurnResult {
   text: string | undefined;
   error: string | undefined;
+}
+
+/** Outcome of resolving an inbound message's attachments. */
+interface ResolvedInbound {
+  text: string;
+  attachments?: { type: 'file'; id: string }[];
 }
 
 export interface SignalBridgeOptions {
@@ -108,17 +117,21 @@ export class SignalBridge implements ChannelOutbound {
     }
   }
 
-  private async sendChunkToTarget(target: string, text: string): Promise<{ timestamp: number }> {
+  private async sendChunkToTarget(
+    target: string,
+    text: string,
+    opts?: SendOptions,
+  ): Promise<{ timestamp: number }> {
     if (target.startsWith('signal:group:')) {
-      return this.signal.sendGroupMessage(target.slice('signal:group:'.length), text);
+      return this.signal.sendGroupMessage(target.slice('signal:group:'.length), text, opts);
     }
     if (target.startsWith('signal:uuid:')) {
-      return this.signal.sendDirectMessage(target.slice('signal:uuid:'.length), text);
+      return this.signal.sendDirectMessage(target.slice('signal:uuid:'.length), text, opts);
     }
     if (target.startsWith('signal:')) {
-      return this.signal.sendDirectMessage(target.slice('signal:'.length), text);
+      return this.signal.sendDirectMessage(target.slice('signal:'.length), text, opts);
     }
-    return this.signal.sendDirectMessage(target, text);
+    return this.signal.sendDirectMessage(target, text, opts);
   }
 
   async handleIncoming(msg: SignalIncomingMessage): Promise<void> {
@@ -133,6 +146,11 @@ export class SignalBridge implements ChannelOutbound {
     const senderChannelUserId = msg.sourceUuid ?? msg.sourceNumber ?? 'unknown';
     await this.ensureSession(sessionId, msg, senderChannelUserId);
 
+    // Resolve attachments: audio is transcribed via STT; other media is
+    // uploaded as a durable session attachment (images become vision input).
+    const resolved = await this.resolveInbound(sessionId, msg);
+    if (!resolved.text && !resolved.attachments) return;
+
     const senderName = msg.sourceName;
     // For DMs the sender IS the session user — surface that identity to the
     // gateway via `x-channel-user-id` so tools like identity_link_request
@@ -141,8 +159,9 @@ export class SignalBridge implements ChannelOutbound {
     // body field on each turn), so we don't claim a session-level user.
     const postOpts = msg.groupId ? undefined : { channelUserId: senderChannelUserId };
     const postResult = await this.client.postMessage(sessionId, {
-      text: msg.text,
+      text: resolved.text,
       mentioned: true,
+      ...(resolved.attachments ? { attachments: resolved.attachments } : {}),
       sender: {
         channel: 'signal',
         channelUserId: senderChannelUserId,
@@ -152,12 +171,93 @@ export class SignalBridge implements ChannelOutbound {
 
     if (!(postResult as { triggered?: boolean }).triggered) return;
 
-    const result = await this.waitForAgentResponse(sessionId);
+    const result = await this.waitForAgentResponse(sessionId, key);
     if (result.error && !result.text) {
       await this.send({ sessionId, to: key, text: `Error: ${result.error}` });
     } else if (result.text) {
       await this.send({ sessionId, to: key, text: result.text });
     }
+  }
+
+  /**
+   * Download each inbound Signal attachment and either transcribe it (audio)
+   * or upload it as a durable session attachment (everything else).
+   */
+  private async resolveInbound(
+    sessionId: string,
+    msg: SignalIncomingMessage,
+  ): Promise<ResolvedInbound> {
+    let text = msg.text;
+    const ids: { type: 'file'; id: string }[] = [];
+    const transcripts: string[] = [];
+
+    for (const att of msg.attachments ?? []) {
+      if (att.size && att.size > MAX_MEDIA_BYTES) {
+        this.log(`skipping oversized attachment ${redactId(att.id)} (${att.size} bytes)`);
+        continue;
+      }
+      let bytes: Uint8Array;
+      let contentType: string | undefined;
+      try {
+        const dl = await this.signal.downloadAttachment(att.id, MAX_MEDIA_BYTES);
+        bytes = dl.bytes;
+        contentType = dl.contentType;
+      } catch (err) {
+        this.log(`failed to download attachment ${redactId(att.id)}: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+      const mime = att.contentType ?? contentType ?? 'application/octet-stream';
+      const filename = att.filename ?? `${att.id}.${mime.split(';', 1)[0]!.split('/')[1] ?? 'bin'}`;
+      if (mime.startsWith('audio/')) {
+        try {
+          const { text: transcript } = await this.client.transcribeAudio({ bytes, mimeType: mime });
+          if (transcript.trim()) transcripts.push(transcript.trim());
+        } catch (err) {
+          this.log(`stt failed for ${redactId(att.id)}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } else {
+        try {
+          const blob = new Blob([bytes as unknown as BlobPart], { type: mime });
+          const uploaded = await this.client.uploadAttachment(sessionId, blob, filename);
+          ids.push({ type: 'file', id: uploaded.id! });
+        } catch (err) {
+          this.log(`upload failed for ${redactId(att.id)}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    }
+
+    if (transcripts.length > 0) {
+      const joined = transcripts.join('\n\n');
+      text = text ? `${text}\n\n[Transcribed voice message]\n${joined}` : `[Transcribed voice message]\n${joined}`;
+    }
+
+    return { text, ...(ids.length > 0 ? { attachments: ids } : {}) };
+  }
+
+  /**
+   * Deliver an outbound `attachment` SSE event via signal-cli base64 send.
+   * Bytes are pulled lazily from the agent-local API and base64-encoded.
+   */
+  private async deliverAttachment(
+    target: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const sessionId = String(payload.sessionId ?? '');
+    const attachmentId = String(payload.attachmentId ?? '');
+    if (!sessionId || !attachmentId) {
+      this.log('attachment event missing sessionId/attachmentId');
+      return;
+    }
+    const caption =
+      typeof payload.caption === 'string' && payload.caption.length > 0 ? payload.caption : '';
+    const hintedName =
+      typeof payload.name === 'string' && payload.name.length > 0 ? payload.name : undefined;
+
+    const { bytes, mimeType, filename } = await this.client.downloadAttachmentBytes(sessionId, attachmentId);
+    const name = hintedName ?? filename ?? 'attachment';
+    const b64 = Buffer.from(bytes).toString('base64');
+    const dataUri = `data:${mimeType};filename=${name};base64,${b64}`;
+    await this.sendChunkToTarget(target, caption, { base64Attachments: [dataUri] });
   }
 
   private async getSessionId(
@@ -218,7 +318,7 @@ export class SignalBridge implements ChannelOutbound {
     }, openOpts);
   }
 
-  private async waitForAgentResponse(sessionId: string): Promise<TurnResult> {
+  private async waitForAgentResponse(sessionId: string, target: string): Promise<TurnResult> {
     const eventsUrl = this.client.buildEventsUrl(sessionId);
     const lastEventId = this.lastEventIds.get(sessionId) ?? 0;
     const controller = new AbortController();
@@ -294,6 +394,16 @@ export class SignalBridge implements ChannelOutbound {
           }
           if (frame.event === 'error') {
             error = String(payload.message ?? 'Unknown error');
+            continue;
+          }
+          if (frame.event === 'attachment') {
+            try {
+              await this.deliverAttachment(target, payload);
+            } catch (err) {
+              this.log(
+                `attachment delivery failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
             continue;
           }
           if (frame.event === 'agent_end') {

--- a/apps/channels/signal/src/signal-api.ts
+++ b/apps/channels/signal/src/signal-api.ts
@@ -1,10 +1,21 @@
 import { WebSocket } from 'ws';
 
+/** Bound attachment downloads so a stalled connection can't block the queue. */
+const ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 15_000;
+
 export interface SignalApiOptions {
   httpUrl: string;
   account: string;
   selfUuid?: string;
   fetch?: typeof fetch;
+}
+
+/** An inbound attachment referenced in a Signal dataMessage. */
+export interface SignalAttachment {
+  id: string;
+  contentType?: string;
+  filename?: string;
+  size?: number;
 }
 
 export interface SignalIncomingMessage {
@@ -15,10 +26,17 @@ export interface SignalIncomingMessage {
   groupId?: string;
   timestamp: number;
   isSelf: boolean;
+  attachments?: SignalAttachment[];
 }
 
 export interface SendResult {
   timestamp: number;
+}
+
+/** Optional outbound extras for a send. */
+export interface SendOptions {
+  /** signal-cli-rest-api base64 strings, e.g. `data:<mime>;filename=<n>;base64,<data>`. */
+  base64Attachments?: string[];
 }
 
 export class SignalApi {
@@ -34,15 +52,15 @@ export class SignalApi {
     this.selfUuid = opts.selfUuid;
   }
 
-  async sendDirectMessage(recipient: string, message: string): Promise<SendResult> {
-    return this.send([recipient], message);
+  async sendDirectMessage(recipient: string, message: string, opts?: SendOptions): Promise<SendResult> {
+    return this.send([recipient], message, opts);
   }
 
-  async sendGroupMessage(groupId: string, message: string): Promise<SendResult> {
-    return this.send([groupId], message);
+  async sendGroupMessage(groupId: string, message: string, opts?: SendOptions): Promise<SendResult> {
+    return this.send([groupId], message, opts);
   }
 
-  private async send(recipients: string[], message: string): Promise<SendResult> {
+  private async send(recipients: string[], message: string, opts?: SendOptions): Promise<SendResult> {
     const res = await this.fetchImpl(`${this.httpUrl}/v2/send`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -51,6 +69,9 @@ export class SignalApi {
         recipients,
         message,
         text_mode: 'styled',
+        ...(opts?.base64Attachments && opts.base64Attachments.length > 0
+          ? { base64_attachments: opts.base64Attachments }
+          : {}),
       }),
     });
     if (!res.ok) {
@@ -59,6 +80,65 @@ export class SignalApi {
     }
     const json = (await res.json()) as { timestamp?: number };
     return { timestamp: json.timestamp ?? Date.now() };
+  }
+
+  /**
+   * Download an inbound attachment's bytes by id via `GET /v1/attachments/{id}`.
+   * When `maxBytes` is given the cap is enforced here: an oversized declared
+   * content-length is rejected up front, and the body is streamed and aborted
+   * the moment it crosses the limit.
+   */
+  async downloadAttachment(
+    id: string,
+    maxBytes?: number,
+  ): Promise<{ bytes: Uint8Array; contentType: string | undefined }> {
+    const res = await this.fetchImpl(`${this.httpUrl}/v1/attachments/${encodeURIComponent(id)}`, {
+      signal: AbortSignal.timeout(ATTACHMENT_DOWNLOAD_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`signal-cli-rest-api attachment download failed (${res.status})`);
+    }
+    const contentType = res.headers.get('content-type') ?? undefined;
+
+    if (maxBytes !== undefined) {
+      const declared = Number(res.headers.get('content-length'));
+      if (Number.isFinite(declared) && declared > maxBytes) {
+        throw new Error(`Signal attachment exceeds the ${maxBytes}-byte limit (content-length ${declared})`);
+      }
+    }
+
+    if (maxBytes === undefined || !res.body) {
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
+        throw new Error(`Signal attachment exceeds the ${maxBytes}-byte limit (${bytes.byteLength} bytes)`);
+      }
+      return { bytes, contentType };
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        total += value.byteLength;
+        if (total > maxBytes) {
+          throw new Error(`Signal attachment exceeds the ${maxBytes}-byte limit`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { bytes: out, contentType };
   }
 
   async sendTyping(recipient: string): Promise<void> {
@@ -159,7 +239,9 @@ export class SignalApi {
     const data = env.dataMessage as Record<string, unknown> | undefined;
     if (!data) return null;
     const text = typeof data.message === 'string' ? data.message : '';
-    if (!text) return null;
+    const attachments = parseAttachments(data.attachments);
+    // Forward only if there's text or at least one attachment to download.
+    if (!text && attachments.length === 0) return null;
 
     const sourceUuid = typeof env.sourceUuid === 'string' ? env.sourceUuid : undefined;
     const sourceNumber = typeof env.sourceNumber === 'string' ? env.sourceNumber : undefined;
@@ -178,6 +260,24 @@ export class SignalApi {
     if (sourceNumber) out.sourceNumber = sourceNumber;
     if (sourceName) out.sourceName = sourceName;
     if (groupId) out.groupId = groupId;
+    if (attachments.length > 0) out.attachments = attachments;
     return out;
   }
+}
+
+/** Parse the `dataMessage.attachments` array into typed descriptors. */
+function parseAttachments(raw: unknown): SignalAttachment[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SignalAttachment[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const a = item as Record<string, unknown>;
+    if (typeof a.id !== 'string') continue;
+    const att: SignalAttachment = { id: a.id };
+    if (typeof a.contentType === 'string') att.contentType = a.contentType;
+    if (typeof a.filename === 'string') att.filename = a.filename;
+    if (typeof a.size === 'number') att.size = a.size;
+    out.push(att);
+  }
+  return out;
 }

--- a/apps/channels/signal/test/bridge.test.ts
+++ b/apps/channels/signal/test/bridge.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  buildSignalBase64AttachmentDataUri,
   conversationKey,
   generateSessionId,
   shouldAcceptSender,
@@ -31,6 +32,17 @@ test('conversationKey uses group prefix for group messages', () => {
 test('generateSessionId produces a date-stamped signal: prefix', () => {
   const id = generateSessionId();
   assert.match(id, /^signal:\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$/);
+});
+
+test('buildSignalBase64AttachmentDataUri escapes filename delimiters', () => {
+  assert.equal(
+    buildSignalBase64AttachmentDataUri(
+      'image/png',
+      'report final;v2, approved.png',
+      Uint8Array.from([1, 2, 3]),
+    ),
+    'data:image/png;filename=report%20final%3Bv2%2C%20approved.png;base64,AQID',
+  );
 });
 
 test('shouldAcceptSender accepts everyone when no allow-list is configured', () => {

--- a/apps/channels/signal/test/signal-api-receive.test.ts
+++ b/apps/channels/signal/test/signal-api-receive.test.ts
@@ -55,6 +55,36 @@ test('streamMessages yields normalized DM envelopes', async () => {
   );
 });
 
+test('streamMessages yields an attachment-only message (no text)', async () => {
+  await withMockWsServer(
+    (ws) => {
+      ws.send(JSON.stringify({
+        envelope: {
+          sourceNumber: '+15559999999',
+          sourceUuid: 'uuid-alice',
+          timestamp: 1709,
+          dataMessage: {
+            message: null,
+            attachments: [
+              { id: 'att-1', contentType: 'image/jpeg', filename: 'pic.jpg', size: 1234 },
+            ],
+          },
+        },
+      }));
+    },
+    async (port) => {
+      const api = new SignalApi({ httpUrl: `http://localhost:${port}`, account: '+15551234567' });
+      const iter = api.streamMessages({ signal: AbortSignal.timeout(1000) });
+      const { value } = await iter.next();
+      assert.equal(value!.text, '');
+      assert.deepEqual(value!.attachments, [
+        { id: 'att-1', contentType: 'image/jpeg', filename: 'pic.jpg', size: 1234 },
+      ]);
+      await iter.return?.();
+    },
+  );
+});
+
 test('streamMessages yields groupId when envelope is from a group', async () => {
   await withMockWsServer(
     (ws) => {

--- a/apps/channels/signal/test/signal-api.test.ts
+++ b/apps/channels/signal/test/signal-api.test.ts
@@ -62,6 +62,42 @@ test('SignalApi.sendGroupMessage POSTs with recipients = [groupId]', async () =>
   });
 });
 
+test('SignalApi.sendDirectMessage includes base64_attachments when provided', async () => {
+  const { fetch: spy, calls } = makeFetchSpy({ body: { timestamp: 1 } });
+  const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });
+
+  await api.sendDirectMessage('+15559999999', 'see this', {
+    base64Attachments: ['data:image/png;filename=pic.png;base64,AAAA'],
+  });
+
+  assert.deepEqual(calls[0]!.body, {
+    number: '+15551234567',
+    recipients: ['+15559999999'],
+    message: 'see this',
+    text_mode: 'styled',
+    base64_attachments: ['data:image/png;filename=pic.png;base64,AAAA'],
+  });
+});
+
+test('SignalApi.downloadAttachment returns bytes under the cap', async () => {
+  const data = Uint8Array.from([1, 2, 3, 4]);
+  const spy: typeof fetch = async () =>
+    new Response(data, { status: 200, headers: { 'content-type': 'image/png' } });
+  const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+1', fetch: spy });
+
+  const out = await api.downloadAttachment('att-1', 1024);
+  assert.deepEqual(Array.from(out.bytes), [1, 2, 3, 4]);
+  assert.equal(out.contentType, 'image/png');
+});
+
+test('SignalApi.downloadAttachment rejects an oversized content-length up front', async () => {
+  const spy: typeof fetch = async () =>
+    new Response(new Uint8Array(10), { status: 200, headers: { 'content-length': '999999' } });
+  const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+1', fetch: spy });
+
+  await assert.rejects(() => api.downloadAttachment('att-1', 100), /exceeds the 100-byte limit/);
+});
+
 test('SignalApi.sendTyping PUTs /v1/typing-indicator/{account}', async () => {
   const { fetch: spy, calls } = makeFetchSpy({ status: 204 });
   const api = new SignalApi({ httpUrl: 'http://signal:8080', account: '+15551234567', fetch: spy });

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -20,7 +20,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 
 | Platform | Package | Connection |
 |----------|---------|------------|
-| Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard |
+| Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard; text + media (files/images, audio transcribed) |
 | WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
 | WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text + media (image/video/document/voice) |
 
@@ -176,6 +176,12 @@ Slack:
 - deduplicates paired message/app-mention events
 - media inbound (`file_share` uploads fetched with bot-token auth and uploaded as session attachments; images become vision input; audio transcribed via STT) and outbound (`attachment_send` → `files.uploadV2`, into the thread when applicable); files over the 25 MiB cap are skipped. Needs `files:read` + `files:write` scopes.
 - optional `allowed_channel_ids`
+
+Signal (external plugin):
+
+- signal-cli-rest-api WebSocket receive (`MODE=json-rpc`); QR-link setup wizard
+- media inbound (attachments fetched via `GET /v1/attachments/{id}` and uploaded as session attachments — images become vision input — audio transcribed via STT) and outbound (`attachment_send` → `base64_attachments` on `/v2/send`); attachments over the 25 MiB cap are skipped
+- DMs open by default unless `allowed_senders` is set; groups default-deny unless `allowed_group_ids` is set
 
 WeChat (external plugin):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
     },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0",


### PR DESCRIPTION
Adds media support to the Signal channel — the first of the two deferred channels (WeChat is the other). Built on the **already-complete** core attachment infrastructure; no core/protocol/gateway changes.

## Inbound (Signal → agent)
- `dataMessage.attachments` (previously ignored) are downloaded via `GET /v1/attachments/{id}` and uploaded as session attachments — images become **vision input** automatically.
- Audio attachments are transcribed via `client.transcribeAudio` and appended as `[Transcribed voice message]` text.
- **Attachment-only messages now trigger the agent** instead of being dropped.
- Download is bounded by a 25 MiB cap (content-length pre-check + streaming abort) and a 15s timeout, enforced inside `SignalApi.downloadAttachment`.

## Outbound (agent → Signal)
- The agent's `attachment_send` deliveries (SSE `attachment` event) are sent as `base64_attachments` on `/v2/send` (data-URI with filename), caption as the message body.

## Implementation
- `signal-api.ts`: parse inbound `attachments`, allow attachment-only envelopes, new `downloadAttachment(id, maxBytes)`, `base64_attachments` on send.
- `bridge.ts`: `resolveInbound` (STT/upload), `deliverAttachment`, `attachment` SSE case.

## Tests
55 pass (added: base64 send body, download-cap rejection, attachment-only inbound parsing).

Published package — bumps `@openhermit/channel-signal` 0.1.1 → 0.2.0 (standalone publish after merge, like WhatsApp). Docs + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media attachment support for Signal: inbound attachments are fetched and processed (images converted to vision inputs, audio transcribed to text); outbound attachments delivered via base64 encoding.
  * Attachments exceeding 25 MiB are automatically skipped.

* **Documentation**
  * Updated README and platform notes with Signal media handling details and attachment limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HCF-STUDIOS/openhermit/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->