### PR TITLE
feat(wechat): inbound images + context_token echo

### DIFF
--- a/apps/channels/wechat/README.md
+++ b/apps/channels/wechat/README.md
@@ -3,13 +3,23 @@
 `@openhermit/channel-wechat` connects a personal WeChat (Weixin) bot to a
 gateway-managed OpenHermit agent over Tencent's **iLink** HTTP protocol.
 
-## v0 scope
+## Scope
 
-- Text inbound and outbound only — image / voice / file / video items
-  are ignored.
+- Text inbound and outbound.
+- **Inbound images**: photos are downloaded from the WeChat C2C CDN and
+  AES-128-ECB decrypted, then uploaded to the agent as attachments (images
+  become vision input). Attachments over the 25 MiB cap are skipped. The CDN
+  base defaults to `https://novac2c.cdn.weixin.qq.com/c2c`, overridable via
+  `OPENHERMIT_WECHAT_CDN_BASE_URL`; a server-provided `full_url` is preferred.
+- Inbound voice / file / video and all **outbound** media are not handled yet
+  (voice needs SILK transcoding; outbound needs the CDN upload flow).
 - QR-link wizard (`ChannelSetup`) returns the QR URL as a plain string;
   the admin UI renders it with its own QR-code library.
-- No typing indicators, no media upload, no multi-account juggling.
+- No typing indicators, no multi-account juggling.
+
+The CDN download + AES decryption is ported from Tencent's MIT-licensed
+[`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin) (see the
+header in `src/ilink/media.ts`).
 
 ## Loading the plugin
 

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.1.2",
-  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text-only v0.",
+  "version": "0.2.0",
+  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text plus inbound images.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,6 +45,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
+    "test": "node --import tsx --test test/*.test.ts",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run build",
     "prepack": "node scripts/strip-dev-condition.mjs",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -18,10 +18,20 @@ import { stripSilenceTokens } from '@openhermit/shared';
 
 import { sendMessage } from './ilink/api.js';
 import { MessageItemType, MessageType, type WeixinMessage } from './ilink/types.js';
+import { CDN_BASE_URL, downloadAndDecrypt, resolveCdnUrl } from './ilink/media.js';
+
+/** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
 
 interface TurnResult {
   text: string | undefined;
   error: string | undefined;
+}
+
+/** Outcome of resolving an inbound message's media. */
+interface ResolvedInbound {
+  text: string;
+  attachments?: { type: 'file'; id: string }[];
 }
 
 export interface WechatBridgeRuntime {
@@ -130,13 +140,58 @@ export class WechatBridge implements ChannelOutbound {
     return parts.length > 0 ? parts.join('\n') : undefined;
   }
 
+  /**
+   * Resolve inbound media: download + decrypt each image item from the CDN
+   * and upload it as a durable session attachment (images become vision
+   * input). Text/captions are kept. Oversized or failed downloads are skipped.
+   */
+  private async resolveInbound(sessionId: string, msg: WeixinMessage): Promise<ResolvedInbound> {
+    const text = this.extractText(msg) ?? '';
+    const ids: { type: 'file'; id: string }[] = [];
+
+    for (const item of msg.item_list ?? []) {
+      if (item.type !== MessageItemType.IMAGE || !item.image_item) continue;
+      const img = item.image_item;
+      const media = img.media;
+      if (!media || (!media.full_url && !media.encrypt_query_param)) continue;
+
+      // Prefer the hex `aeskey` (raw 16-byte key) over the base64 `media.aes_key`.
+      const aesKeyBase64 = img.aeskey
+        ? Buffer.from(img.aeskey, 'hex').toString('base64')
+        : media.aes_key;
+      if (!aesKeyBase64) {
+        this.log('image item missing aes key; skipping');
+        continue;
+      }
+
+      try {
+        const url = resolveCdnUrl(media.encrypt_query_param, media.full_url, CDN_BASE_URL);
+        const bytes = await downloadAndDecrypt({ url, aesKeyBase64, maxBytes: MAX_MEDIA_BYTES });
+        const blob = new Blob([bytes as unknown as BlobPart], { type: 'image/jpeg' });
+        const uploaded = await this.client.uploadAttachment(sessionId, blob, 'image.jpg');
+        ids.push({ type: 'file', id: uploaded.id! });
+      } catch (err) {
+        this.log(`image download/decrypt failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return { text, ...(ids.length > 0 ? { attachments: ids } : {}) };
+  }
+
   private async handleMessageInner(msg: WeixinMessage, peer: string): Promise<void> {
-    const text = this.extractText(msg);
-    if (!text) return;
+    const hasImage = (msg.item_list ?? []).some(
+      (item) => item.type === MessageItemType.IMAGE && item.image_item,
+    );
+    if (!this.extractText(msg) && !hasImage) return;
 
     const isGroup = Boolean(msg.group_id?.trim());
     const sessionId = await this.getSessionId(peer, isGroup);
     await this.ensureSession(sessionId, msg, isGroup);
+
+    // Download + decrypt inbound images and upload them as session
+    // attachments (images become vision input). Text/captions are kept.
+    const resolved = await this.resolveInbound(sessionId, msg);
+    if (!resolved.text && !resolved.attachments) return;
 
     const senderUserId = msg.from_user_id?.trim();
     const senderPayload = senderUserId
@@ -155,8 +210,9 @@ export class WechatBridge implements ChannelOutbound {
     const postOpts = !isGroup && senderUserId ? { channelUserId: senderUserId } : undefined;
 
     const postResult = await this.client.postMessage(sessionId, {
-      text,
+      text: resolved.text,
       mentioned: !isGroup,
+      ...(resolved.attachments ? { attachments: resolved.attachments } : {}),
       ...senderPayload,
     }, postOpts);
 

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -90,11 +90,18 @@ export class WechatBridge implements ChannelOutbound {
     return this.sendText(params.to, params.text);
   }
 
-  private async sendText(toUserId: string, text: string): Promise<ChannelOutboundResult> {
+  private async sendText(
+    toUserId: string,
+    text: string,
+    turnContextToken?: string,
+  ): Promise<ChannelOutboundResult> {
     const trimmed = text.trim();
     if (!trimmed) return { success: true };
 
-    const contextToken = this.peerContextTokens.get(toUserId);
+    // Replies pass the token snapshotted at their turn's start so a newer
+    // inbound message can't swap it; proactive sends (session_send) fall back
+    // to the latest known token for the peer.
+    const contextToken = turnContextToken ?? this.peerContextTokens.get(toUserId);
     const msg: WeixinMessage = {
       to_user_id: toUserId,
       message_type: MessageType.BOT,
@@ -168,10 +175,17 @@ export class WechatBridge implements ChannelOutbound {
       const media = img.media;
       if (!media || (!media.full_url && !media.encrypt_query_param)) continue;
 
-      // Prefer the hex `aeskey` (raw 16-byte key) over the base64 `media.aes_key`.
-      const aesKeyBase64 = img.aeskey
-        ? Buffer.from(img.aeskey, 'hex').toString('base64')
-        : media.aes_key;
+      // Prefer the hex `aeskey` (raw 16-byte key = 32 hex chars), but only when
+      // it's actually valid hex — otherwise Buffer.from(...,'hex') would
+      // silently truncate to a wrong key. Fall back to the base64 media.aes_key.
+      let aesKeyBase64: string | undefined;
+      const hexKey = img.aeskey?.trim();
+      if (hexKey && /^[0-9a-fA-F]{32}$/.test(hexKey)) {
+        aesKeyBase64 = Buffer.from(hexKey, 'hex').toString('base64');
+      } else {
+        if (hexKey) this.log('image aeskey is not valid 16-byte hex; falling back to media.aes_key');
+        aesKeyBase64 = media.aes_key;
+      }
       if (!aesKeyBase64) {
         this.log('image item missing aes key; skipping');
         continue;
@@ -196,6 +210,11 @@ export class WechatBridge implements ChannelOutbound {
       (item) => item.type === MessageItemType.IMAGE && item.image_item,
     );
     if (!this.extractText(msg) && !hasImage) return;
+
+    // Snapshot this turn's context token up front so the reply echoes the
+    // token of the message it's answering, even if a newer message for the
+    // same peer arrives and overwrites the shared map mid-turn.
+    const turnContextToken = msg.context_token?.trim();
 
     const isGroup = Boolean(msg.group_id?.trim());
     const sessionId = await this.getSessionId(peer, isGroup);
@@ -234,13 +253,13 @@ export class WechatBridge implements ChannelOutbound {
     const result = await this.waitForAgentResponse(sessionId);
     const replyText = result.text;
     if (result.error && !replyText) {
-      await this.sendText(peer, `Error: ${result.error}`);
+      await this.sendText(peer, `Error: ${result.error}`, turnContextToken);
       return;
     }
     if (replyText) {
       const stripped = stripSilenceTokens(replyText);
       if (!stripped.isSilent) {
-        await this.sendText(peer, stripped.hadToken ? stripped.text : replyText);
+        await this.sendText(peer, stripped.hadToken ? stripped.text : replyText, turnContextToken);
       }
     }
   }

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -54,6 +54,13 @@ export class WechatBridge implements ChannelOutbound {
   private readonly peerSessions = new Map<string, string>();
   /** Per-peer message queue to serialize handling. */
   private readonly peerLocks = new Map<string, Promise<void>>();
+  /**
+   * Latest iLink `context_token` per peer. Issued per-message on inbound and
+   * echoed verbatim on outbound sends so replies stay tied to the upstream
+   * conversation context. In-memory only — after a restart the first
+   * proactive send to a peer goes without a token until they message again.
+   */
+  private readonly peerContextTokens = new Map<string, string>();
 
   constructor(
     private runtime: WechatBridgeRuntime,
@@ -87,6 +94,7 @@ export class WechatBridge implements ChannelOutbound {
     const trimmed = text.trim();
     if (!trimmed) return { success: true };
 
+    const contextToken = this.peerContextTokens.get(toUserId);
     const msg: WeixinMessage = {
       to_user_id: toUserId,
       message_type: MessageType.BOT,
@@ -95,6 +103,7 @@ export class WechatBridge implements ChannelOutbound {
       item_list: [
         { type: MessageItemType.TEXT, text_item: { text: trimmed } },
       ],
+      ...(contextToken ? { context_token: contextToken } : {}),
     };
 
     try {
@@ -120,6 +129,10 @@ export class WechatBridge implements ChannelOutbound {
 
     const peer = msg.group_id?.trim() || msg.from_user_id?.trim();
     if (!peer) return;
+
+    // Capture the per-message context token so our reply can echo it.
+    const contextToken = msg.context_token?.trim();
+    if (contextToken) this.peerContextTokens.set(peer, contextToken);
 
     const prev = this.peerLocks.get(peer) ?? Promise.resolve();
     const current = prev.then(

--- a/apps/channels/wechat/src/ilink/media.ts
+++ b/apps/channels/wechat/src/ilink/media.ts
@@ -1,0 +1,86 @@
+/**
+ * WeChat CDN media download + AES-128-ECB decryption.
+ *
+ * Ported from Tencent's MIT-licensed `openclaw-weixin`
+ * (`src/cdn/aes-ecb.ts`, `src/cdn/pic-decrypt.ts`, `src/cdn/cdn-url.ts`):
+ *
+ *   Copyright (C) 2026 Tencent. Licensed under the MIT License.
+ *
+ * Inbound media items reference encrypted bytes on the WeChat C2C CDN. Each
+ * `CDNMedia` carries either a complete `full_url` (preferred) or an
+ * `encrypt_query_param` the client assembles against a CDN base URL, plus an
+ * AES key. Bytes are AES-128-ECB encrypted and must be decrypted after fetch.
+ */
+import { createDecipheriv } from 'node:crypto';
+
+/** Default WeChat C2C CDN base, overridable via env. Only used when a media
+ * item lacks a server-provided `full_url`. */
+export const CDN_BASE_URL =
+  process.env.OPENHERMIT_WECHAT_CDN_BASE_URL ?? 'https://novac2c.cdn.weixin.qq.com/c2c';
+
+/** Decrypt AES-128-ECB (PKCS7 padding). */
+export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/**
+ * Parse a `CDNMedia.aes_key` JSON field into a raw 16-byte AES key. Two
+ * encodings occur in the wild:
+ *   - base64(raw 16 bytes)           → images (from the `media` field)
+ *   - base64(32-char hex string)     → file / voice / video
+ */
+export function parseAesKey(aesKeyBase64: string): Buffer {
+  const decoded = Buffer.from(aesKeyBase64, 'base64');
+  if (decoded.length === 16) return decoded;
+  if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString('ascii'))) {
+    return Buffer.from(decoded.toString('ascii'), 'hex');
+  }
+  throw new Error(
+    `aes_key must decode to 16 raw bytes or a 32-char hex string, got ${decoded.length} bytes`,
+  );
+}
+
+/** Build a CDN download URL from an encrypt_query_param when no full_url is given. */
+export function buildCdnDownloadUrl(encryptedQueryParam: string, cdnBaseUrl: string): string {
+  return `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptedQueryParam)}`;
+}
+
+/** Resolve the download URL for a media item, preferring the server's full_url. */
+export function resolveCdnUrl(
+  encryptQueryParam: string | undefined,
+  fullUrl: string | undefined,
+  cdnBaseUrl: string,
+): string {
+  if (fullUrl) return fullUrl;
+  if (encryptQueryParam) return buildCdnDownloadUrl(encryptQueryParam, cdnBaseUrl);
+  throw new Error('media item has neither full_url nor encrypt_query_param');
+}
+
+/**
+ * Download and AES-128-ECB decrypt a CDN media file. `maxBytes` caps the
+ * download (rejected up front via content-length, then enforced on the body).
+ */
+export async function downloadAndDecrypt(params: {
+  url: string;
+  aesKeyBase64: string;
+  maxBytes: number;
+  timeoutMs?: number;
+}): Promise<Buffer> {
+  const { url, aesKeyBase64, maxBytes, timeoutMs = 15_000 } = params;
+  const key = parseAesKey(aesKeyBase64);
+
+  const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) throw new Error(`CDN download failed (${res.status})`);
+
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`CDN media exceeds the ${maxBytes}-byte limit (content-length ${declared})`);
+  }
+
+  const encrypted = Buffer.from(await res.arrayBuffer());
+  if (encrypted.byteLength > maxBytes) {
+    throw new Error(`CDN media exceeds the ${maxBytes}-byte limit (${encrypted.byteLength} bytes)`);
+  }
+  return decryptAesEcb(encrypted, key);
+}

--- a/apps/channels/wechat/src/ilink/types.ts
+++ b/apps/channels/wechat/src/ilink/types.ts
@@ -30,9 +30,35 @@ export const MessageType = {
   BOT: 2,
 } as const;
 
-/** `MessageItem.text_item` — the only item shape we read/write in v0. */
+/** `MessageItem.text_item`. */
 export interface TextItem {
   text?: string;
+}
+
+/**
+ * CDN media reference. `aes_key` is base64 in JSON; `full_url` (when present)
+ * is a complete download URL, otherwise the client builds one from a CDN base.
+ * Shape ported from Tencent's MIT-licensed `openclaw-weixin` (`api/types.ts`).
+ */
+export interface CDNMedia {
+  encrypt_query_param?: string;
+  aes_key?: string;
+  /** 0 = fileid only, 1 = packed thumbnail/preview info. */
+  encrypt_type?: number;
+  /** Complete download URL returned by the server (no client assembly needed). */
+  full_url?: string;
+}
+
+/** `MessageItem.image_item` — inbound photo. */
+export interface ImageItem {
+  /** Full-resolution CDN reference. */
+  media?: CDNMedia;
+  /** Thumbnail CDN reference. */
+  thumb_media?: CDNMedia;
+  /** Raw AES-128 key as a hex string (16 bytes); preferred over `media.aes_key`. */
+  aeskey?: string;
+  url?: string;
+  hd_size?: number;
 }
 
 export interface MessageItem {
@@ -42,7 +68,8 @@ export interface MessageItem {
   is_completed?: boolean;
   msg_id?: string;
   text_item?: TextItem;
-  /** Other item shapes (image_item/voice_item/file_item/video_item) intentionally untyped here. */
+  image_item?: ImageItem;
+  /** voice_item/file_item/video_item remain untyped until later media phases. */
   [key: string]: unknown;
 }
 

--- a/apps/channels/wechat/test/media.test.ts
+++ b/apps/channels/wechat/test/media.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { test } from 'node:test';
+
+import {
+  buildCdnDownloadUrl,
+  decryptAesEcb,
+  downloadAndDecrypt,
+  parseAesKey,
+  resolveCdnUrl,
+} from '../src/ilink/media.js';
+
+/** AES-128-ECB encrypt (PKCS7) — mirrors the WeChat CDN's encryption. */
+function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
+  const cipher = createCipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+}
+
+async function withFetch(impl: typeof fetch, fn: () => Promise<void>): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+test('parseAesKey accepts a base64 raw 16-byte key (image form)', () => {
+  const key = randomBytes(16);
+  assert.deepEqual(parseAesKey(key.toString('base64')), key);
+});
+
+test('parseAesKey accepts a base64-of-hex key (file/voice/video form)', () => {
+  const key = randomBytes(16);
+  const base64OfHex = Buffer.from(key.toString('hex'), 'ascii').toString('base64');
+  assert.deepEqual(parseAesKey(base64OfHex), key);
+});
+
+test('parseAesKey rejects malformed keys', () => {
+  assert.throws(() => parseAesKey(Buffer.from('too-short').toString('base64')), /16 raw bytes/);
+});
+
+test('decryptAesEcb round-trips with encryptAesEcb', () => {
+  const key = randomBytes(16);
+  const plaintext = Buffer.from('hello wechat image bytes ✅', 'utf-8');
+  assert.deepEqual(decryptAesEcb(encryptAesEcb(plaintext, key), key), plaintext);
+});
+
+test('resolveCdnUrl prefers full_url, falls back to building from base', () => {
+  assert.equal(resolveCdnUrl('q', 'https://cdn/full', 'https://base'), 'https://cdn/full');
+  assert.equal(
+    resolveCdnUrl('q==', undefined, 'https://base'),
+    buildCdnDownloadUrl('q==', 'https://base'),
+  );
+  assert.throws(() => resolveCdnUrl(undefined, undefined, 'https://base'), /full_url|encrypt_query_param/);
+});
+
+test('downloadAndDecrypt fetches and decrypts CDN bytes', async () => {
+  const key = randomBytes(16);
+  const plaintext = randomBytes(64);
+  const ciphertext = encryptAesEcb(plaintext, key);
+
+  await withFetch(async () => new Response(ciphertext, { status: 200 }), async () => {
+    const out = await downloadAndDecrypt({
+      url: 'https://cdn/download?x=1',
+      aesKeyBase64: key.toString('base64'),
+      maxBytes: 1024,
+    });
+    assert.deepEqual(out, plaintext);
+  });
+});
+
+test('downloadAndDecrypt rejects an oversized content-length up front', async () => {
+  await withFetch(
+    async () => new Response(new Uint8Array(16), { status: 200, headers: { 'content-length': '999999' } }),
+    async () => {
+      await assert.rejects(
+        () => downloadAndDecrypt({
+          url: 'https://cdn/x',
+          aesKeyBase64: randomBytes(16).toString('base64'),
+          maxBytes: 100,
+        }),
+        /exceeds the 100-byte limit/,
+      );
+    },
+  );
+});

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -21,7 +21,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 | Platform | Package | Connection |
 |----------|---------|------------|
 | Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard; text + media (files/images, audio transcribed) |
-| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text-only v0 |
+| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text + inbound images |
 | WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text + media (image/video/document/voice) |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
@@ -187,7 +187,8 @@ WeChat (external plugin):
 
 - iLink long-poll loop on `bot_token` — no per-message webhook
 - QR-link setup wizard exchanges scan+confirmation for `bot_token` + IDC-pinned `base_url`; both persist on the channel row
-- text-only v0 (no media, no group filtering)
+- inbound images: photos are downloaded from the WeChat C2C CDN and AES-128-ECB decrypted, then uploaded as session attachments (vision input); over the 25 MiB cap they are skipped. Inbound voice/file/video and all outbound media are not handled yet
+- no group filtering
 - `errcode === -14` from `getUpdates` is treated as long-poll cursor reset, **not** auth failure
 
 WhatsApp (external plugin):

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -74,7 +74,7 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Install with `hermit channel install @openhermit/channel-wechat`, then restart the gateway.
 - Pair the bot through *Manage → Channels → Add channel → WeChat*: the UI renders a QR code that you scan with the WeChat mobile app and confirm. The setup wizard exchanges the scan + confirmation for a long-lived `bot_token` and IDC-pinned `base_url`, which the gateway stores on the channel row.
 - Restarts preserve the login: the gateway reloads `bot_token` from the channel row and resumes the iLink long-poll without re-scanning. You only need to re-pair if you unlink the bot from inside the WeChat client.
-- Text-only in v0 — no attachments, no group filtering.
+- Media: inbound images are decrypted from the WeChat CDN and uploaded to the agent as vision input (over 25 MiB skipped). Inbound voice/file/video and all outbound media aren't handled yet. No group filtering.
 
 ### WhatsApp (external plugin)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "magic-bytes.js": "^1.13.0",
         "mime-types": "^3.0.2",
         "prom-client": "^15.1.3",
-        "undici": "^7.25.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -151,7 +150,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0"
@@ -243,7 +242,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.9.3",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",


### PR DESCRIPTION
First phase of WeChat media support — **inbound images** — the smallest, lowest-risk slice (AES-decrypt only; no SILK, no CDN upload). Based on analysis of Tencent's official [`openclaw-weixin`](https://github.com/Tencent/openclaw-weixin) plugin.

## What & why
WeChat `IMAGE` items were silently dropped. They reference **AES-128-ECB-encrypted** bytes on the WeChat C2C CDN — and that data is **already in the `getUpdates` payload** we receive (no new endpoint needed). This decodes them.

## Inbound (WeChat → agent)
- Detect `IMAGE` items, resolve the CDN URL (prefer server `full_url`, else build from a CDN base), **AES-128-ECB decrypt**, and `uploadAttachment` → `postMessage({attachments})` so images become **vision input**.
- AES key handles both encodings seen in the wild (raw-16-byte base64 for images; base64-of-hex elsewhere).
- Image-only messages now trigger the agent; over the 25 MiB cap they're skipped.
- CDN base defaults to `https://novac2c.cdn.weixin.qq.com/c2c`, overridable via `OPENHERMIT_WECHAT_CDN_BASE_URL`.

## Porting / license
The CDN download + AES crypto (`src/ilink/media.ts`) is ported from Tencent's **MIT-licensed** `openclaw-weixin`, with the copyright/attribution retained in the file header (MIT-compatible with our MIT package).

## Tests
7 unit tests (first for this package): AES round-trip, both `aes_key` formats, malformed-key rejection, `full_url`-vs-base resolution, CDN download + content-length cap. Build + typecheck green.

## Scope / follow-ups
- **Phase 2**: inbound voice (SILK→WAV via `silk-wasm`) + file + video.
- **Phase 3**: outbound media (CDN upload via `GetUploadUrl`).

## Verification note
The crypto is fixture-tested, but the **live payload shape** (does our `getUpdates` deliver `full_url` + `aes_key` on the image item?) can only be confirmed by sending a real photo from a linked WeChat account. Recommend a quick live check before publishing 0.2.0.

Published package — bumps `@openhermit/channel-wechat` 0.1.1 → 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WeChat adapter now supports inbound images: downloads from the WeChat CDN, AES-decrypts media, and uploads images as vision/attachments (skipping items over 25 MiB). Outbound messages can include attachments when available. QR-link wizard behavior remains unchanged.
* **Improvements**
  * Enhanced per-message reply correlation for WeChat iLink proactive sends.
* **Documentation**
  * Updated WeChat adapter docs to reflect image support, size limits, and current omissions (inbound voice/file/video and all outbound media).
* **Tests**
  * Added CDN download and decryption coverage for the WeChat media flow.
* **Chores**
  * Bumped WeChat adapter to version 0.2.0 and added a TypeScript test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->