### PR TITLE
feat(wechat): inbound voice notes (SILK → STT)

### DIFF
--- a/apps/channels/wechat/README.md
+++ b/apps/channels/wechat/README.md
@@ -11,8 +11,13 @@ gateway-managed OpenHermit agent over Tencent's **iLink** HTTP protocol.
   become vision input). Attachments over the 25 MiB cap are skipped. The CDN
   base defaults to `https://novac2c.cdn.weixin.qq.com/c2c`, overridable via
   `OPENHERMIT_WECHAT_CDN_BASE_URL`; a server-provided `full_url` is preferred.
-- Inbound voice / file / video and all **outbound** media are not handled yet
-  (voice needs SILK transcoding; outbound needs the CDN upload flow).
+- **Inbound voice**: SILK voice notes are downloaded + decrypted, transcoded to
+  WAV via [`silk-wasm`](https://www.npmjs.com/package/silk-wasm), and transcribed
+  through the agent's STT (the transcript is prefixed with a `[Voice message,
+  transcribed.]` marker). When WeChat already supplies its own transcript
+  (`voice_item.text`), that is used directly and the download is skipped.
+- Inbound file / video and all **outbound** media are not handled yet
+  (outbound voice/media needs the CDN upload flow).
 - QR-link wizard (`ChannelSetup`) returns the QR URL as a plain string;
   the admin UI renders it with its own QR-code library.
 - No typing indicators, no multi-account juggling.

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.2.0",
-  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text plus inbound images.",
+  "version": "0.3.0",
+  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and inbound voice (transcribed).",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -52,7 +52,8 @@
     "postpack": "node scripts/restore-package-json.mjs"
   },
   "dependencies": {
-    "@openhermit/sdk": "^0.6.0"
+    "@openhermit/sdk": "^0.6.0",
+    "silk-wasm": "^3.7.1"
   },
   "devDependencies": {
     "@openhermit/protocol": "0.2.0",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -17,8 +17,18 @@ import type {
 import { stripSilenceTokens } from '@openhermit/shared';
 
 import { sendMessage } from './ilink/api.js';
-import { MessageItemType, MessageType, type WeixinMessage } from './ilink/types.js';
+import {
+  MessageItemType,
+  MessageType,
+  type ImageItem,
+  type VoiceItem,
+  type WeixinMessage,
+} from './ilink/types.js';
 import { CDN_BASE_URL, downloadAndDecrypt, resolveCdnUrl } from './ilink/media.js';
+import { SILK_SAMPLE_RATE, silkToWav } from './ilink/silk.js';
+
+/** Marker prepended to a transcribed voice note so the agent knows the user spoke. */
+const VOICE_MARKER = '[Voice message, transcribed.]';
 
 /** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
@@ -32,6 +42,8 @@ interface TurnResult {
 interface ResolvedInbound {
   text: string;
   attachments?: { type: 'file'; id: string }[];
+  /** True when at least one voice note contributed (transcribed) text. */
+  wasVoice?: boolean;
 }
 
 export interface WechatBridgeRuntime {
@@ -166,50 +178,113 @@ export class WechatBridge implements ChannelOutbound {
    * input). Text/captions are kept. Oversized or failed downloads are skipped.
    */
   private async resolveInbound(sessionId: string, msg: WeixinMessage): Promise<ResolvedInbound> {
-    const text = this.extractText(msg) ?? '';
+    const parts: string[] = [];
+    const base = this.extractText(msg);
+    if (base) parts.push(base);
+
     const ids: { type: 'file'; id: string }[] = [];
+    let wasVoice = false;
 
     for (const item of msg.item_list ?? []) {
-      if (item.type !== MessageItemType.IMAGE || !item.image_item) continue;
-      const img = item.image_item;
-      const media = img.media;
-      if (!media || (!media.full_url && !media.encrypt_query_param)) continue;
-
-      // Prefer the hex `aeskey` (raw 16-byte key = 32 hex chars), but only when
-      // it's actually valid hex — otherwise Buffer.from(...,'hex') would
-      // silently truncate to a wrong key. Fall back to the base64 media.aes_key.
-      let aesKeyBase64: string | undefined;
-      const hexKey = img.aeskey?.trim();
-      if (hexKey && /^[0-9a-fA-F]{32}$/.test(hexKey)) {
-        aesKeyBase64 = Buffer.from(hexKey, 'hex').toString('base64');
-      } else {
-        if (hexKey) this.log('image aeskey is not valid 16-byte hex; falling back to media.aes_key');
-        aesKeyBase64 = media.aes_key;
-      }
-      if (!aesKeyBase64) {
-        this.log('image item missing aes key; skipping');
-        continue;
-      }
-
-      try {
-        const url = resolveCdnUrl(media.encrypt_query_param, media.full_url, CDN_BASE_URL);
-        const bytes = await downloadAndDecrypt({ url, aesKeyBase64, maxBytes: MAX_MEDIA_BYTES });
-        const blob = new Blob([bytes as unknown as BlobPart], { type: 'image/jpeg' });
-        const uploaded = await this.client.uploadAttachment(sessionId, blob, 'image.jpg');
-        ids.push({ type: 'file', id: uploaded.id! });
-      } catch (err) {
-        this.log(`image download/decrypt failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (item.type === MessageItemType.IMAGE && item.image_item) {
+        const id = await this.resolveImage(sessionId, item.image_item);
+        if (id) ids.push(id);
+      } else if (item.type === MessageItemType.VOICE && item.voice_item) {
+        const transcript = await this.resolveVoice(item.voice_item);
+        if (transcript) {
+          parts.push(transcript);
+          wasVoice = true;
+        }
       }
     }
 
