### PR TITLE
chore(cli): bump to 0.9.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,7 +243,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",


### PR DESCRIPTION
Releases the bundled changes merged after `0.9.2` was published. These are all bundled into the `openhermit` CLI (agent runtime + gateway UI), so they only reach users via a CLI publish.

- **#181** — SSRF fix in attachment URL passthrough (DNS rebinding + IPv6 loopback). **Security fix.**
- **#183** — recover an open session after a mid-stream failure (sessions no longer get stuck after credit depletion / transient errors).
- **#182** — admin UI list pagination (20/page).

Release after merge:
```
npm run build
npm publish -w openhermit
npm view openhermit version   # expect 0.9.3
```

Separately (not part of this PR): `@openhermit/channel-signal@0.2.0` is merged but unpublished — `npm publish -w @openhermit/channel-signal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version bumped to `0.9.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->