### PR TITLE
fix(agent): recover an open session after a mid-stream failure

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -57,6 +57,8 @@ import {
   extractToolResultDetails,
   extractToolResultText,
   isAssistantMessage,
+  isEmptyAssistantTurn,
+  stripEmptyAssistantTurns,
   serializeDetails,
 } from './agent-runner/message-utils.js';
 import {
@@ -2707,10 +2709,16 @@ export class AgentRunner implements SessionRuntime {
       ? restoredMessages
       : messages;
 
+    // Defensive guard: never send a failed/aborted empty assistant placeholder
+    // back to the provider. handleRunError already pops it from the live
+    // transcript, but strip here too so resumed sessions and any other path
+    // can't re-send one (providers 400 on empty content, stranding the session).
+    const cleanedMessages = stripEmptyAssistantTurns(allMessages);
+
     // Truncate oversized tool results before compaction so that a single
     // huge tool response cannot blow past the entire context window.
     const model = resolveModel(config);
-    const truncatedMessages = truncateToolResults(allMessages, model.contextWindow);
+    const truncatedMessages = truncateToolResults(cleanedMessages, model.contextWindow);
 
     // Only offer LLM compaction when we have a dedicated API key.
     // When streamFn is provided (tests, proxied setups), the shared stream
@@ -3169,6 +3177,21 @@ export class AgentRunner implements SessionRuntime {
     this.clearIdleSummaryTimer(session);
     session.updatedAt = ts;
     session.status = 'idle';
+
+    // A mid-stream failure (credit depletion, transient 5xx, …) leaves
+    // pi-agent-core's empty "error" assistant placeholder at the tail of the
+    // live transcript. Drop it so the next turn retries from clean history —
+    // otherwise the cached session keeps re-sending an empty assistant turn,
+    // which providers reject, and the session stays stuck even after the
+    // underlying cause is resolved (new sessions work, this one never does).
+    const stateMessages = session.agent.state.messages;
+    while (
+      stateMessages.length > 0 &&
+      isEmptyAssistantTurn(stateMessages[stateMessages.length - 1]!)
+    ) {
+      stateMessages.pop();
+    }
+
     agentErrorsTotal.inc({ agent_id: this.scope.agentId, source: 'runtime' });
     if (session.turnStartMs) {
       agentTurnDuration.observe(

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -12,6 +12,43 @@ export const isAssistantMessage = (
   'role' in message &&
   message.role === 'assistant';
 
+/**
+ * A failed/aborted assistant turn that carries no usable content. When a
+ * provider stream throws mid-turn (e.g. credit depletion, a transient 5xx),
+ * pi-agent-core records the failure as an assistant message with empty content
+ * and `stopReason: 'error' | 'aborted'` (see its `handleRunFailure`). That
+ * placeholder is never a valid thing to send back to a provider — an empty
+ * content block makes Anthropic (and most providers) reject the *next* request
+ * with a 400, so a session that hit a failure keeps failing even after the
+ * underlying cause is resolved. Detect those so we can drop them.
+ *
+ * The check is deliberately narrow: only assistant turns with no meaningful
+ * content (no non-empty text, no tool call, no thinking) qualify, so we never
+ * orphan tool results or discard a partial reply that actually said something.
+ */
+export const isEmptyAssistantTurn = (message: AgentMessage): boolean => {
+  if (!isAssistantMessage(message)) return false;
+  const content = Array.isArray(message.content) ? message.content : [];
+  const hasUsableContent = content.some((block) => {
+    if (!block || typeof block !== 'object' || !('type' in block)) return false;
+    if (block.type === 'text') {
+      return typeof (block as TextContent).text === 'string'
+        && (block as TextContent).text.trim().length > 0;
+    }
+    // Any non-text block (toolCall, thinking, etc.) counts as usable content.
+    return true;
+  });
+  return !hasUsableContent;
+};
+
+/**
+ * Remove failed/aborted placeholder assistant turns (see `isEmptyAssistantTurn`)
+ * from a message history. Used both to clean the live in-memory transcript after
+ * a run failure and as a defensive guard right before LLM conversion.
+ */
+export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage[] =>
+  messages.filter((message) => !isEmptyAssistantTurn(message));
+
 export const extractAssistantText = (message: AssistantMessage): string => {
   const textParts = message.content
     .filter((content): content is Extract<typeof content, { type: 'text' }> => content.type === 'text')

--- a/apps/agent/test/empty-assistant-turn.test.ts
+++ b/apps/agent/test/empty-assistant-turn.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+
+import {
+  isEmptyAssistantTurn,
+  stripEmptyAssistantTurns,
+} from '../src/agent-runner/message-utils.js';
+
+/** The placeholder pi-agent-core pushes when a stream throws mid-turn. */
+const failurePlaceholder = (stopReason: 'error' | 'aborted'): AgentMessage =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'text', text: '' }],
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude',
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    stopReason,
+    errorMessage: 'insufficient credits',
+    timestamp: 1,
+  }) as unknown as AgentMessage;
+
+const userMsg = (text: string): AgentMessage =>
+  ({ role: 'user', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AgentMessage;
+
+const assistantMsg = (text: string): AgentMessage =>
+  ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AgentMessage;
+
+const assistantToolCall = (): AgentMessage =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'toolCall', id: 't1', name: 'bash', arguments: {} }],
+    stopReason: 'toolUse',
+    timestamp: 1,
+  }) as unknown as AgentMessage;
+
+test('isEmptyAssistantTurn flags the empty error/aborted placeholders', () => {
+  assert.equal(isEmptyAssistantTurn(failurePlaceholder('error')), true);
+  assert.equal(isEmptyAssistantTurn(failurePlaceholder('aborted')), true);
+  // Whitespace-only content is still empty.
+  assert.equal(isEmptyAssistantTurn(assistantMsg('   \n ')), true);
+});
+
+test('isEmptyAssistantTurn does not flag real content or other roles', () => {
+  assert.equal(isEmptyAssistantTurn(assistantMsg('hello')), false);
+  assert.equal(isEmptyAssistantTurn(assistantToolCall()), false); // tool call is usable content
+  assert.equal(isEmptyAssistantTurn(userMsg('')), false); // never touch user/tool messages
+});
+
+test('stripEmptyAssistantTurns removes the poison left by a depleted turn', () => {
+  // Transcript after a credit-depletion failure: user asked, the failed turn
+  // recorded an empty assistant placeholder, then the user retried.
+  const history = [
+    userMsg('first question'),
+    failurePlaceholder('error'),
+    userMsg('retry after top-up'),
+  ];
+  const cleaned = stripEmptyAssistantTurns(history);
+  assert.deepEqual(
+    cleaned.map((m) => m.role),
+    ['user', 'user'],
+  );
+  // The real messages are preserved verbatim.
+  assert.equal((cleaned[0]!.content as { text: string }[])[0]!.text, 'first question');
+  assert.equal((cleaned[1]!.content as { text: string }[])[0]!.text, 'retry after top-up');
+});
+
+test('stripEmptyAssistantTurns keeps a healthy transcript intact', () => {
+  const history = [userMsg('hi'), assistantMsg('hello!'), userMsg('thanks')];
+  assert.deepEqual(stripEmptyAssistantTurns(history), history);
+});


### PR DESCRIPTION
## The report
> When a session is open during a credit depletion event, that session fails to detect when new credits are added. Starting a brand-new session works fine, but the original session remains unaware of the updated balance.

**Reproduced and root-caused.** It's not actually about detecting the balance — the open session's transcript gets poisoned and every later turn 400s.

## Root cause
When a provider stream throws mid-turn (credit depletion → 402, or any transient error), pi-agent-core's `handleRunFailure` records the failure as an **assistant message with empty content** (`content: [{type:'text', text:''}]`, `stopReason: 'error'`) and pushes it into the live in-memory transcript (`@mariozechner/pi-agent-core` `agent.js`).

OpenHermit's `handleRunError` (`agent-runner.ts`) only set the session idle + logged an error — it **never rolled that placeholder back**. Nothing else filtered it (`transformContext` doesn't, and the default `convertToLlm` filters by role only). The `Agent` is cached per live session, so the next turn re-sends an **empty assistant turn**, which Anthropic (and most providers) reject with a 400 — the session stays stuck even after credits return. A brand-new session builds a fresh `Agent` with a clean transcript, hence the asymmetry.

(The API key itself was never the issue — `resolveApiKey`/`getApiKey` resolve fresh each turn.)

## Fix (belt-and-suspenders)
1. **`handleRunError`** pops trailing empty failure placeholders off the live transcript, so the next turn retries from clean history.
2. **`transformContext`** strips empty assistant turns right before LLM conversion — a defensive guard that also covers resumed sessions and any other path.

New `isEmptyAssistantTurn` / `stripEmptyAssistantTurns` helpers in `message-utils`, deliberately narrow (only content-less assistant turns) so tool results are never orphaned and partial replies are never discarded.

## Tests
4 unit tests covering placeholder detection (error/aborted/whitespace), not flagging real content / tool calls / user turns, and stripping the poison while keeping healthy transcripts intact. Agent package builds + typechecks clean.

Bundled in the gateway/agent runtime — ships with the next `openhermit` CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where failed or aborted agent turns would repeatedly inject empty placeholder messages into session state, preventing sessions from recovering automatically on retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->