### PR TITLE
Strip copied [Name] speaker tags from group replies

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -59,6 +59,11 @@ import {
   isAssistantMessage,
   isEmptyAssistantTurn,
   stripEmptyAssistantTurns,
+  stripLeadingSpeakerTag,
+  normalizeSpeakerName,
+  newSpeakerTagStream,
+  pushSpeakerTagDelta,
+  flushSpeakerTagStream,
   serializeDetails,
 } from './agent-runner/message-utils.js';
 import {
@@ -1196,10 +1201,16 @@ export class AgentRunner implements SessionRuntime {
       : message.text;
     const promptMessage = { ...message, text: promptText };
 
+    // Remember senders so we can strip a copied `[Name]` tag from the reply.
+    if (isGroup && message.sender?.displayName) {
+      this.rememberGroupSender(session, message.sender.displayName);
+    }
+
     const run = async (): Promise<void> => {
       try {
         await this.refreshAgentConfiguration(session);
         session.latestAssistantText = undefined;
+        session.speakerTagStream = undefined;
         session.consecutiveToolFailures = 0;
         if (message.messageId !== undefined) {
           session.currentTurnCorrelationId = message.messageId;
@@ -1745,6 +1756,11 @@ export class AgentRunner implements SessionRuntime {
 
     this.logRuntime(`auto-created guest user ${guestId} for ${channel}:${channelUserId}`);
     return { userId: guestId, role: 'guest' as const, ...(name ? { userName: name } : {}), ...callerInfo };
+  }
+
+  private rememberGroupSender(session: RunnerSession, name: string | undefined): void {
+    if (!name?.trim()) return;
+    (session.groupSenderNames ??= new Set<string>()).add(normalizeSpeakerName(name));
   }
 
   /**
@@ -2431,6 +2447,9 @@ export class AgentRunner implements SessionRuntime {
       if (entry.role === 'user' && typeof entry.content === 'string') {
         lastAssistant = null;
         const userName = typeof entry.userName === 'string' ? entry.userName : undefined;
+        if (isGroup && userName && session) {
+          this.rememberGroupSender(session, userName);
+        }
         const textContent = isGroup && userName
           ? `[${userName}] ${entry.content}`
           : entry.content;
@@ -2894,13 +2913,41 @@ export class AgentRunner implements SessionRuntime {
           });
         }
 
+        // Same strip on the live stream as the final message; no-op until names exist.
+        const isGroupStream = session.spec.source.type === 'group';
+        if (event.assistantMessageEvent.type === 'text_start' && isGroupStream) {
+          session.speakerTagStream = newSpeakerTagStream();
+        }
+
         if (event.assistantMessageEvent.type === 'text_delta') {
-          void this.events.publish({
-            type: 'text_delta',
-            sessionId: session.spec.sessionId,
-            text: event.assistantMessageEvent.delta,
-            ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
-          });
+          const rawDelta = event.assistantMessageEvent.delta;
+          let outText = rawDelta;
+          if (isGroupStream) {
+            // In case the provider skipped text_start.
+            session.speakerTagStream ??= newSpeakerTagStream();
+            outText = pushSpeakerTagDelta(session.speakerTagStream, rawDelta, session.groupSenderNames ?? []);
+          }
+          if (outText.length > 0) {
+            void this.events.publish({
+              type: 'text_delta',
+              sessionId: session.spec.sessionId,
+              text: outText,
+              ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
+            });
+          }
+        }
+
+        if (event.assistantMessageEvent.type === 'text_end' && session.speakerTagStream) {
+          const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+          if (tail.length > 0) {
+            void this.events.publish({
+              type: 'text_delta',
+              sessionId: session.spec.sessionId,
+              text: tail,
+              ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
+            });
+          }
+          session.speakerTagStream = undefined;
         }
 
         if (event.assistantMessageEvent.type === 'error') {
@@ -2914,6 +2961,20 @@ export class AgentRunner implements SessionRuntime {
       }
 
       case 'message_end': {
+        // Backstop in case the provider emitted no text_end.
+        if (session.speakerTagStream) {
+          const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+          if (tail.length > 0) {
+            void this.events.publish({
+              type: 'text_delta',
+              sessionId: session.spec.sessionId,
+              text: tail,
+              ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
+            });
+          }
+          session.speakerTagStream = undefined;
+        }
+
         if (!isAssistantMessage(event.message)) {
           break;
         }
@@ -2922,6 +2983,12 @@ export class AgentRunner implements SessionRuntime {
         const thinkingText = extractThinkingText(event.message);
         const thinkingSignature = extractThinkingSignature(event.message);
         const assistantMessage = event.message;
+
+        // Used by both the normal and error paths so stored text matches the stream.
+        const cleanGroupText = (text: string): string =>
+          session.spec.source.type === 'group'
+            ? stripLeadingSpeakerTag(text, session.groupSenderNames ?? [])
+            : text;
 
         // Handle error responses from the model provider.
         if (assistantMessage.stopReason === 'error') {
@@ -2944,7 +3011,7 @@ export class AgentRunner implements SessionRuntime {
             await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
               ts,
               role: 'assistant',
-              content: assistantText ?? '',
+              content: cleanGroupText(assistantText ?? ''),
               ...(thinkingText ? { thinking: thinkingText } : {}),
               ...(thinkingSignature ? { thinkingSignature } : {}),
               provider: assistantMessage.provider,
@@ -2979,18 +3046,20 @@ export class AgentRunner implements SessionRuntime {
           break;
         }
 
+        const cleanedText = cleanGroupText(effectiveText);
+
         if (isFinalThinkingOnly) {
           void this.events.publish({
             type: 'text_final',
             sessionId: session.spec.sessionId,
-            text: thinkingText,
+            text: cleanedText,
             ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
           });
         }
 
-        session.latestAssistantText = effectiveText;
+        session.latestAssistantText = cleanedText;
         session.messageCount += 1;
-        session.lastMessagePreview = effectiveText;
+        session.lastMessagePreview = cleanedText;
         const ts = new Date().toISOString();
         session.updatedAt = ts;
         void this.queueSideEffect(session, () => this.persistSessionIndex(session));
@@ -3007,7 +3076,7 @@ export class AgentRunner implements SessionRuntime {
           await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
             ts,
             role: 'assistant',
-            content: effectiveText,
+            content: cleanedText,
             ...(effectiveThinking ? { thinking: effectiveThinking } : {}),
             ...(effectiveThinking && thinkingSignature ? { thinkingSignature } : {}),
             provider: assistantMessage.provider,

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -85,6 +85,111 @@ export const extractThinkingSignature = (message: AssistantMessage): string | un
 export const hasMeaningfulAssistantText = (text: string): boolean =>
   text.trim().length > 0;
 
+// The (?!\() excludes markdown links `[x](y)`; the length cap keeps it to a name.
+const LEADING_SPEAKER_TAG = /^\s*\[([^[\]\n]{1,80})\](?!\()\s*:?\s*/;
+
+// Strip a leading `[Name]` tag the model copied from the group input format
+// (`[DisplayName] text`), only when the name is a known participant. Unknown
+// tags and markdown links are left alone.
+export const stripLeadingSpeakerTag = (
+  text: string,
+  knownNames: Iterable<string>,
+): string => {
+  const match = LEADING_SPEAKER_TAG.exec(text);
+  if (!match) return text;
+
+  const known = toKnownSet(knownNames);
+  if (known.size === 0) return text;
+
+  const candidate = normalizeSpeakerName(match[1]!);
+  if (!known.has(candidate)) return text;
+
+  // An empty assistant turn corrupts the stored history, so keep the original.
+  const stripped = text.slice(match[0].length);
+  return stripped.trim().length > 0 ? stripped : text;
+};
+
+// So a name matches regardless of unicode composition or case.
+export const normalizeSpeakerName = (name: string): string =>
+  name.trim().normalize('NFC').toLowerCase();
+
+const toKnownSet = (knownNames: Iterable<string>): Set<string> => {
+  const known = new Set<string>();
+  for (const name of knownNames) {
+    const norm = normalizeSpeakerName(name);
+    if (norm) known.add(norm);
+  }
+  return known;
+};
+
+// Past this many chars, a leading tag is no longer plausible; stop buffering.
+const MAX_LEAD_BUFFER = 96;
+
+// Without this, a live token stream would flicker `[Name]` before the final
+// strip lands. Buffers the start of a text block until the tag resolves.
+export interface SpeakerTagStreamState {
+  buffer: string;
+  resolved: boolean;
+}
+
+export const newSpeakerTagStream = (): SpeakerTagStreamState => ({
+  buffer: '',
+  resolved: false,
+});
+
+const decideLead = (
+  buffer: string,
+  knownNames: Iterable<string>,
+): { resolved: false } | { resolved: true; emit: string } => {
+  const afterWs = buffer.replace(/^\s+/, '');
+  if (afterWs.length === 0) return { resolved: false };
+  if (afterWs[0] !== '[') return { resolved: true, emit: buffer };
+
+  const match = LEADING_SPEAKER_TAG.exec(buffer);
+  if (match) {
+    const rest = buffer.slice(match[0].length);
+    if (rest.trim().length > 0) {
+      return { resolved: true, emit: stripLeadingSpeakerTag(buffer, knownNames) };
+    }
+    // Tag closed but no content yet, so wait for more if it's a known sender.
+    const candidate = normalizeSpeakerName(match[1]!);
+    if (!toKnownSet(knownNames).has(candidate)) {
+      return { resolved: true, emit: buffer };
+    }
+    return { resolved: false };
+  }
+
+  // Open '[' that can no longer become a single-line tag.
+  if (afterWs.includes('\n') || buffer.length > MAX_LEAD_BUFFER) {
+    return { resolved: true, emit: buffer };
+  }
+  return { resolved: false };
+};
+
+// Returns '' while still buffering the lead, otherwise the text to emit.
+export const pushSpeakerTagDelta = (
+  state: SpeakerTagStreamState,
+  delta: string,
+  knownNames: Iterable<string>,
+): string => {
+  if (state.resolved) return delta;
+  state.buffer += delta;
+  const decision = decideLead(state.buffer, knownNames);
+  if (!decision.resolved) return '';
+  state.resolved = true;
+  return decision.emit;
+};
+
+// Idempotent: returns '' once the block has already resolved.
+export const flushSpeakerTagStream = (
+  state: SpeakerTagStreamState,
+  knownNames: Iterable<string>,
+): string => {
+  if (state.resolved) return '';
+  state.resolved = true;
+  return stripLeadingSpeakerTag(state.buffer, knownNames);
+};
+
 export const createUserMessage = (
   message: SessionMessage,
   attachmentContent: (TextContent | ImageContent)[] = [],

--- a/apps/agent/src/agent-runner/prompt.ts
+++ b/apps/agent/src/agent-runner/prompt.ts
@@ -24,24 +24,6 @@ const PRINCIPLES = `\
 - Never fabricate information. If tools (session history, memory, search, etc.) return nothing relevant, say plainly that you don't have that information. Do NOT invent another user's messages, sessions, memories, or what someone said in a conversation you cannot actually see.
 - Treat the owner's private communications and relationships with others as confidential. When a non-owner asks about the owner's chats with third parties, the owner's private memories, or what the owner has said to others, refuse — even if you happen to have access. Only the owner themselves may ask about their own private content.`;
 
-const STYLE = `\
-## How you talk
-
-You are talking to real people. Write the way a thoughtful person texts, not the way a corporate blog or a generic AI assistant writes.
-
-- Use plain, simple words and short sentences. Say things directly.
-- Use active voice. Talk to the person as "you".
-- Match their energy and length. In casual chat keep it short, often one to three sentences, and do not write an essay when a line will do. Brevity is about tone, not task depth: when someone asks for a real explanation, code, or detailed help, give them the full answer they need.
-- Send one focused reply per turn. Do not stack several alternate drafts, and do not restate the same point three different ways.
-- Never use em dashes. Use a comma, a period, or parentheses instead.
-- Cut the corporate and AI filler. Avoid words and phrases like: delve, tapestry, realm, navigate the landscape, testament, game-changer, unlock, harness, elevate, robust, seamless, dive deep, it's worth noting, when it comes to, that said, at the end of the day, in conclusion, in summary.
-- Skip clichés and stock metaphors. Say the real thing instead.
-- Drop the throat-clearing. No "Great question", no "I'd be happy to", no hedging or padding. Just answer.
-- Having a personality, an opinion, or some humor is good. Warmth beats polish.
-- Use formatting (lists, bold, code blocks) only when it genuinely helps, mostly for technical or task output. In normal conversation just write plain sentences.
-
-Your configured name and personality take precedence over this section. It shapes how you express yourself, not who you are. If your role calls for a formal register, stay formal. These rules just help you deliver that voice in a natural, human way instead of a corporate one.`;
-
 // ── Prompt builder ───────────────────────────────────────────────────
 
 export interface CurrentUserContext {
@@ -101,9 +83,6 @@ export const buildSystemPrompt = async (
 
   // 3. PRINCIPLES
   keyedSections.push({ key: 'principles', content: PRINCIPLES });
-
-  // 3b. STYLE: default conversational voice for all user-facing replies.
-  keyedSections.push({ key: 'style', content: STYLE });
 
   // 4. TOOLSET DESCRIPTIONS
   const descriptions = toolsets

--- a/apps/agent/src/agent-runner/prompt.ts
+++ b/apps/agent/src/agent-runner/prompt.ts
@@ -24,6 +24,24 @@ const PRINCIPLES = `\
 - Never fabricate information. If tools (session history, memory, search, etc.) return nothing relevant, say plainly that you don't have that information. Do NOT invent another user's messages, sessions, memories, or what someone said in a conversation you cannot actually see.
 - Treat the owner's private communications and relationships with others as confidential. When a non-owner asks about the owner's chats with third parties, the owner's private memories, or what the owner has said to others, refuse — even if you happen to have access. Only the owner themselves may ask about their own private content.`;
 
+const STYLE = `\
+## How you talk
+
+You are talking to real people. Write the way a thoughtful person texts, not the way a corporate blog or a generic AI assistant writes.
+
+- Use plain, simple words and short sentences. Say things directly.
+- Use active voice. Talk to the person as "you".
+- Match their energy and length. In casual chat keep it short, often one to three sentences, and do not write an essay when a line will do. Brevity is about tone, not task depth: when someone asks for a real explanation, code, or detailed help, give them the full answer they need.
+- Send one focused reply per turn. Do not stack several alternate drafts, and do not restate the same point three different ways.
+- Never use em dashes. Use a comma, a period, or parentheses instead.
+- Cut the corporate and AI filler. Avoid words and phrases like: delve, tapestry, realm, navigate the landscape, testament, game-changer, unlock, harness, elevate, robust, seamless, dive deep, it's worth noting, when it comes to, that said, at the end of the day, in conclusion, in summary.
+- Skip clichés and stock metaphors. Say the real thing instead.
+- Drop the throat-clearing. No "Great question", no "I'd be happy to", no hedging or padding. Just answer.
+- Having a personality, an opinion, or some humor is good. Warmth beats polish.
+- Use formatting (lists, bold, code blocks) only when it genuinely helps, mostly for technical or task output. In normal conversation just write plain sentences.
+
+Your configured name and personality take precedence over this section. It shapes how you express yourself, not who you are. If your role calls for a formal register, stay formal. These rules just help you deliver that voice in a natural, human way instead of a corporate one.`;
+
 // ── Prompt builder ───────────────────────────────────────────────────
 
 export interface CurrentUserContext {
@@ -83,6 +101,9 @@ export const buildSystemPrompt = async (
 
   // 3. PRINCIPLES
   keyedSections.push({ key: 'principles', content: PRINCIPLES });
+
+  // 3b. STYLE: default conversational voice for all user-facing replies.
+  keyedSections.push({ key: 'style', content: STYLE });
 
   // 4. TOOLSET DESCRIPTIONS
   const descriptions = toolsets

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -5,6 +5,7 @@ import type { ApprovalRequestStore, AttachmentStorage, AttachmentStore, Internal
 import type { LangfuseClientLike, LangfuseTurnContext } from '../langfuse.js';
 import type { SessionDescriptor } from '../runtime.js';
 import type { ApprovalGate } from './approval-gate.js';
+import type { SpeakerTagStreamState } from './message-utils.js';
 
 export interface RunnerSession extends SessionDescriptor {
   agent: Agent;
@@ -15,6 +16,9 @@ export interface RunnerSession extends SessionDescriptor {
   idleSummaryTimer: ReturnType<typeof setTimeout> | undefined;
   latestAssistantText: string | undefined;
   lastUserMessageText?: string;
+  // Sender names for stripping a copied `[Name]` tag from the reply. Group only.
+  groupSenderNames?: Set<string>;
+  speakerTagStream?: SpeakerTagStreamState | undefined;
   /** Inbound messageId of the user message that triggered the in-flight
    *  turn. Stamped onto every outbound event for that turn as
    *  `correlationId`, so callers can group events back to the originating

--- a/apps/agent/test/prompt.test.ts
+++ b/apps/agent/test/prompt.test.ts
@@ -28,7 +28,6 @@ test('buildSystemPrompt includes container mounting guidance when container tool
 
   assert.match(prompt, /Mounting files into service containers/);
   assert.match(prompt, /mount_target/);
-  assert.match(prompt, /Autonomy level: supervised/);
 });
 
 test('buildSystemPrompt omits container section when container toolset is absent', async (t) => {
@@ -40,7 +39,6 @@ test('buildSystemPrompt omits container section when container toolset is absent
 
   assert.doesNotMatch(prompt, /container_start/);
   assert.doesNotMatch(prompt, /mount_target/);
-  assert.match(prompt, /Autonomy level: supervised/);
 });
 
 test('buildSystemPrompt omits memory section when memory toolset is absent', async (t) => {
@@ -66,4 +64,15 @@ test('buildSystemPrompt includes all sections when all toolsets are present', as
   assert.match(prompt, /### Containers/);
   assert.match(prompt, /### Web/);
   assert.match(prompt, /### Instructions Management/);
+});
+
+test('buildSystemPrompt always includes the conversational style section', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  await security.load();
+  const config = await security.readConfig();
+
+  const prompt = await buildSystemPrompt(config, security, allToolsets);
+
+  assert.match(prompt, /## How you talk/);
+  assert.match(prompt, /Never use em dashes/);
 });

--- a/apps/agent/test/prompt.test.ts
+++ b/apps/agent/test/prompt.test.ts
@@ -65,14 +65,3 @@ test('buildSystemPrompt includes all sections when all toolsets are present', as
   assert.match(prompt, /### Web/);
   assert.match(prompt, /### Instructions Management/);
 });
-
-test('buildSystemPrompt always includes the conversational style section', async (t) => {
-  const { security } = await createSecurityFixture(t);
-  await security.load();
-  const config = await security.readConfig();
-
-  const prompt = await buildSystemPrompt(config, security, allToolsets);
-
-  assert.match(prompt, /## How you talk/);
-  assert.match(prompt, /Never use em dashes/);
-});

--- a/apps/agent/test/speaker-tag-stream.test.ts
+++ b/apps/agent/test/speaker-tag-stream.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  stripLeadingSpeakerTag,
+  newSpeakerTagStream,
+  pushSpeakerTagDelta,
+  flushSpeakerTagStream,
+} from '../src/agent-runner/message-utils.js';
+
+const NAMES = ['Matthew Graham', 'Alice', 'Leandro Gavidia'];
+
+// Run one text block through the guard (text_start -> deltas -> text_end) and
+// return the concatenation of everything emitted.
+const runStream = (chunks: string[], names: Iterable<string> = NAMES): string => {
+  const state = newSpeakerTagStream();
+  let out = '';
+  for (const chunk of chunks) out += pushSpeakerTagDelta(state, chunk, names);
+  out += flushSpeakerTagStream(state, names);
+  return out;
+};
+
+// Every fragmentation of `full`: one delta, char-by-char, and every two-way split.
+const fragmentations = (full: string): string[][] => {
+  const variants: string[][] = [[full], [...full]];
+  for (let i = 1; i < full.length; i += 1) {
+    variants.push([full.slice(0, i), full.slice(i)]);
+  }
+  return variants;
+};
+
+describe('speaker-tag stream: emit semantics', () => {
+  test('buffers a partial tag and emits nothing until it resolves', () => {
+    const state = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(state, '[Ali', NAMES), '');
+    assert.equal(pushSpeakerTagDelta(state, 'ce', NAMES), '');
+    assert.equal(pushSpeakerTagDelta(state, '] hello', NAMES), 'hello');
+  });
+
+  test('passes non-tag text through immediately, with no buffering', () => {
+    const state = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(state, 'Fair point.', NAMES), 'Fair point.');
+    assert.equal(pushSpeakerTagDelta(state, ' Nice.', NAMES), ' Nice.');
+  });
+
+  test('once resolved, later deltas pass through verbatim', () => {
+    const state = newSpeakerTagStream();
+    pushSpeakerTagDelta(state, '[Alice] ', NAMES);
+    assert.equal(pushSpeakerTagDelta(state, '[not a tag] more', NAMES), '[not a tag] more');
+  });
+
+  test('an empty delta is absorbed while buffering and passes through once resolved', () => {
+    const buffering = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(buffering, '[Ali', NAMES), '');
+    assert.equal(pushSpeakerTagDelta(buffering, '', NAMES), '');
+    assert.equal(pushSpeakerTagDelta(buffering, 'ce] hi', NAMES), 'hi');
+
+    const resolved = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(resolved, 'hello', NAMES), 'hello');
+    assert.equal(pushSpeakerTagDelta(resolved, '', NAMES), '');
+  });
+
+  test('an unclosed bracket followed by a newline emits the whole buffer', () => {
+    const state = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(state, '[Alice', NAMES), '');
+    assert.equal(pushSpeakerTagDelta(state, '\nmore text', NAMES), '[Alice\nmore text');
+  });
+
+  test('never leaks the tag in any emitted chunk', () => {
+    const state = newSpeakerTagStream();
+    const emitted: string[] = [];
+    for (const ch of [...'[Matthew Graham] hello world']) {
+      const out = pushSpeakerTagDelta(state, ch, NAMES);
+      if (out) emitted.push(out);
+    }
+    emitted.push(flushSpeakerTagStream(state, NAMES));
+    const firstReal = emitted.find((e) => e.trim().length > 0);
+    assert.ok(firstReal, 'expected at least one non-empty chunk to be emitted');
+    assert.ok(!firstReal.startsWith('['), `leaked a tag: ${JSON.stringify(firstReal)}`);
+    assert.equal(emitted.join(''), 'hello world');
+  });
+});
+
+describe('speaker-tag stream: flush', () => {
+  test('flush is idempotent', () => {
+    const state = newSpeakerTagStream();
+    pushSpeakerTagDelta(state, 'hello', NAMES);
+    assert.equal(flushSpeakerTagStream(state, NAMES), '');
+    assert.equal(flushSpeakerTagStream(state, NAMES), '');
+  });
+
+  test('flush on an untouched stream emits nothing', () => {
+    assert.equal(flushSpeakerTagStream(newSpeakerTagStream(), NAMES), '');
+  });
+
+  test('a tag-only block flushes back to the original (never empty)', () => {
+    assert.equal(runStream(['[Alice]']), '[Alice]');
+    assert.equal(runStream(['[Alice', ']']), '[Alice]');
+  });
+
+  test('a known tag that never gets content is preserved by the backstop flush', () => {
+    // Models the message_end backstop: deltas arrive but no text_end / content.
+    const state = newSpeakerTagStream();
+    assert.equal(pushSpeakerTagDelta(state, '[Alice]', NAMES), '');
+    assert.equal(flushSpeakerTagStream(state, NAMES), '[Alice]');
+  });
+});
+
+describe('speaker-tag stream: targeted cases', () => {
+  test('strips a known tag split across deltas', () => {
+    assert.equal(runStream(['[Matthew', ' Graham]', ' Fair,', ' fair.']), 'Fair, fair.');
+  });
+
+  test('leaves an unknown tag intact', () => {
+    assert.equal(runStream(['[note]', ' remember this']), '[note] remember this');
+  });
+
+  test('preserves a leading markdown link', () => {
+    assert.equal(
+      runStream(['[Alice]', '(https://x.com)', ' see this']),
+      '[Alice](https://x.com) see this',
+    );
+  });
+
+  test('resets cleanly per block (a fresh stream does not inherit state)', () => {
+    assert.equal(runStream(['[Alice] one']), 'one');
+    assert.equal(runStream(['[Matthew Graham] two']), 'two');
+  });
+});
+
+describe('speaker-tag stream: equivalence to the one-shot strip', () => {
+  const cases = [
+    '[Matthew Graham] hey there',
+    'no tag here at all',
+    '[note] keep me',
+    '[Alice]: with a colon',
+    '[Leandro Gavidia] multi\nline reply',
+    '[Alice]',
+    '[Alice](https://x.com) link',
+    '  [alice]  spaced reply',
+    `[${'x'.repeat(100)} never closes`,
+    '[Alice\nbob] newline inside the tag',
+    '',
+    '[',
+    'plain reply',
+  ];
+
+  for (const full of cases) {
+    test(`stream output equals stripLeadingSpeakerTag for ${JSON.stringify(full)}`, () => {
+      const expected = stripLeadingSpeakerTag(full, NAMES);
+      for (const chunks of fragmentations(full)) {
+        assert.equal(
+          runStream(chunks),
+          expected,
+          `fragmentation ${JSON.stringify(chunks)} diverged`,
+        );
+      }
+    });
+  }
+});

--- a/apps/agent/test/speaker-tag.test.ts
+++ b/apps/agent/test/speaker-tag.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  stripLeadingSpeakerTag,
+  normalizeSpeakerName,
+} from '../src/agent-runner/message-utils.js';
+
+const NAMES = ['Matthew Graham', 'Alice', 'Leandro Gavidia'];
+
+// "Jose" with the accent as a single codepoint (NFC) vs e + combining mark (NFD).
+const JOSE_NFC = 'Jos\u00e9';
+const JOSE_NFD = 'Jose\u0301';
+
+describe('normalizeSpeakerName', () => {
+  test('lowercases and trims', () => {
+    assert.equal(normalizeSpeakerName('  Alice  '), 'alice');
+    assert.equal(normalizeSpeakerName('MiXeD CaSe'), 'mixed case');
+  });
+
+  test('collapses NFC and NFD unicode forms to the same value', () => {
+    assert.notEqual(JOSE_NFC, JOSE_NFD); // genuinely different strings
+    assert.equal(normalizeSpeakerName(JOSE_NFC), normalizeSpeakerName(JOSE_NFD));
+  });
+
+  test('blank input normalizes to empty string', () => {
+    assert.equal(normalizeSpeakerName(''), '');
+    assert.equal(normalizeSpeakerName('   '), '');
+    assert.equal(normalizeSpeakerName('\t\n'), '');
+  });
+
+  test('leaves an already-normalized name unchanged', () => {
+    assert.equal(normalizeSpeakerName('matthew graham'), 'matthew graham');
+  });
+});
+
+describe('stripLeadingSpeakerTag: matching', () => {
+  test('strips a known tag and the following whitespace', () => {
+    assert.equal(stripLeadingSpeakerTag('[Matthew Graham] Fair, fair.', NAMES), 'Fair, fair.');
+  });
+
+  test('strips regardless of the tag name case', () => {
+    assert.equal(stripLeadingSpeakerTag('[alice] hi', NAMES), 'hi');
+    assert.equal(stripLeadingSpeakerTag('[ALICE] hi', NAMES), 'hi');
+  });
+
+  test('tolerates leading and inner whitespace around the tag', () => {
+    assert.equal(stripLeadingSpeakerTag('  [alice]   hello', NAMES), 'hello');
+  });
+
+  test('strips a tag followed by a colon', () => {
+    assert.equal(stripLeadingSpeakerTag('[Alice]: hi there', NAMES), 'hi there');
+    assert.equal(stripLeadingSpeakerTag('[Alice] : hi there', NAMES), 'hi there');
+  });
+
+  test('matches a known name whose stored form differs in case or whitespace', () => {
+    assert.equal(stripLeadingSpeakerTag('[alice] hi', ['  ALICE  ']), 'hi');
+  });
+
+  test('matches across NFC/NFD unicode forms in both directions', () => {
+    assert.equal(stripLeadingSpeakerTag(`[${JOSE_NFC}] hi`, [JOSE_NFD]), 'hi');
+    assert.equal(stripLeadingSpeakerTag(`[${JOSE_NFD}] hi`, [JOSE_NFC]), 'hi');
+  });
+
+  test('matches a name that contains spaces and punctuation but no brackets', () => {
+    assert.equal(stripLeadingSpeakerTag("[O'Brien (work)] hey", ["O'Brien (work)"]), 'hey');
+  });
+
+  test('matches a name at the 80-character length cap', () => {
+    const name = 'a'.repeat(80);
+    assert.equal(stripLeadingSpeakerTag(`[${name}] hi`, [name]), 'hi');
+  });
+
+  test('accepts any iterable of known names (Set, generator)', () => {
+    assert.equal(stripLeadingSpeakerTag('[Alice] hi', new Set(['Alice'])), 'hi');
+    const gen = function* () {
+      yield 'Alice';
+    };
+    assert.equal(stripLeadingSpeakerTag('[Alice] hi', gen()), 'hi');
+  });
+});
+
+describe('stripLeadingSpeakerTag: left alone', () => {
+  test('an unknown bracketed name', () => {
+    const input = '[note] remember to follow up';
+    assert.equal(stripLeadingSpeakerTag(input, NAMES), input);
+  });
+
+  test('a leading markdown link', () => {
+    const input = '[Alice](https://example.com) is the link';
+    assert.equal(stripLeadingSpeakerTag(input, NAMES), input);
+  });
+
+  test('a reply with no leading tag', () => {
+    const input = 'Fair point. They have the talent to capitalize.';
+    assert.equal(stripLeadingSpeakerTag(input, NAMES), input);
+  });
+
+  test('a bracketed name that appears mid-sentence, not at the start', () => {
+    const input = 'I think [Alice] said that earlier.';
+    assert.equal(stripLeadingSpeakerTag(input, NAMES), input);
+  });
+
+  test('no known names supplied', () => {
+    assert.equal(stripLeadingSpeakerTag('[Alice] hello', []), '[Alice] hello');
+  });
+
+  test('a name longer than the cap is not recognized', () => {
+    const name = 'a'.repeat(81);
+    assert.equal(stripLeadingSpeakerTag(`[${name}] hi`, [name]), `[${name}] hi`);
+  });
+
+  test('a name containing brackets cannot match (regex excludes brackets)', () => {
+    const input = '[Bot [v2]] hi';
+    assert.equal(stripLeadingSpeakerTag(input, ['Bot [v2]']), input);
+  });
+
+  test('a tag spanning a newline is not a single-line tag', () => {
+    const input = '[Alice\nbob] hi';
+    assert.equal(stripLeadingSpeakerTag(input, ['Alice\nbob']), input);
+  });
+
+  test('blank entries in knownNames are ignored and never match a blank tag', () => {
+    const known = ['Alice', '   ', 'Bob', '\t\n'];
+    assert.equal(stripLeadingSpeakerTag('[   ] text', known), '[   ] text');
+    assert.equal(stripLeadingSpeakerTag('[\t] text', known), '[\t] text');
+  });
+});
+
+describe('stripLeadingSpeakerTag: conservative behavior', () => {
+  test('strips only the first tag, leaving a second bracketed token', () => {
+    assert.equal(
+      stripLeadingSpeakerTag('[Alice] [Matthew Graham] said hi', NAMES),
+      '[Matthew Graham] said hi',
+    );
+  });
+
+  test('keeps the original when stripping would leave nothing (tag-only message)', () => {
+    assert.equal(stripLeadingSpeakerTag('[Alice]', NAMES), '[Alice]');
+    assert.equal(stripLeadingSpeakerTag('[Alice]:', NAMES), '[Alice]:');
+    assert.equal(stripLeadingSpeakerTag('  [Matthew Graham]  ', NAMES), '  [Matthew Graham]  ');
+  });
+
+  test('an empty string is returned unchanged', () => {
+    assert.equal(stripLeadingSpeakerTag('', NAMES), '');
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,7 +19,6 @@ import {
   type WsRequest,
   type WsEvent,
   type WsServerMessage,
-  isWsRequest,
 } from '@openhermit/protocol';
 
 export type { SessionAttachment, AttachmentMaterializationState };


### PR DESCRIPTION
In group chats inbound messages are shown to the model as `[Name] text`, and it sometimes copies that prefix onto its own reply (e.g. answering as `[Matthew Graham] ...`). This strips a leading `[Name]` tag matching a known participant, in the stored/sent message and in the live token stream, comparing names NFC and case insensitively.

Also adds a default conversational style section to the system prompt, and removes two stale prompt-test assertions left from the autonomy_level removal.

Tests: normalizeSpeakerName, stripLeadingSpeakerTag, and the streaming guard, including a property test that every delta fragmentation matches the one-shot strip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant copied speaker tags (e.g., `"[Name]:"`) from appearing in group conversation assistant output, including during streaming, persisted logs, and resumed sessions.
  * Improved cleanup reliability by handling missed end-of-message streaming cases.

* **Tests**
  * Added new unit tests for speaker-tag normalization, stripping, and streaming behavior (including edge cases and fragmentation consistency).
  * Updated prompt generation tests to align with revised expected system prompt content.

* **Chores**
  * Removed an unused SDK import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->