### PR TITLE
fix(wechat): set caller channel identity on DMs

### DIFF
--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text-only v0.",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -148,11 +148,17 @@ export class WechatBridge implements ChannelOutbound {
         }
       : {};
 
+    // DMs: surface the caller via `x-channel-user-id` so the runtime resolves a
+    // session-level channel identity (currentChannel/currentChannelUserId).
+    // Without it, tools like identity_link_request fail with "requires a known
+    // caller channel". Groups stay per-message (no session-level claim).
+    const postOpts = !isGroup && senderUserId ? { channelUserId: senderUserId } : undefined;
+
     const postResult = await this.client.postMessage(sessionId, {
       text,
       mentioned: !isGroup,
       ...senderPayload,
-    });
+    }, postOpts);
 
     if (!(postResult as { triggered?: boolean }).triggered) return;
 
@@ -208,6 +214,10 @@ export class WechatBridge implements ChannelOutbound {
     if (!isGroup && msg.from_user_id) metadata.wechat_peer_id = msg.from_user_id;
     if (msg.from_user_id) metadata.wechat_from_user_id = msg.from_user_id;
 
+    // DMs: claim a session-level caller identity (see handleMessageInner).
+    const senderUserId = msg.from_user_id?.trim();
+    const openOpts = !isGroup && senderUserId ? { channelUserId: senderUserId } : undefined;
+
     await this.client.openSession({
       sessionId,
       source: {
@@ -217,7 +227,7 @@ export class WechatBridge implements ChannelOutbound {
         type: isGroup ? 'group' : 'direct',
       },
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-    });
+    }, openOpts);
   }
 
   private async waitForAgentResponse(sessionId: string): Promise<TurnResult> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0"


### PR DESCRIPTION
## The bug (observed live on test.openhermit.ai)
A WeChat DM user asked agent `one` to link identities → `identity_link_request` threw **"requires a known caller channel"** (session `wechat:…`, `tool_result` error at 2026-06-22T01:30). It affects **every** WeChat DM, not just this one.

## Root cause
The tool needs `context.currentChannel` **and** `context.currentChannelUserId` (`tools/user.ts:256`). Those derive from the session's `resolvedChannel`/`resolvedChannelUserId` (`agent-runner.ts:2016-2017`), which are populated **only** from the `channelUserId` option passed to `openSession`/`postMessage` (the `x-channel-user-id` header).

The WeChat bridge passed the sender **only in the `postMessage` body** (which resolves the *user* — so `currentUserId` is set) and **never** as the `channelUserId` option to `openSession`/`postMessage`. So the session-level channel identity stayed empty and the identity-link tools always failed.

Telegram and Signal don't have this bug — they pass `{ channelUserId }` as the opt (e.g. `signal/bridge.ts:170,317`).

## Fix
Mirror them: for DMs, pass `{ channelUserId: senderUserId }` to both `openSession` and `postMessage`. Groups stay per-message (no session-level claim). Build + typecheck clean. (No unit test — this package has no test harness on `main`, and the bridge constructs its own client; the change mirrors the verified Signal/Telegram pattern.)

Published package — bumps `@openhermit/channel-wechat` 0.1.1 → 0.1.2. After merge: `npm publish -w @openhermit/channel-wechat`, then redeploy the test box (pull + restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session management for direct messages in the WeChat channel.

* **Chores**
  * Version bumped to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->