-    return { text, ...(ids.length > 0 ? { attachments: ids } : {}) };
+    return {
+      text: parts.join('\n'),
+      wasVoice,
+      ...(ids.length > 0 ? { attachments: ids } : {}),
+    };
+  }
+
+  /** Download + decrypt an inbound image and upload it as a session attachment. */
+  private async resolveImage(
+    sessionId: string,
+    img: ImageItem,
+  ): Promise<{ type: 'file'; id: string } | undefined> {
+    const media = img.media;
+    if (!media || (!media.full_url && !media.encrypt_query_param)) return undefined;
+
+    // Prefer the hex `aeskey` (raw 16-byte key = 32 hex chars), but only when
+    // it's actually valid hex — otherwise Buffer.from(...,'hex') would
+    // silently truncate to a wrong key. Fall back to the base64 media.aes_key.
+    let aesKeyBase64: string | undefined;
+    const hexKey = img.aeskey?.trim();
+    if (hexKey && /^[0-9a-fA-F]{32}$/.test(hexKey)) {
+      aesKeyBase64 = Buffer.from(hexKey, 'hex').toString('base64');
+    } else {
+      if (hexKey) this.log('image aeskey is not valid 16-byte hex; falling back to media.aes_key');
+      aesKeyBase64 = media.aes_key;
+    }
+    if (!aesKeyBase64) {
+      this.log('image item missing aes key; skipping');
+      return undefined;
+    }
+
+    try {
+      const url = resolveCdnUrl(media.encrypt_query_param, media.full_url, CDN_BASE_URL);
+      const bytes = await downloadAndDecrypt({ url, aesKeyBase64, maxBytes: MAX_MEDIA_BYTES });
+      const blob = new Blob([bytes as unknown as BlobPart], { type: 'image/jpeg' });
+      const uploaded = await this.client.uploadAttachment(sessionId, blob, 'image.jpg');
+      return { type: 'file', id: uploaded.id! };
+    } catch (err) {
+      this.log(`image download/decrypt failed: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Resolve an inbound voice note to transcribed text. Prefers WeChat's own
+   * transcript when present; otherwise downloads + decrypts the SILK clip,
+   * transcodes it to WAV, and runs the agent's STT. Returns `undefined` on any
+   * failure so the turn proceeds with whatever other content it has.
+   */
+  private async resolveVoice(voice: VoiceItem): Promise<string | undefined> {
+    // WeChat sometimes pre-transcribes the clip — use it and skip the download.
+    const pre = voice.text?.trim();
+    if (pre) return pre;
+
+    const media = voice.media;
+    if (!media || (!media.full_url && !media.encrypt_query_param) || !media.aes_key) {
+      this.log('voice item missing CDN ref or aes key; skipping');
+      return undefined;
+    }
+
+    try {
+      const url = resolveCdnUrl(media.encrypt_query_param, media.full_url, CDN_BASE_URL);
+      const silk = await downloadAndDecrypt({
+        url,
+        aesKeyBase64: media.aes_key,
+        maxBytes: MAX_MEDIA_BYTES,
+      });
+      const decoded = await silkToWav(silk, voice.sample_rate || SILK_SAMPLE_RATE);
+      if (!decoded) {
+        this.log('voice silk decode failed; skipping');
+        return undefined;
+      }
+      const stt = await this.client.transcribeAudio({ bytes: decoded.wav, mimeType: 'audio/wav' });
+      return stt.text.trim() || undefined;
+    } catch (err) {
+      this.log(`voice transcription failed: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
   }
 
   private async handleMessageInner(msg: WeixinMessage, peer: string): Promise<void> {
-    const hasImage = (msg.item_list ?? []).some(
-      (item) => item.type === MessageItemType.IMAGE && item.image_item,
+    const hasMedia = (msg.item_list ?? []).some(
+      (item) =>
+        (item.type === MessageItemType.IMAGE && item.image_item) ||
+        (item.type === MessageItemType.VOICE && item.voice_item),
     );
-    if (!this.extractText(msg) && !hasImage) return;
+    if (!this.extractText(msg) && !hasMedia) return;
 
     // Snapshot this turn's context token up front so the reply echoes the
     // token of the message it's answering, even if a newer message for the
@@ -224,6 +299,11 @@ export class WechatBridge implements ChannelOutbound {
     // attachments (images become vision input). Text/captions are kept.
     const resolved = await this.resolveInbound(sessionId, msg);
     if (!resolved.text && !resolved.attachments) return;
+
+    // Tag transcribed voice so the agent knows the user spoke (and, once
+    // outbound voice lands, that a spoken reply is appropriate).
+    const agentText =
+      resolved.wasVoice && resolved.text ? `${VOICE_MARKER}\n\n${resolved.text}` : resolved.text;
 
     const senderUserId = msg.from_user_id?.trim();
     const senderPayload = senderUserId
@@ -242,7 +322,7 @@ export class WechatBridge implements ChannelOutbound {
     const postOpts = !isGroup && senderUserId ? { channelUserId: senderUserId } : undefined;
 
     const postResult = await this.client.postMessage(sessionId, {
-      text: resolved.text,
+      text: agentText,
       mentioned: !isGroup,
       ...(resolved.attachments ? { attachments: resolved.attachments } : {}),
       ...senderPayload,

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -20,6 +20,7 @@ import { sendMessage } from './ilink/api.js';
 import {
   MessageItemType,
   MessageType,
+  VoiceEncodeType,
   type ImageItem,
   type VoiceItem,
   type WeixinMessage,
@@ -251,6 +252,12 @@ export class WechatBridge implements ChannelOutbound {
     // WeChat sometimes pre-transcribes the clip — use it and skip the download.
     const pre = voice.text?.trim();
     if (pre) return pre;
+
+    // We only decode SILK; any other codec would just fail after download.
+    if (voice.encode_type !== undefined && voice.encode_type !== VoiceEncodeType.SILK) {
+      this.log(`voice encode_type ${voice.encode_type} is not SILK; skipping`);
+      return undefined;
+    }
 
     const media = voice.media;
     if (!media || (!media.full_url && !media.encrypt_query_param) || !media.aes_key) {

--- a/apps/channels/wechat/src/ilink/silk.ts
+++ b/apps/channels/wechat/src/ilink/silk.ts
@@ -1,0 +1,78 @@
+/**
+ * SILK ↔ WAV/PCM transcoding for WeChat voice notes.
+ *
+ * WeChat voice messages are SILK-encoded — a codec no STT/TTS provider
+ * accepts directly. Inbound clips must be decoded to PCM and wrapped as WAV
+ * before transcription; outbound replies must be encoded back to SILK before
+ * upload. Both use `silk-wasm` (Tencent's WASM SILK codec), imported lazily so
+ * the WASM blob only loads when a voice message actually flows through.
+ *
+ * The inbound decode mirrors Tencent's MIT `openclaw-weixin`
+ * (`src/media/silk-transcode.ts`); the outbound encode has no upstream
+ * template and is OpenHermit's own.
+ */
+
+/** WeChat SILK voice notes are 24 kHz, 16-bit, mono. */
+export const SILK_SAMPLE_RATE = 24_000;
+
+/**
+ * Wrap raw little-endian 16-bit PCM in a 44-byte canonical RIFF/WAVE header so
+ * a generic STT provider can decode it. Mono, 16-bit, `sampleRate` Hz.
+ */
+export function pcmToWav(pcm: Uint8Array, sampleRate = SILK_SAMPLE_RATE): Buffer {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(36 + pcm.byteLength, 4);
+  header.write('WAVE', 8, 'ascii');
+  header.write('fmt ', 12, 'ascii');
+  header.writeUInt32LE(16, 16); // fmt chunk size
+  header.writeUInt16LE(1, 20); // PCM format
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write('data', 36, 'ascii');
+  header.writeUInt32LE(pcm.byteLength, 40);
+  return Buffer.concat([header, Buffer.from(pcm)]);
+}
+
+/**
+ * Decode a SILK voice clip to a WAV buffer. Returns `null` (rather than
+ * throwing) when `silk-wasm` is unavailable or the bytes fail to decode, so
+ * callers can fall back to the WeChat-supplied transcript or skip the clip.
+ */
+export async function silkToWav(
+  silk: Buffer,
+  sampleRate = SILK_SAMPLE_RATE,
+): Promise<{ wav: Buffer; durationMs: number } | null> {
+  try {
+    const { decode } = await import('silk-wasm');
+    const result = await decode(silk, sampleRate);
+    return { wav: pcmToWav(result.data, sampleRate), durationMs: result.duration };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Encode WAV or raw mono `pcm_s16le` bytes to SILK for an outbound voice note.
+ * `silk-wasm` accepts WAV directly (pass `sampleRate = 0`) or raw PCM (pass its
+ * real sample rate). Returns `null` on failure so callers fall back to text.
+ */
+export async function toSilk(
+  input: Uint8Array,
+  sampleRate = SILK_SAMPLE_RATE,
+): Promise<{ silk: Buffer; durationMs: number } | null> {
+  try {
+    const { encode } = await import('silk-wasm');
+    const result = await encode(input, sampleRate);
+    return { silk: Buffer.from(result.data), durationMs: result.duration };
+  } catch {
+    return null;
+  }
+}

--- a/apps/channels/wechat/src/ilink/types.ts
+++ b/apps/channels/wechat/src/ilink/types.ts
@@ -61,6 +61,38 @@ export interface ImageItem {
   hd_size?: number;
 }
 
+/** `VoiceItem.encode_type` — audio codec. WeChat voice notes are SILK (6). */
+export const VoiceEncodeType = {
+  PCM: 1,
+  ADPCM: 2,
+  FEATURE: 3,
+  SPEEX: 4,
+  AMR: 5,
+  SILK: 6,
+  MP3: 7,
+  OGG_SPEEX: 8,
+} as const;
+
+/**
+ * `MessageItem.voice_item` — inbound voice note. Shape ported from Tencent's
+ * MIT `openclaw-weixin` (`src/api/types.ts`). Unlike `ImageItem`, voice carries
+ * its AES key only inside `media.aes_key` (base64) — there is no top-level hex
+ * `aeskey`. WeChat sometimes pre-transcribes the clip into `text`.
+ */
+export interface VoiceItem {
+  /** CDN reference to the encrypted audio bytes. */
+  media?: CDNMedia;
+  /** Codec, see {@link VoiceEncodeType}; WeChat voice notes are `SILK` (6). */
+  encode_type?: number;
+  bits_per_sample?: number;
+  /** Sample rate in Hz (WeChat SILK voice notes are 24000). */
+  sample_rate?: number;
+  /** Clip length in milliseconds. */
+  playtime?: number;
+  /** WeChat-side speech-to-text result, when present. */
+  text?: string;
+}
+
 export interface MessageItem {
   type?: number;
   create_time_ms?: number;
@@ -69,7 +101,8 @@ export interface MessageItem {
   msg_id?: string;
   text_item?: TextItem;
   image_item?: ImageItem;
-  /** voice_item/file_item/video_item remain untyped until later media phases. */
+  voice_item?: VoiceItem;
+  /** file_item/video_item remain untyped until later media phases. */
   [key: string]: unknown;
 }
 

--- a/apps/channels/wechat/test/silk.test.ts
+++ b/apps/channels/wechat/test/silk.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { pcmToWav, silkToWav, toSilk, SILK_SAMPLE_RATE } from '../src/ilink/silk.js';
+
+/** Build ~0.4s of mono s16le PCM at the given rate (a quiet sine tone). */
+function makeTonePcm(sampleRate = SILK_SAMPLE_RATE, ms = 400): Uint8Array {
+  const n = Math.round((sampleRate * ms) / 1000);
+  const buf = Buffer.alloc(n * 2);
+  for (let i = 0; i < n; i++) {
+    const sample = Math.round(Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 8000);
+    buf.writeInt16LE(sample, i * 2);
+  }
+  return buf;
+}
+
+test('pcmToWav writes a canonical 44-byte mono/16-bit RIFF header', () => {
+  const pcm = makeTonePcm(SILK_SAMPLE_RATE, 100);
+  const wav = pcmToWav(pcm, SILK_SAMPLE_RATE);
+
+  assert.equal(wav.subarray(0, 4).toString('ascii'), 'RIFF');
+  assert.equal(wav.subarray(8, 12).toString('ascii'), 'WAVE');
+  assert.equal(wav.subarray(12, 16).toString('ascii'), 'fmt ');
+  assert.equal(wav.subarray(36, 40).toString('ascii'), 'data');
+  assert.equal(wav.readUInt16LE(20), 1); // PCM
+  assert.equal(wav.readUInt16LE(22), 1); // mono
+  assert.equal(wav.readUInt32LE(24), SILK_SAMPLE_RATE);
+  assert.equal(wav.readUInt16LE(34), 16); // bits per sample
+  assert.equal(wav.readUInt32LE(40), pcm.byteLength); // data size
+  assert.equal(wav.byteLength, 44 + pcm.byteLength);
+});
+
+test('toSilk → silkToWav round-trips PCM through the real codec', async () => {
+  const pcm = makeTonePcm();
+  const encoded = await toSilk(pcm, SILK_SAMPLE_RATE);
+  assert.ok(encoded, 'encode should succeed');
+  assert.ok(encoded!.silk.byteLength > 0);
+  assert.ok(encoded!.durationMs > 0);
+
+  const decoded = await silkToWav(encoded!.silk, SILK_SAMPLE_RATE);
+  assert.ok(decoded, 'decode should succeed');
+  assert.equal(decoded!.wav.subarray(0, 4).toString('ascii'), 'RIFF');
+  assert.ok(decoded!.wav.byteLength > 44, 'decoded wav should carry audio data');
+});
+
+test('toSilk accepts a WAV container directly (sampleRate 0)', async () => {
+  const wav = pcmToWav(makeTonePcm(), SILK_SAMPLE_RATE);
+  const encoded = await toSilk(wav, 0);
+  assert.ok(encoded, 'encode from WAV should succeed');
+  assert.ok(encoded!.silk.byteLength > 0);
+});
+
+test('silkToWav returns null on garbage input instead of throwing', async () => {
+  const out = await silkToWav(Buffer.from('not silk at all'));
+  assert.equal(out, null);
+});

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -21,7 +21,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 | Platform | Package | Connection |
 |----------|---------|------------|
 | Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard; text + media (files/images, audio transcribed) |
-| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text + inbound images |
+| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text + inbound images + inbound voice (SILK→STT) |
 | WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text + media (image/video/document/voice) |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
@@ -187,7 +187,8 @@ WeChat (external plugin):
 
 - iLink long-poll loop on `bot_token` — no per-message webhook
 - QR-link setup wizard exchanges scan+confirmation for `bot_token` + IDC-pinned `base_url`; both persist on the channel row
-- inbound images: photos are downloaded from the WeChat C2C CDN and AES-128-ECB decrypted, then uploaded as session attachments (vision input); over the 25 MiB cap they are skipped. Inbound voice/file/video and all outbound media are not handled yet
+- inbound images: photos are downloaded from the WeChat C2C CDN and AES-128-ECB decrypted, then uploaded as session attachments (vision input); over the 25 MiB cap they are skipped
+- inbound voice: SILK voice notes are downloaded + decrypted, transcoded to WAV via `silk-wasm`, and transcribed via the agent's STT (prefixed with a `[Voice message, transcribed.]` marker); WeChat's own `voice_item.text` transcript is used directly when present. Inbound file/video and all outbound media are not handled yet
 - no group filtering
 - `errcode === -14` from `getUpdates` is treated as long-poll cursor reset, **not** auth failure
 

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -24,7 +24,7 @@ A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, 
 
 **Installable as npm packages** (add via `hermit channel install`):
 
-- **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text-only v0.
+- **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text, inbound images, and inbound voice (transcribed).
 - **WhatsApp** — `@openhermit/channel-whatsapp`. Link a WhatsApp account through WhatsApp Web / Linked Devices using a QR-scan wizard. Supports text plus media (images/video/documents as attachments; voice notes transcribed).
 
 Each non-CLI channel needs a credential (a bot token, app secret, or linked-device auth state). Operator-entered tokens are stored as secrets — see [Chapter 18](18-secrets.md). Channel-owned auth state, such as WhatsApp Web credentials, is stored in encrypted channel credential rows.
@@ -74,7 +74,7 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Install with `hermit channel install @openhermit/channel-wechat`, then restart the gateway.
 - Pair the bot through *Manage → Channels → Add channel → WeChat*: the UI renders a QR code that you scan with the WeChat mobile app and confirm. The setup wizard exchanges the scan + confirmation for a long-lived `bot_token` and IDC-pinned `base_url`, which the gateway stores on the channel row.
 - Restarts preserve the login: the gateway reloads `bot_token` from the channel row and resumes the iLink long-poll without re-scanning. You only need to re-pair if you unlink the bot from inside the WeChat client.
-- Media: inbound images are decrypted from the WeChat CDN and uploaded to the agent as vision input (over 25 MiB skipped). Inbound voice/file/video and all outbound media aren't handled yet. No group filtering.
+- Media: inbound images are decrypted from the WeChat CDN and uploaded to the agent as vision input (over 25 MiB skipped). Inbound voice notes are decrypted, transcoded from SILK to WAV via `silk-wasm`, and transcribed via the agent's STT (WeChat's own transcript is used when present). Inbound file/video and all outbound media aren't handled yet. No group filtering.
 
 ### WhatsApp (external plugin)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,10 +151,11 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@openhermit/sdk": "^0.6.0"
+        "@openhermit/sdk": "^0.6.0",
+        "silk-wasm": "^3.7.1"
       },
       "devDependencies": {
         "@openhermit/protocol": "0.2.0",
@@ -10966,6 +10967,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/silk-wasm": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/silk-wasm/-/silk-wasm-3.7.1.tgz",
+      "integrity": "sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.11.0"
       }
     },
     "node_modules/smart-buffer": {


### PR DESCRIPTION
Phase 2a of WeChat media support: the agent can now **hear** voice notes.

## What
- WeChat voice messages are SILK-encoded — no STT provider accepts that directly. This downloads + AES-128-ECB decrypts the clip (reusing the existing image media path), transcodes **SILK → WAV** via [`silk-wasm`](https://www.npmjs.com/package/silk-wasm), and runs the agent's STT.
- The transcript is prefixed with a `[Voice message, transcribed.]` marker so the agent knows the user spoke.
- **Shortcut**: when WeChat already supplies its own transcript (`voice_item.text`), it's used directly and the download is skipped.

## How
- `ilink/types.ts` — adds the `VoiceItem` wire type (shape ported from Tencent's MIT `openclaw-weixin` `src/api/types.ts`) + `VoiceEncodeType` (6 = SILK) + `voice_item` on `MessageItem`.
- `ilink/silk.ts` (new) — `silkToWav` (decode → PCM → 44-byte RIFF WAV, mono/16-bit/24kHz) and `toSilk` (encode, used by the upcoming outbound PR). `silk-wasm` is a **lazy external import** so its WASM blob only loads when voice actually flows.
- `bridge.ts` — splits `resolveInbound` into `resolveImage` / `resolveVoice`; the media guard now also admits voice-only messages. Failures degrade gracefully (skip the clip, log) so a bad voice note never breaks the turn.

## Scope
Inbound voice only. Inbound file/video and **all outbound media** (incl. voice replies) remain out of scope — outbound voice needs the CDN upload flow and lands in a follow-up PR.

## Tests
11 pass, including a **real `silk-wasm` round-trip** (`toSilk → silkToWav`) and the WAV header layout. Build + typecheck green; `silk-wasm` stays external in the bundle.

## Verification note
Inbound STT requires the agent to have a voice/STT provider configured. After merge + deploy, verifying on a real device means sending the bot a voice note and confirming the transcript reaches the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound voice message support to the WeChat channel, including automatic SILK decoding, transcoding to WAV, and speech-to-text transcription.
  * Transcribed voice content is now included in agent conversations alongside existing text and inbound images.

* **Documentation**
  * Updated WeChat adapter documentation to reflect inbound voice transcription, including handling of pre-provided transcripts and remaining gaps (e.g., inbound file/video and outbound media).

* **Tests**
  * Added automated tests covering SILK ↔ WAV/PCM conversion behavior and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->