### PR TITLE
fix(agent): close SSRF in attachment URL passthrough (DNS rebinding + IPv6 loopback)

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -67,6 +67,7 @@
     "magic-bytes.js": "^1.13.0",
     "mime-types": "^3.0.2",
     "prom-client": "^15.1.3",
+    "undici": "^7.25.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/agent/src/attachments/persist.ts
+++ b/apps/agent/src/attachments/persist.ts
@@ -11,6 +11,11 @@ import type {
 import type { AgentRunner } from '../agent-runner.js';
 
 import { resolveMimeType, sanitizeName } from './helpers.js';
+import {
+  createSsrfSafeAgent,
+  isBlockedLiteralHost,
+  type HostResolver,
+} from './ssrf.js';
 
 /**
  * URL-passthrough resolver for inbound `postMessage` attachments shaped as
@@ -21,8 +26,12 @@ import { resolveMimeType, sanitizeName } from './helpers.js';
  *
  * Errors throw `OpenHermitError('attachment_fetch_failed', 400)` so the whole
  * `postMessage` fails fast — silently dropping the upload is worse than a 4xx
- * the caller can retry. SSRF guards reject non-https and private / loopback
- * / link-local hosts (incl. 169.254.169.254 cloud-metadata).
+ * the caller can retry. SSRF guards reject non-https URLs, IP-literal hosts in
+ * private / loopback / link-local / metadata ranges, and — crucially — any
+ * hostname that *resolves* to such an address. Resolution, validation, and
+ * connection are pinned to the same address (see `./ssrf.ts`), so a domain
+ * that aliases to 127.0.0.1 / 169.254.169.254 or rebinds mid-request cannot
+ * smuggle a request to an internal target. Per-hop checks cover redirects.
  */
 const ATTACHMENT_FETCH_TIMEOUT_MS = 30_000;
 
@@ -32,32 +41,6 @@ const MAX_REDIRECT_HOPS = 5;
 
 const fail = (message: string, code = 'attachment_fetch_failed'): never => {
   throw new OpenHermitError(message, code, 400);
-};
-
-const isBlockedHost = (hostname: string): boolean => {
-  const h = hostname.toLowerCase();
-  if (h === 'localhost' || h.endsWith('.localhost')) return true;
-
-  // IPv4 literal — block private / loopback / link-local / unspecified.
-  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h)) {
-    const [a, b] = h.split('.').map(Number) as [number, number];
-    if (a === 127 || a === 10 || a === 0) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 169 && b === 254) return true; // includes EC2/GCP metadata
-    return false;
-  }
-
-  // IPv6 — match common literal forms. Brackets are stripped by URL.hostname.
-  if (h.includes(':')) {
-    if (h === '::1' || h === '::') return true;
-    if (h.startsWith('fc') || h.startsWith('fd')) return true; // ULA fc00::/7
-    if (h.startsWith('fe8') || h.startsWith('fe9') || h.startsWith('fea') || h.startsWith('feb'))
-      return true; // link-local fe80::/10
-    return false;
-  }
-
-  return false;
 };
 
 const deriveNameFromUrl = (url: URL): string | undefined => {
@@ -82,6 +65,12 @@ export interface ResolveAttachmentByUrlInput {
   attachmentStorage: AttachmentStorage;
   runtime: AgentRunner;
   logger?: ((message: string) => void) | undefined;
+  /**
+   * Hostname → resolved IPs. Injectable for tests; defaults to a real DNS
+   * lookup. The same resolver drives the connection-pinning dispatcher, so a
+   * stub here exercises the full SSRF path deterministically.
+   */
+  resolveHost?: HostResolver | undefined;
 }
 
 export const resolveAttachmentByUrl = async (
@@ -96,14 +85,17 @@ export const resolveAttachmentByUrl = async (
   }
   // Manual redirect follow so the SSRF protocol+host guards run on *every*
   // hop. `redirect: 'follow'` would only validate the initial URL — a 302 to
-  // http://169.254.169.254/ would otherwise sneak past.
+  // http://169.254.169.254/ would otherwise sneak past. The literal-host check
+  // is a cheap pre-filter; the authoritative resolve-validate-pin happens in
+  // the dispatcher's lookup (see ./ssrf.ts), which also covers hostnames that
+  // only reveal a blocked address once resolved.
   const validateHop = (u: URL): void => {
     if (!ALLOWED_PROTOCOLS.has(u.protocol)) {
       fail(
         `attachment_fetch_failed: protocol "${u.protocol}" not allowed (https only)`,
       );
     }
-    if (isBlockedHost(u.hostname)) {
+    if (isBlockedLiteralHost(u.hostname)) {
       fail(
         `attachment_fetch_failed: host "${u.hostname}" is not allowed (SSRF guard)`,
       );
@@ -111,42 +103,56 @@ export const resolveAttachmentByUrl = async (
   };
   validateHop(parsed);
 
+  // Dispatcher resolves every connection (initial + redirect hops) through the
+  // SSRF lookup and pins the validated address — no second, unvalidated DNS
+  // resolution at connect time, so DNS rebinding can't smuggle past.
+  const dispatcher = createSsrfSafeAgent(input.resolveHost);
   const signal = AbortSignal.timeout(ATTACHMENT_FETCH_TIMEOUT_MS);
   let res: Response;
   let current = parsed;
   let hops = 0;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    try {
-      res = await fetch(current.toString(), {
-        method: 'GET',
-        redirect: 'manual',
-        signal,
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      fail(`attachment_fetch_failed: ${msg} (url=${current.toString()})`);
-      throw new Error('unreachable');
-    }
-    if (res.status >= 300 && res.status < 400 && res.headers.has('location')) {
-      if (hops >= MAX_REDIRECT_HOPS) {
-        fail(
-          `attachment_fetch_failed: too many redirects (>${MAX_REDIRECT_HOPS})`,
-        );
-      }
-      let next: URL;
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       try {
-        next = new URL(res.headers.get('location')!, current);
-      } catch {
-        fail(`attachment_fetch_failed: malformed redirect target`);
+        res = await fetch(current.toString(), {
+          method: 'GET',
+          redirect: 'manual',
+          signal,
+          // `dispatcher` is an undici extension to RequestInit, not in lib.dom.
+          dispatcher,
+        } as RequestInit & { dispatcher: unknown });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        fail(`attachment_fetch_failed: ${msg} (url=${current.toString()})`);
         throw new Error('unreachable');
       }
-      validateHop(next);
-      current = next;
-      hops += 1;
-      continue;
+      if (
+        res.status >= 300 &&
+        res.status < 400 &&
+        res.headers.has('location')
+      ) {
+        if (hops >= MAX_REDIRECT_HOPS) {
+          fail(
+            `attachment_fetch_failed: too many redirects (>${MAX_REDIRECT_HOPS})`,
+          );
+        }
+        let next: URL;
+        try {
+          next = new URL(res.headers.get('location')!, current);
+        } catch {
+          fail(`attachment_fetch_failed: malformed redirect target`);
+          throw new Error('unreachable');
+        }
+        validateHop(next);
+        current = next;
+        hops += 1;
+        continue;
+      }
+      break;
     }
-    break;
+  } finally {
+    void dispatcher.close().catch(() => {});
   }
   if (!res.ok) {
     fail(

--- a/apps/agent/src/attachments/ssrf.ts
+++ b/apps/agent/src/attachments/ssrf.ts
@@ -1,0 +1,170 @@
+import { lookup as dnsLookup } from 'node:dns';
+import { isIP } from 'node:net';
+
+import { Agent } from 'undici';
+
+/**
+ * SSRF protections for the attachment URL-passthrough fetch path.
+ *
+ * Two layers, because each catches what the other can't:
+ *
+ *  1. `isBlockedLiteralHost` — a cheap, synchronous check on the URL hostname.
+ *     Rejects `localhost` and any IP-literal host (IPv4 or IPv6, brackets and
+ *     zone-ids stripped) that lands in a private / loopback / link-local /
+ *     metadata / unspecified range *before* we open a socket. No DNS needed.
+ *
+ *  2. `makeSsrfLookup` / `createSsrfSafeAgent` — a custom DNS lookup wired into
+ *     the undici dispatcher. For every connection (initial request *and* each
+ *     redirect hop) it resolves the hostname, rejects if ANY resolved address
+ *     is blocked, and connects to exactly the address it validated. Because the
+ *     dispatcher performs the only name resolution, there is no second lookup an
+ *     attacker can answer differently — this closes the DNS-alias bypass and the
+ *     DNS-rebinding TOCTOU window (the validated address is pinned through
+ *     connection establishment).
+ */
+
+export type HostResolver = (hostname: string) => Promise<string[]>;
+
+/** Real resolver — all A/AAAA records, in system order. */
+export const defaultResolver: HostResolver = (hostname) =>
+  new Promise((resolve, reject) => {
+    dnsLookup(hostname, { all: true, verbatim: true }, (err, addresses) => {
+      if (err) reject(err);
+      else resolve(addresses.map((a) => a.address));
+    });
+  });
+
+/** IPv4 dotted-quad → blocked if private / loopback / link-local / etc. */
+const isBlockedV4 = (ip: string): boolean => {
+  const o = ip.split('.').map((s) => Number(s));
+  if (o.length !== 4 || o.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true; // unparseable → fail closed
+  }
+  const [a, b] = o as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 "this network" / unspecified
+  if (a === 10) return true; // 10/8 private
+  if (a === 127) return true; // 127/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254/16 link-local (incl. cloud metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
+  if (a === 192 && b === 168) return true; // 192.168/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  if (a >= 224) return true; // 224/4 multicast + 240/4 reserved
+  return false;
+};
+
+/**
+ * Extract an embedded IPv4 from an IPv4-mapped/-compatible IPv6 address, in
+ * either textual form: `::ffff:127.0.0.1` or its compressed hex form
+ * `::ffff:7f00:1`. Returns null when there's no embedded IPv4.
+ */
+const extractMappedV4 = (ip: string): string | null => {
+  const m = ip.match(/^::(?:ffff:)?(.+)$/);
+  if (!m || !m[1]) return null;
+  const rest = m[1];
+  if (isIP(rest) === 4) return rest; // ::ffff:127.0.0.1
+  const parts = rest.split(':');
+  if (parts.length === 2) {
+    const hi = parseInt(parts[0]!, 16);
+    const lo = parseInt(parts[1]!, 16);
+    if (Number.isFinite(hi) && Number.isFinite(lo)) {
+      return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+    }
+  }
+  return null;
+};
+
+/**
+ * True if a *resolved* IP literal (v4 or v6) is in a range we refuse to fetch
+ * from. Anything we can't recognise as a routable public address fails closed.
+ */
+export const isBlockedAddress = (raw: string): boolean => {
+  let ip = raw.trim().toLowerCase();
+  const pct = ip.indexOf('%'); // strip zone-id, e.g. fe80::1%eth0
+  if (pct !== -1) ip = ip.slice(0, pct);
+
+  const fam = isIP(ip);
+  if (fam === 4) return isBlockedV4(ip);
+  if (fam === 6) {
+    const mapped = extractMappedV4(ip);
+    if (mapped) return isBlockedV4(mapped);
+    if (ip === '::1' || ip === '::') return true; // loopback / unspecified
+    if (ip.startsWith('fc') || ip.startsWith('fd')) return true; // fc00::/7 ULA
+    if (/^fe[89ab]/.test(ip)) return true; // fe80::/10 link-local
+    if (ip.startsWith('ff')) return true; // ff00::/8 multicast
+    return false;
+  }
+  return true; // not an IP literal we understand → fail closed
+};
+
+/**
+ * Synchronous pre-connection check on a URL hostname. Strips IPv6 brackets
+ * (`URL.hostname` keeps them, e.g. `[::1]`) and zone-ids before testing IP
+ * literals. Non-literal hostnames return false here — they're validated by the
+ * dispatcher lookup once resolved.
+ */
+export const isBlockedLiteralHost = (hostname: string): boolean => {
+  let h = hostname.trim().toLowerCase();
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1);
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (isIP(h) !== 0) return isBlockedAddress(h);
+  return false;
+};
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address?: string | { address: string; family: number }[],
+  family?: number,
+) => void;
+
+type LookupOptions = { all?: boolean };
+
+/**
+ * Build a `net`-compatible lookup that resolves via `resolver`, rejects if any
+ * resolved address is blocked, and otherwise returns the validated address(es)
+ * — pinning the connection to what was validated.
+ */
+export const makeSsrfLookup =
+  (resolver: HostResolver = defaultResolver) =>
+  (hostname: string, options: LookupOptions, callback: LookupCallback): void => {
+    resolver(hostname)
+      .then((addresses) => {
+        if (addresses.length === 0) {
+          callback(new Error(`SSRF guard: "${hostname}" has no DNS records`));
+          return;
+        }
+        const blocked = addresses.find((a) => isBlockedAddress(a));
+        if (blocked) {
+          callback(
+            new Error(
+              `SSRF guard: "${hostname}" resolves to blocked address ${blocked}`,
+            ),
+          );
+          return;
+        }
+        if (options && options.all) {
+          callback(
+            null,
+            addresses.map((a) => ({ address: a, family: isIP(a) === 6 ? 6 : 4 })),
+          );
+        } else {
+          const chosen = addresses[0]!;
+          callback(null, chosen, isIP(chosen) === 6 ? 6 : 4);
+        }
+      })
+      .catch((err) => {
+        callback(err instanceof Error ? err : new Error(String(err)));
+      });
+  };
+
+/**
+ * An undici dispatcher whose connector resolves + validates + pins every
+ * outbound connection (including redirect hops) through `makeSsrfLookup`.
+ * Caller owns the returned Agent and should `await agent.close()` when done.
+ */
+export const createSsrfSafeAgent = (resolver: HostResolver = defaultResolver): Agent =>
+  new Agent({
+    connect: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      lookup: makeSsrfLookup(resolver) as any,
+    },
+  });

--- a/apps/agent/test/attachment-ssrf.test.ts
+++ b/apps/agent/test/attachment-ssrf.test.ts
@@ -1,15 +1,8 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import { test } from 'node:test';
 
 import { OpenHermitError } from '@openhermit/shared';
-import {
-  DbAttachmentStore,
-  LocalAttachmentStorage,
-} from '@openhermit/store';
 
 import { resolveAttachmentByUrl } from '../src/attachments/index.js';
 import {
@@ -103,7 +96,14 @@ const runLookup = (
 ): Promise<{ err: Error | null; address?: unknown; family?: number }> =>
   new Promise((resolve) => {
     makeSsrfLookup(resolver)(hostname, options, (err, address, family) => {
-      resolve({ err: err ?? null, address, family });
+      // Build conditionally: under exactOptionalPropertyTypes an explicit
+      // `address: undefined` is not assignable to an optional `address?`.
+      const out: { err: Error | null; address?: unknown; family?: number } = {
+        err: err ?? null,
+      };
+      if (address !== undefined) out.address = address;
+      if (family !== undefined) out.family = family;
+      resolve(out);
     });
   });
 
@@ -150,23 +150,22 @@ test('makeSsrfLookup: returns all validated addresses when options.all', async (
 
 // ─── End-to-end through resolveAttachmentByUrl (injected resolver) ─────────
 
-async function buildCtx(t: import('node:test').TestContext) {
-  const attachmentStore = await DbAttachmentStore.open();
-  t.after(() => attachmentStore.close());
-  const storageRoot = await mkdtemp(path.join(tmpdir(), 'openhermit-ssrf-'));
-  t.after(() => rm(storageRoot, { recursive: true, force: true }));
-  const attachmentStorage = new LocalAttachmentStorage({ root: storageRoot });
-  const runner = {
-    materializeAttachmentToSandbox: async () => ({
-      sandboxId: 'sb',
-      sandboxPath: '/x',
-    }),
-  };
-  return { attachmentStore, attachmentStorage, runner };
-}
+// The fetch is refused at connect, so persistence is never reached. These
+// stubs throw if touched — proving no bytes are ever stored — and let the test
+// run without a database.
+const unreachable = (label: string) =>
+  new Proxy(
+    {},
+    {
+      get() {
+        return () => {
+          throw new Error(`${label} must not be reached when connect is blocked`);
+        };
+      },
+    },
+  );
 
-test('resolveAttachmentByUrl: DNS-alias host (public name → private IP) is blocked at connect', async (t) => {
-  const ctx = await buildCtx(t);
+test('resolveAttachmentByUrl: DNS-alias host (public name → private IP) is blocked at connect', async () => {
   // A perfectly ordinary-looking hostname that we make resolve to loopback.
   // It clears the literal-host pre-filter, then the pinned dispatcher lookup
   // refuses to connect — no socket to an internal target is ever opened.
@@ -180,10 +179,12 @@ test('resolveAttachmentByUrl: DNS-alias host (public name → private IP) is blo
         uploaderUserId: null,
         url: 'https://images.totally-legit-cdn.test/cat.png',
         maxBytes: 1024 * 1024,
-        attachmentStore: ctx.attachmentStore,
-        attachmentStorage: ctx.attachmentStorage,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        runtime: ctx.runner as any,
+        attachmentStore: unreachable('attachmentStore') as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        attachmentStorage: unreachable('attachmentStorage') as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        runtime: unreachable('runtime') as any,
         resolveHost,
       }),
     (err: unknown) =>

--- a/apps/agent/test/attachment-ssrf.test.ts
+++ b/apps/agent/test/attachment-ssrf.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { OpenHermitError } from '@openhermit/shared';
+import {
+  DbAttachmentStore,
+  LocalAttachmentStorage,
+} from '@openhermit/store';
+
+import { resolveAttachmentByUrl } from '../src/attachments/index.js';
+import {
+  isBlockedAddress,
+  isBlockedLiteralHost,
+  makeSsrfLookup,
+  type HostResolver,
+} from '../src/attachments/ssrf.js';
+
+// ─── isBlockedAddress: resolved IP literals ───────────────────────────────
+
+test('isBlockedAddress: blocks private / loopback / link-local / metadata v4', () => {
+  for (const ip of [
+    '127.0.0.1',
+    '127.1.2.3',
+    '10.0.0.1',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '169.254.169.254', // cloud metadata
+    '0.0.0.0',
+    '100.64.0.1', // CGNAT
+    '224.0.0.1', // multicast
+  ]) {
+    assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+  }
+});
+
+test('isBlockedAddress: allows routable public v4', () => {
+  for (const ip of ['1.1.1.1', '8.8.8.8', '93.184.216.34', '172.15.0.1', '172.32.0.1']) {
+    assert.equal(isBlockedAddress(ip), false, `${ip} should be allowed`);
+  }
+});
+
+test('isBlockedAddress: blocks v6 loopback / ULA / link-local / mapped-v4', () => {
+  for (const ip of [
+    '::1',
+    '::',
+    'fc00::1',
+    'fd12:3456::1',
+    'fe80::1',
+    'fe80::1%eth0', // zone id stripped
+    '::ffff:127.0.0.1', // IPv4-mapped, dotted
+    '::ffff:7f00:1', // IPv4-mapped, hex form (== 127.0.0.1)
+    '::ffff:a9fe:a9fe', // 169.254.169.254
+    'ff02::1', // multicast
+  ]) {
+    assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+  }
+});
+
+test('isBlockedAddress: allows public v6 and mapped-public-v4', () => {
+  assert.equal(isBlockedAddress('2606:4700:4700::1111'), false);
+  assert.equal(isBlockedAddress('::ffff:8.8.8.8'), false);
+});
+
+test('isBlockedAddress: fails closed on garbage', () => {
+  assert.equal(isBlockedAddress('not-an-ip'), true);
+  assert.equal(isBlockedAddress(''), true);
+});
+
+// ─── isBlockedLiteralHost: URL.hostname forms ─────────────────────────────
+
+test('isBlockedLiteralHost: strips IPv6 brackets (regression: [::1] bypass)', () => {
+  // URL.hostname keeps the brackets; the old guard compared against "::1" and
+  // never matched, so https://[::1]/ reached fetch. This locks that shut.
+  assert.equal(isBlockedLiteralHost('[::1]'), true);
+  assert.equal(isBlockedLiteralHost('[fe80::1]'), true);
+  assert.equal(isBlockedLiteralHost('[::ffff:127.0.0.1]'), true);
+});
+
+test('isBlockedLiteralHost: blocks localhost and numeric IPv4 literals', () => {
+  assert.equal(isBlockedLiteralHost('localhost'), true);
+  assert.equal(isBlockedLiteralHost('foo.localhost'), true);
+  assert.equal(isBlockedLiteralHost('127.0.0.1'), true);
+  assert.equal(isBlockedLiteralHost('169.254.169.254'), true);
+});
+
+test('isBlockedLiteralHost: passes ordinary hostnames (resolved later)', () => {
+  // Not a literal IP — the dispatcher lookup validates it post-resolution.
+  assert.equal(isBlockedLiteralHost('cdn.example.com'), false);
+  assert.equal(isBlockedLiteralHost('8.8.8.8.nip.io'), false);
+});
+
+// ─── makeSsrfLookup: resolve → validate → pin ─────────────────────────────
+
+const runLookup = (
+  resolver: HostResolver,
+  hostname: string,
+  options: { all?: boolean } = {},
+): Promise<{ err: Error | null; address?: unknown; family?: number }> =>
+  new Promise((resolve) => {
+    makeSsrfLookup(resolver)(hostname, options, (err, address, family) => {
+      resolve({ err: err ?? null, address, family });
+    });
+  });
+
+test('makeSsrfLookup: rejects a host that resolves to a blocked address (DNS alias)', async () => {
+  const r = await runLookup(async () => ['169.254.169.254'], 'metadata.evil.test');
+  assert.ok(r.err, 'expected an error');
+  assert.match(r.err!.message, /SSRF guard/);
+  assert.match(r.err!.message, /169\.254\.169\.254/);
+});
+
+test('makeSsrfLookup: rejects when ANY resolved address is blocked', async () => {
+  const r = await runLookup(
+    async () => ['93.184.216.34', '127.0.0.1'],
+    'mixed.evil.test',
+  );
+  assert.ok(r.err, 'one blocked address must reject the whole set');
+});
+
+test('makeSsrfLookup: rejects empty resolution', async () => {
+  const r = await runLookup(async () => [], 'void.test');
+  assert.ok(r.err);
+  assert.match(r.err!.message, /no DNS records/);
+});
+
+test('makeSsrfLookup: pins the validated public address (single form)', async () => {
+  const r = await runLookup(async () => ['93.184.216.34'], 'cdn.example.com');
+  assert.equal(r.err, null);
+  assert.equal(r.address, '93.184.216.34');
+  assert.equal(r.family, 4);
+});
+
+test('makeSsrfLookup: returns all validated addresses when options.all', async () => {
+  const r = await runLookup(
+    async () => ['93.184.216.34', '2606:4700::1111'],
+    'cdn.example.com',
+    { all: true },
+  );
+  assert.equal(r.err, null);
+  assert.deepEqual(r.address, [
+    { address: '93.184.216.34', family: 4 },
+    { address: '2606:4700::1111', family: 6 },
+  ]);
+});
+
+// ─── End-to-end through resolveAttachmentByUrl (injected resolver) ─────────
+
+async function buildCtx(t: import('node:test').TestContext) {
+  const attachmentStore = await DbAttachmentStore.open();
+  t.after(() => attachmentStore.close());
+  const storageRoot = await mkdtemp(path.join(tmpdir(), 'openhermit-ssrf-'));
+  t.after(() => rm(storageRoot, { recursive: true, force: true }));
+  const attachmentStorage = new LocalAttachmentStorage({ root: storageRoot });
+  const runner = {
+    materializeAttachmentToSandbox: async () => ({
+      sandboxId: 'sb',
+      sandboxPath: '/x',
+    }),
+  };
+  return { attachmentStore, attachmentStorage, runner };
+}
+
+test('resolveAttachmentByUrl: DNS-alias host (public name → private IP) is blocked at connect', async (t) => {
+  const ctx = await buildCtx(t);
+  // A perfectly ordinary-looking hostname that we make resolve to loopback.
+  // It clears the literal-host pre-filter, then the pinned dispatcher lookup
+  // refuses to connect — no socket to an internal target is ever opened.
+  const resolveHost: HostResolver = async () => ['127.0.0.1'];
+
+  await assert.rejects(
+    () =>
+      resolveAttachmentByUrl({
+        agentId: `t-${randomUUID().slice(0, 8)}`,
+        sessionId: `s-${randomUUID().slice(0, 8)}`,
+        uploaderUserId: null,
+        url: 'https://images.totally-legit-cdn.test/cat.png',
+        maxBytes: 1024 * 1024,
+        attachmentStore: ctx.attachmentStore,
+        attachmentStorage: ctx.attachmentStorage,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        runtime: ctx.runner as any,
+        resolveHost,
+      }),
+    (err: unknown) =>
+      err instanceof OpenHermitError && err.code === 'attachment_fetch_failed',
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "magic-bytes.js": "^1.13.0",
         "mime-types": "^3.0.2",
         "prom-client": "^15.1.3",
+        "undici": "^7.25.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary

Closes an **authenticated SSRF** in the inbound attachment URL-passthrough path (`apps/agent/src/attachments/persist.ts`, called from `apps/gateway/src/app.ts:1262` on `POST .../sessions/:sessionId/messages`). Reported privately via the public commit email after the Amiko security contact bounced (550).

A session participant can post an attachment shaped `{ type: 'file', url }`; the gateway fetches the URL server-side and persists the bytes as a session attachment the same participant can then download. The old guard inspected only the **literal URL hostname** and never resolved DNS — so a host that *resolves* to an internal address slipped through, turning this into full-read SSRF (cloud-metadata credential theft, internal service reads).

## Two holes fixed

1. **DNS-alias / rebinding bypass (reported).** Validation now runs through a custom **undici dispatcher lookup** on every connection (initial + each redirect hop): it resolves the host, rejects if **any** resolved address is private/loopback/link-local/metadata, and connects to **exactly** the validated address. Because the dispatcher does the only name resolution, there's no second, attacker-controlled lookup at connect time — the address is **pinned** through connection establishment, closing the rebinding TOCTOU. TLS SNI/cert validation stays bound to the original hostname.

2. **IPv6 loopback bypass (found while fixing).** `URL.hostname` returns IPv6 literals **with brackets** (`[::1]`), so the old `::1`/`fc`/`fe8` prefix checks never matched — `https://[::1]/` reached `fetch` unguarded. `isBlockedLiteralHost` now strips brackets + zone-ids before testing. (The code comment "Brackets are stripped by URL.hostname" was simply wrong.)

Also hardened the range checks: IPv4-mapped IPv6 (`::ffff:127.0.0.1` and its hex form), CGNAT `100.64/10`, multicast/reserved, and **fail-closed** on anything not recognised as a routable public address.

## Scope / impact
- Auth context unchanged: still requires a session participant (`requireAuth` + `requireSessionAccessHttp`). Severity is **High** (authenticated, but metadata/internal reachability with response exfiltration).
- No API/shape change. Legitimate public-CDN fetches behave identically.
- Adds `undici` (already the transitive `fetch` impl) as an explicit dependency.

## Tests
New `apps/agent/test/attachment-ssrf.test.ts`:
- `isBlockedAddress` / `isBlockedLiteralHost` across v4, v6, mapped-v4, bracketed `[::1]` regression, garbage → fail-closed.
- `makeSsrfLookup`: rejects DNS-alias to a blocked IP, rejects mixed sets, pins validated address, handles `all`.
- End-to-end: `resolveAttachmentByUrl` with an injected resolver (public-looking host → `127.0.0.1`) is blocked at connect — no socket to an internal target is opened.

All 26 tests in the SSRF + existing passthrough suites pass.

## Follow-up (not in this PR)
The published security contact on the Amiko site returns 550 — worth fixing so the next report doesn't have to fall back to a commit email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened SSRF protections for attachment URL fetching to block private/loopback/metadata addresses and validate DNS/resolved addresses across redirects.
* **Chores**
  * Added runtime networking dependency for improved request handling.
* **Tests**
  * Added comprehensive SSRF-focused tests covering address blocking, hostname resolution failures, and end-to-end attachment fetch blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->