### PR TITLE
feat(admin-ui): paginate the list panels (20/page)

### DIFF
--- a/apps/gateway/ui/src/components/FleetPanel.tsx
+++ b/apps/gateway/ui/src/components/FleetPanel.tsx
@@ -5,6 +5,7 @@ import { SecretsDialog } from './SecretsDialog';
 import { SecurityDialog } from './SecurityDialog';
 import { ConfigDialog } from './ConfigDialog';
 import { UsageDialog } from './UsageDialog';
+import { Pagination, usePagination } from './Pagination';
 
 export interface UsageWindow {
   inputTokens: number;
@@ -176,6 +177,8 @@ export function FleetPanel() {
     errors: fleet.reduce((acc, a) => acc + a.errors24h, 0),
   }), [fleet]);
 
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(fleet);
+
   return (
     <div className="panel">
       <div className="panel__header">
@@ -241,7 +244,7 @@ export function FleetPanel() {
             </tr>
           </thead>
           <tbody>
-            {fleet.map((a) => (
+            {pageItems.map((a) => (
               <tr key={a.agentId} className={selected.has(a.agentId) ? 'fleet-row--selected' : ''}>
                 <td>
                   <input
@@ -300,7 +303,7 @@ export function FleetPanel() {
         </div>
 
         <div className="fleet-cards">
-          {fleet.map((a) => (
+          {pageItems.map((a) => (
             <div
               key={a.agentId}
               className={`fleet-card${selected.has(a.agentId) ? ' fleet-card--selected' : ''}`}
@@ -363,6 +366,8 @@ export function FleetPanel() {
             </div>
           ))}
         </div>
+
+        <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
         </>
       )}
 

--- a/apps/gateway/ui/src/components/McpServersPanel.tsx
+++ b/apps/gateway/ui/src/components/McpServersPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api';
+import { Pagination, usePagination } from './Pagination';
 
 interface McpServerInfo {
   id: string;
@@ -40,6 +41,8 @@ export function McpServersPanel() {
 
   useEffect(() => { void load(); }, [load]);
 
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(servers);
+
   const handleDelete = async (id: string) => {
     if (!confirm(`Delete MCP server "${id}"? This will also remove all agent assignments.`)) return;
     try {
@@ -70,7 +73,7 @@ export function McpServersPanel() {
       )}
 
       <div className="skill-list">
-        {servers.map((s) => (
+        {pageItems.map((s) => (
           <div className="skill-card" key={s.id}>
             <div className="skill-card__info">
               <span className="skill-card__name">{s.name}</span>
@@ -92,6 +95,8 @@ export function McpServersPanel() {
           </div>
         ))}
       </div>
+
+      <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
 
       {showCreate && (
         <McpServerFormDialog

--- a/apps/gateway/ui/src/components/Pagination.tsx
+++ b/apps/gateway/ui/src/components/Pagination.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from 'react';
+
+/** Default rows per page across the admin list panels. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+interface PaginationState<T> {
+  /** 1-based current page. */
+  page: number;
+  setPage: (page: number) => void;
+  /** Total number of pages (>= 1). */
+  pageCount: number;
+  /** The slice of `items` for the current page. */
+  pageItems: T[];
+  total: number;
+  pageSize: number;
+}
+
+/**
+ * Client-side pagination over an in-memory array. The page auto-clamps when
+ * the list shrinks (e.g. after a delete or filter change) so we never strand
+ * the user on an empty page.
+ */
+export function usePagination<T>(items: T[], pageSize: number = DEFAULT_PAGE_SIZE): PaginationState<T> {
+  const [page, setPage] = useState(1);
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+
+  useEffect(() => {
+    if (page > pageCount) setPage(pageCount);
+  }, [page, pageCount]);
+
+  const safePage = Math.min(page, pageCount);
+  const pageItems = useMemo(
+    () => items.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [items, safePage, pageSize],
+  );
+
+  return { page: safePage, setPage, pageCount, pageItems, total: items.length, pageSize };
+}
+
+/**
+ * Compact pager: "X–Y of N" plus Prev/Next. Renders nothing when everything
+ * fits on a single page.
+ */
+export function Pagination({
+  page,
+  pageCount,
+  total,
+  pageSize,
+  onPage,
+}: {
+  page: number;
+  pageCount: number;
+  total: number;
+  pageSize: number;
+  onPage: (page: number) => void;
+}) {
+  if (pageCount <= 1) return null;
+  const from = (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+  return (
+    <div className="pagination">
+      <span className="pagination__info">
+        {from}–{to} of {total}
+      </span>
+      <div className="pagination__controls">
+        <button
+          className="btn btn--ghost btn--sm"
+          disabled={page <= 1}
+          onClick={() => onPage(page - 1)}
+        >
+          Prev
+        </button>
+        <span className="pagination__page">
+          {page} / {pageCount}
+        </span>
+        <button
+          className="btn btn--ghost btn--sm"
+          disabled={page >= pageCount}
+          onClick={() => onPage(page + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/gateway/ui/src/components/Pagination.tsx
+++ b/apps/gateway/ui/src/components/Pagination.tsx
@@ -58,7 +58,7 @@ export function Pagination({
   const from = (page - 1) * pageSize + 1;
   const to = Math.min(page * pageSize, total);
   return (
-    <div className="pagination">
+    <nav className="pagination" aria-label="Pagination">
       <span className="pagination__info">
         {from}–{to} of {total}
       </span>
@@ -81,6 +81,6 @@ export function Pagination({
           Next
         </button>
       </div>
-    </div>
+    </nav>
   );
 }

--- a/apps/gateway/ui/src/components/SandboxesPanel.tsx
+++ b/apps/gateway/ui/src/components/SandboxesPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
+import { Pagination, usePagination } from './Pagination';
 
 type RuntimeStatus = 'running' | 'exited' | 'created' | 'removed' | 'unknown';
 
@@ -70,6 +71,8 @@ export function SandboxesPanel() {
     total: sandboxes.length,
   };
 
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(sandboxes);
+
   return (
     <div className="panel">
       <div className="panel__header">
@@ -111,7 +114,7 @@ export function SandboxesPanel() {
                 </tr>
               </thead>
               <tbody>
-                {sandboxes.map((s) => (
+                {pageItems.map((s) => (
                   <tr key={s.id}>
                     <td>
                       <div className="fleet-cell-agent">
@@ -150,7 +153,7 @@ export function SandboxesPanel() {
           </div>
 
           <div className="fleet-cards">
-            {sandboxes.map((s) => (
+            {pageItems.map((s) => (
               <div key={s.id} className="fleet-card">
                 <div className="fleet-card__top">
                   <div className="fleet-card__heading">
@@ -182,6 +185,8 @@ export function SandboxesPanel() {
               </div>
             ))}
           </div>
+
+          <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
         </>
       )}
     </div>

--- a/apps/gateway/ui/src/components/SchedulesPanel.tsx
+++ b/apps/gateway/ui/src/components/SchedulesPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api';
+import { Pagination, usePagination } from './Pagination';
 
 interface AgentInfo {
   agentId: string;
@@ -111,6 +112,8 @@ export function SchedulesPanel() {
 
   const fmtTime = (t?: string) => t ? new Date(t).toLocaleString() : '—';
 
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(schedules);
+
   return (
     <div className="panel">
       <div className="panel__header">
@@ -144,7 +147,7 @@ export function SchedulesPanel() {
       )}
 
       <div className="schedule-list">
-        {schedules.map((s) => (
+        {pageItems.map((s) => (
           <div className="schedule-card" key={s.scheduleId}>
             <div className="schedule-card__info">
               <div>
@@ -176,6 +179,8 @@ export function SchedulesPanel() {
           </div>
         ))}
       </div>
+
+      <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
 
       {showCreate && agentId && (
         <CreateScheduleDialog

--- a/apps/gateway/ui/src/components/SkillsPanel.tsx
+++ b/apps/gateway/ui/src/components/SkillsPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api';
+import { Pagination, usePagination } from './Pagination';
 
 interface SkillInfo {
   id: string;
@@ -39,6 +40,8 @@ export function SkillsPanel() {
 
   useEffect(() => { void load(); }, [load]);
 
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(skills);
+
   const handleDelete = async (id: string) => {
     if (!confirm(`Delete skill "${id}"? This will also remove all agent assignments.`)) return;
     try {
@@ -69,7 +72,7 @@ export function SkillsPanel() {
       )}
 
       <div className="skill-list">
-        {skills.map((s) => (
+        {pageItems.map((s) => (
           <div className="skill-card" key={s.id}>
             <div className="skill-card__info">
               <span className="skill-card__name">{s.name}</span>
@@ -91,6 +94,8 @@ export function SkillsPanel() {
           </div>
         ))}
       </div>
+
+      <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
 
       {showCreate && (
         <SkillFormDialog

--- a/apps/gateway/ui/src/components/UsersPanel.tsx
+++ b/apps/gateway/ui/src/components/UsersPanel.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { api } from '../api';
+import { Pagination, usePagination } from './Pagination';
 
 interface UserSummary {
   userId: string;
@@ -59,6 +60,8 @@ export function UsersPanel() {
     const id = setInterval(load, REFRESH_MS);
     return () => clearInterval(id);
   }, [load]);
+
+  const { page, setPage, pageCount, pageItems, total, pageSize } = usePagination(users);
 
   const toggleExpand = async (userId: string) => {
     if (expanded === userId) {
@@ -122,7 +125,7 @@ export function UsersPanel() {
                 </tr>
               </thead>
               <tbody>
-                {users.map((u) => (
+                {pageItems.map((u) => (
                   <Fragment key={u.userId}>
                     <tr>
                       <td>
@@ -167,7 +170,7 @@ export function UsersPanel() {
           </div>
 
           <div className="fleet-cards">
-            {users.map((u) => (
+            {pageItems.map((u) => (
               <div key={u.userId} className="fleet-card">
                 <div className="fleet-card__top">
                   <div className="fleet-card__heading">
@@ -208,6 +211,8 @@ export function UsersPanel() {
               </div>
             ))}
           </div>
+
+          <Pagination page={page} pageCount={pageCount} total={total} pageSize={pageSize} onPage={setPage} />
         </>
       )}
     </div>

--- a/apps/gateway/ui/src/styles.css
+++ b/apps/gateway/ui/src/styles.css
@@ -1193,3 +1193,32 @@ dialog::backdrop { background: rgba(9, 9, 11, 0.4); }
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+
+/* ── Pagination ─────────────────────────────────────────────────────── */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.pagination__info {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.pagination__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pagination__page {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 56px;
+  text-align: center;
+}


### PR DESCRIPTION
The admin UI list panels rendered their entire list in one go, which gets unwieldy on busy deployments. This adds **client-side pagination, default 20 rows/page**.

## What
- New reusable **`usePagination` hook + `<Pagination>` component** (`components/Pagination.tsx`): compact `X–Y of N` + Prev/Next, **hidden when everything fits on one page**. The hook **auto-clamps** the current page when the list shrinks (after a delete/filter) so you're never stranded on an empty page.
- Applied to the six main list panels:
  - **Fleet** (agents) — pages the table + card views together
  - **Skills**
  - **Users** — table + cards
  - **MCP Servers**
  - **Schedules** (the schedule list; the agent selector is untouched)
  - **Sandboxes** — table + cards

## Notes
- Purely client-side over the already-fetched arrays — no API/protocol changes. (If a deployment ever has thousands of rows, server-side paging would be a follow-up, but client-side is the right fit for the current fetch-all endpoints.)
- Selection in Fleet still operates across the whole fleet (Select-all selects all agents, not just the visible page) — intentional.
- Ships with the next `openhermit` CLI release (the admin UI is bundled into the gateway, built at package time — no `dist` committed).

Gateway UI builds clean (`vite build`) and typechecks (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination for fleets, servers, sandboxes, schedules, skills, and users. Lists now show 20 items per page with Prev/Next and a concise "X–Y of N" summary to navigate large result sets.

* **Style**
  * Added pagination styles for layout, controls, and summary text to match the app UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->