### PR TITLE
feat(wechat): outbound voice replies (TTS → SILK → CDN)

### DIFF
--- a/apps/channels/wechat/README.md
+++ b/apps/channels/wechat/README.md
@@ -16,8 +16,15 @@ gateway-managed OpenHermit agent over Tencent's **iLink** HTTP protocol.
   through the agent's STT (the transcript is prefixed with a `[Voice message,
   transcribed.]` marker). When WeChat already supplies its own transcript
   (`voice_item.text`), that is used directly and the download is skipped.
-- Inbound file / video and all **outbound** media are not handled yet
-  (outbound voice/media needs the CDN upload flow).
+- **Outbound voice** (DM replies to a voice note): the reply is synthesized via
+  the agent's TTS (`audio/pcm` → 24 kHz mono), encoded to SILK, uploaded to the
+  WeChat C2C CDN (`getuploadurl` + AES-128-ECB encrypt), and sent as a native
+  voice note. Anything unspeakable (code blocks, very long text) or any failure
+  falls back to a text reply. Group replies always stay text. **Note:** the
+  reference plugin has no outbound-voice path, so the voice-item shape is
+  unverified against the live protocol and may need adjustment.
+- Inbound file / video and other outbound media (images/files) are not handled
+  yet.
 - QR-link wizard (`ChannelSetup`) returns the QR URL as a plain string;
   the admin UI renders it with its own QR-code library.
 - No typing indicators, no multi-account juggling.

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.3.0",
-  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and inbound voice (transcribed).",
+  "version": "0.4.0",
+  "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -26,10 +26,29 @@ import {
   type WeixinMessage,
 } from './ilink/types.js';
 import { CDN_BASE_URL, downloadAndDecrypt, resolveCdnUrl } from './ilink/media.js';
-import { SILK_SAMPLE_RATE, silkToWav } from './ilink/silk.js';
+import { SILK_SAMPLE_RATE, silkToWav, toSilk } from './ilink/silk.js';
+import { uploadVoiceToCdn } from './ilink/upload.js';
 
-/** Marker prepended to a transcribed voice note so the agent knows the user spoke. */
-const VOICE_MARKER = '[Voice message, transcribed.]';
+/**
+ * Marker prepended to a transcribed voice note. It both tells the agent the
+ * user spoke and asks for a speech-friendly reply, since when the inbound was
+ * voice we try to answer with a voice note.
+ */
+const VOICE_MARKER =
+  '[Voice message, transcribed. Your reply will be converted to speech, so respond in ' +
+  'plain prose without code blocks, markdown formatting, or long lists.]';
+
+/** Cap on text we'll synthesize into a voice reply — longer stays text. */
+const VOICE_MAX_TEXT_LENGTH = 1000;
+
+/** Whether a reply is fit for voice delivery (mirrors the Telegram bridge). */
+const shouldSpeak = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > VOICE_MAX_TEXT_LENGTH) return false;
+  if (trimmed.includes('```')) return false;
+  return true;
+};
 
 /** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
@@ -137,6 +156,88 @@ export class WechatBridge implements ChannelOutbound {
       const message = err instanceof Error ? err.message : String(err);
       this.log(`failed to send message to ${toUserId}: ${message}`);
       return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Synthesize `text` to speech, encode it to SILK, upload it to the WeChat
+   * CDN, and send it as a native voice note. Returns `true` on success; on any
+   * failure (TTS unavailable, unspeakable content, encode/upload/send error)
+   * it returns `false` so the caller falls back to a text reply.
+   *
+   * NOTE: the reference `openclaw-weixin` has no outbound voice path, so the
+   * `voice_item` shape and the SILK encode params are unverified against the
+   * live protocol. The graceful fallback keeps a wrong guess from breaking the
+   * conversation — worst case the user gets text instead of a voice note.
+   */
+  private async trySendVoiceReply(
+    toUserId: string,
+    text: string,
+    turnContextToken?: string,
+  ): Promise<boolean> {
+    if (!shouldSpeak(text)) return false;
+    try {
+      // ElevenLabs `audio/pcm` → pcm_24000 (mono s16le, 24 kHz) — exactly what
+      // silk-wasm's encoder wants, and matches WeChat's SILK sample rate.
+      const tts = await this.client.synthesizeAudio({ text, outputMimeType: 'audio/pcm' });
+      const encoded = await toSilk(tts.bytes, SILK_SAMPLE_RATE);
+      if (!encoded) {
+        this.log('voice reply: silk encode failed; falling back to text');
+        return false;
+      }
+
+      const uploaded = await uploadVoiceToCdn({
+        baseUrl: this.runtime.baseUrl,
+        token: this.runtime.botToken,
+        bytes: encoded.silk,
+        toUserId,
+      });
+
+      return await this.sendVoice(toUserId, uploaded, encoded.durationMs, turnContextToken);
+    } catch (err) {
+      this.log(`voice reply failed for ${toUserId}: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  }
+
+  /** Send an already-uploaded SILK clip as a WeChat voice note. */
+  private async sendVoice(
+    toUserId: string,
+    uploaded: { downloadEncryptedQueryParam: string; aeskeyHex: string },
+    durationMs: number,
+    turnContextToken?: string,
+  ): Promise<boolean> {
+    const contextToken = turnContextToken ?? this.peerContextTokens.get(toUserId);
+    const voiceItem: VoiceItem = {
+      media: {
+        encrypt_query_param: uploaded.downloadEncryptedQueryParam,
+        // Match how images encode the key on outbound: base64 of the hex string.
+        aes_key: Buffer.from(uploaded.aeskeyHex, 'ascii').toString('base64'),
+        encrypt_type: 1,
+      },
+      encode_type: VoiceEncodeType.SILK,
+      sample_rate: SILK_SAMPLE_RATE,
+      bits_per_sample: 16,
+      playtime: Math.round(durationMs),
+    };
+    const msg: WeixinMessage = {
+      to_user_id: toUserId,
+      message_type: MessageType.BOT,
+      client_id: randomUUID(),
+      create_time_ms: Date.now(),
+      item_list: [{ type: MessageItemType.VOICE, voice_item: voiceItem }],
+      ...(contextToken ? { context_token: contextToken } : {}),
+    };
+    try {
+      await sendMessage({
+        baseUrl: this.runtime.baseUrl,
+        token: this.runtime.botToken,
+        body: { msg },
+      });
+      return true;
+    } catch (err) {
+      this.log(`failed to send voice to ${toUserId}: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
     }
   }
 
@@ -346,7 +447,17 @@ export class WechatBridge implements ChannelOutbound {
     if (replyText) {
       const stripped = stripSilenceTokens(replyText);
       if (!stripped.isSilent) {
-        await this.sendText(peer, stripped.hadToken ? stripped.text : replyText, turnContextToken);
+        const outText = stripped.hadToken ? stripped.text : replyText;
+        // When the user sent voice (DM only), answer with a voice note; fall
+        // back to text if TTS/encode/upload/send fails or the text isn't
+        // speakable. Group replies always stay text.
+        const sentVoice =
+          resolved.wasVoice && !isGroup
+            ? await this.trySendVoiceReply(peer, outText, turnContextToken)
+            : false;
+        if (!sentVoice) {
+          await this.sendText(peer, outText, turnContextToken);
+        }
       }
     }
   }

--- a/apps/channels/wechat/src/ilink/api.ts
+++ b/apps/channels/wechat/src/ilink/api.ts
@@ -21,6 +21,8 @@ import type {
   BaseInfo,
   GetUpdatesReq,
   GetUpdatesResp,
+  GetUploadUrlReq,
+  GetUploadUrlResp,
   NotifyStartResp,
   NotifyStopResp,
   QrCodeResponse,
@@ -252,6 +254,51 @@ export const sendMessage = async (
     timeoutMs: DEFAULT_API_TIMEOUT_MS,
     label: 'sendMessage',
   });
+};
+
+/**
+ * Request a CDN upload slot for outbound media. Returns the upload URL plus the
+ * `upload_param` the client may use to assemble one. The bytes themselves are
+ * POSTed separately via {@link uploadToCdn}.
+ */
+export const getUploadUrl = async (
+  opts: WeixinApiOptions & { req: GetUploadUrlReq },
+): Promise<GetUploadUrlResp> => {
+  const raw = await apiPost({
+    baseUrl: opts.baseUrl,
+    endpoint: 'ilink/bot/getuploadurl',
+    body: JSON.stringify({ ...opts.req, base_info: buildBaseInfo(opts.botAgent) }),
+    token: opts.token,
+    timeoutMs: DEFAULT_API_TIMEOUT_MS,
+    label: 'getUploadUrl',
+  });
+  return JSON.parse(raw) as GetUploadUrlResp;
+};
+
+/**
+ * Upload already-encrypted bytes to the WeChat C2C CDN. The download reference
+ * comes back in the `x-encrypted-param` response header (not the body); it is
+ * what an outbound media item references via `media.encrypt_query_param`.
+ */
+export const uploadToCdn = async (params: {
+  uploadUrl: string;
+  ciphertext: Buffer;
+  timeoutMs?: number;
+}): Promise<{ downloadEncryptedQueryParam: string }> => {
+  const res = await fetch(params.uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: new Uint8Array(params.ciphertext),
+    signal: AbortSignal.timeout(params.timeoutMs ?? DEFAULT_API_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`uploadToCdn ${res.status}: ${await res.text().catch(() => '')}`);
+  }
+  const downloadEncryptedQueryParam = res.headers.get('x-encrypted-param');
+  if (!downloadEncryptedQueryParam) {
+    throw new Error('uploadToCdn: response missing x-encrypted-param header');
+  }
+  return { downloadEncryptedQueryParam };
 };
 
 export const notifyStart = async (opts: WeixinApiOptions): Promise<NotifyStartResp> => {

--- a/apps/channels/wechat/src/ilink/media.ts
+++ b/apps/channels/wechat/src/ilink/media.ts
@@ -11,7 +11,7 @@
  * `encrypt_query_param` the client assembles against a CDN base URL, plus an
  * AES key. Bytes are AES-128-ECB encrypted and must be decrypted after fetch.
  */
-import { createDecipheriv } from 'node:crypto';
+import { createCipheriv, createDecipheriv } from 'node:crypto';
 
 /** Default WeChat C2C CDN base, overridable via env. Only used when a media
  * item lacks a server-provided `full_url`. */
@@ -22,6 +22,17 @@ export const CDN_BASE_URL =
 export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
   const decipher = createDecipheriv('aes-128-ecb', key, null);
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/** Encrypt AES-128-ECB (PKCS7 padding) — for outbound CDN uploads. */
+export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
+  const cipher = createCipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+}
+
+/** Ciphertext size of `n` plaintext bytes under AES-128-ECB + PKCS7 padding. */
+export function aesEcbPaddedSize(n: number): number {
+  return Math.ceil((n + 1) / 16) * 16;
 }
 
 /**

--- a/apps/channels/wechat/src/ilink/types.ts
+++ b/apps/channels/wechat/src/ilink/types.ts
@@ -143,6 +143,45 @@ export interface SendMessageReq {
   msg?: WeixinMessage;
 }
 
+/** `GetUploadUrlReq.media_type` — kind of media being uploaded to the CDN. */
+export const UploadMediaType = {
+  IMAGE: 1,
+  VIDEO: 2,
+  FILE: 3,
+  VOICE: 4,
+} as const;
+
+/**
+ * Request a CDN upload slot (`ilink/bot/getuploadurl`). The bytes are
+ * AES-128-ECB encrypted before upload, so both the plaintext size/md5 and the
+ * ciphertext size are declared. Shape ported from Tencent's MIT `openclaw-weixin`
+ * (`src/api/types.ts`).
+ */
+export interface GetUploadUrlReq {
+  filekey?: string;
+  media_type?: number;
+  to_user_id?: string;
+  /** Plaintext size in bytes. */
+  rawsize?: number;
+  /** Plaintext MD5 (hex). */
+  rawfilemd5?: string;
+  /** Ciphertext size after AES-128-ECB + PKCS7 padding. */
+  filesize?: number;
+  no_need_thumb?: boolean;
+  /** Encryption key as a hex string (32 chars / 16 bytes). */
+  aeskey?: string;
+}
+
+export interface GetUploadUrlResp {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  upload_param?: string;
+  thumb_upload_param?: string;
+  /** Complete upload URL; preferred over assembling from `upload_param`. */
+  upload_full_url?: string;
+}
+
 export interface NotifyStartResp {
   ret?: number;
   errmsg?: string;

--- a/apps/channels/wechat/src/ilink/upload.ts
+++ b/apps/channels/wechat/src/ilink/upload.ts
@@ -1,0 +1,79 @@
+/**
+ * Outbound media upload to the WeChat C2C CDN.
+ *
+ * The reference `openclaw-weixin` implements this for image/video/file but NOT
+ * for voice — this orchestration is OpenHermit's own, following the same shape:
+ *   1. pick a random per-file AES key + filekey,
+ *   2. declare plaintext size/md5 and ciphertext size to `getuploadurl`,
+ *   3. AES-128-ECB encrypt the bytes and POST them to the returned URL,
+ *   4. read the download reference from the `x-encrypted-param` response header.
+ *
+ * The resulting `UploadedMedia` is what an outbound `voice_item.media`
+ * references so the recipient's client can fetch + decrypt the clip.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+
+import { getUploadUrl, uploadToCdn, type WeixinApiOptions } from './api.js';
+import { aesEcbPaddedSize, encryptAesEcb } from './media.js';
+import { UploadMediaType } from './types.js';
+
+export interface UploadedMedia {
+  /** Goes into `media.encrypt_query_param` on the outbound item. */
+  downloadEncryptedQueryParam: string;
+  /** AES key as a hex string (matches how images encode `media.aes_key`). */
+  aeskeyHex: string;
+  /** Plaintext byte size. */
+  rawsize: number;
+}
+
+/**
+ * Encrypt + upload a media buffer to the CDN and return the download reference.
+ * `mediaType` is one of {@link UploadMediaType}.
+ */
+export async function uploadMediaToCdn(
+  opts: WeixinApiOptions & {
+    bytes: Buffer;
+    mediaType: number;
+    toUserId: string;
+  },
+): Promise<UploadedMedia> {
+  const aesKey = randomBytes(16);
+  const aeskeyHex = aesKey.toString('hex');
+  const filekey = randomBytes(16).toString('hex');
+  const rawsize = opts.bytes.byteLength;
+  const rawfilemd5 = createHash('md5').update(opts.bytes).digest('hex');
+  const filesize = aesEcbPaddedSize(rawsize);
+
+  const slot = await getUploadUrl({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    ...(opts.botAgent ? { botAgent: opts.botAgent } : {}),
+    req: {
+      filekey,
+      media_type: opts.mediaType,
+      to_user_id: opts.toUserId,
+      rawsize,
+      rawfilemd5,
+      filesize,
+      no_need_thumb: true,
+      aeskey: aeskeyHex,
+    },
+  });
+
+  const uploadUrl = slot.upload_full_url;
+  if (!uploadUrl) {
+    throw new Error('getUploadUrl returned no upload_full_url');
+  }
+
+  const ciphertext = encryptAesEcb(opts.bytes, aesKey);
+  const { downloadEncryptedQueryParam } = await uploadToCdn({ uploadUrl, ciphertext });
+
+  return { downloadEncryptedQueryParam, aeskeyHex, rawsize };
+}
+
+/** Convenience wrapper for uploading a SILK voice clip. */
+export function uploadVoiceToCdn(
+  opts: WeixinApiOptions & { bytes: Buffer; toUserId: string },
+): Promise<UploadedMedia> {
+  return uploadMediaToCdn({ ...opts, mediaType: UploadMediaType.VOICE });
+}

--- a/apps/channels/wechat/test/upload.test.ts
+++ b/apps/channels/wechat/test/upload.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { createHash, randomBytes } from 'node:crypto';
+import { test } from 'node:test';
+
+import { aesEcbPaddedSize, decryptAesEcb, encryptAesEcb } from '../src/ilink/media.js';
+import { uploadVoiceToCdn } from '../src/ilink/upload.js';
+
+test('aesEcbPaddedSize rounds up to the next 16-byte block (incl. full-block pad)', () => {
+  assert.equal(aesEcbPaddedSize(0), 16);
+  assert.equal(aesEcbPaddedSize(1), 16);
+  assert.equal(aesEcbPaddedSize(15), 16);
+  assert.equal(aesEcbPaddedSize(16), 32); // PKCS7 adds a full block at an exact multiple
+  assert.equal(aesEcbPaddedSize(17), 32);
+});
+
+test('encryptAesEcb round-trips with decryptAesEcb', () => {
+  const key = randomBytes(16);
+  const plaintext = randomBytes(50);
+  assert.deepEqual(decryptAesEcb(encryptAesEcb(plaintext, key), key), plaintext);
+});
+
+test('uploadVoiceToCdn declares plaintext/ciphertext sizes, encrypts, and returns the download ref', async () => {
+  const silk = randomBytes(40);
+  let uploadReq: { body?: string } = {};
+  let postedBytes: Uint8Array | undefined;
+
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes('getuploadurl')) {
+      uploadReq = { body: init?.body as string };
+      return new Response(
+        JSON.stringify({ ret: 0, upload_full_url: 'https://cdn.example/upload?x=1' }),
+        { status: 200 },
+      );
+    }
+    // CDN upload leg — capture ciphertext, return the download ref in the header.
+    postedBytes = init?.body as Uint8Array;
+    return new Response(null, { status: 200, headers: { 'x-encrypted-param': 'DL_PARAM_123' } });
+  }) as typeof fetch;
+
+  try {
+    const out = await uploadVoiceToCdn({
+      baseUrl: 'https://bot.example/',
+      token: 'tok',
+      bytes: silk,
+      toUserId: 'wxid_peer',
+    });
+
+    assert.equal(out.downloadEncryptedQueryParam, 'DL_PARAM_123');
+    assert.match(out.aeskeyHex, /^[0-9a-f]{32}$/);
+    assert.equal(out.rawsize, 40);
+
+    const req = JSON.parse(uploadReq.body ?? '{}') as Record<string, unknown>;
+    assert.equal(req.media_type, 4); // UploadMediaType.VOICE
+    assert.equal(req.to_user_id, 'wxid_peer');
+    assert.equal(req.rawsize, 40);
+    assert.equal(req.rawfilemd5, createHash('md5').update(silk).digest('hex'));
+    assert.equal(req.filesize, aesEcbPaddedSize(40)); // 48
+    assert.equal(req.no_need_thumb, true);
+    assert.equal(req.aeskey, out.aeskeyHex);
+
+    // Posted bytes are the ciphertext: padded length, and decrypt back to silk.
+    assert.ok(postedBytes);
+    assert.equal(postedBytes!.byteLength, aesEcbPaddedSize(40));
+    const key = Buffer.from(out.aeskeyHex, 'hex');
+    assert.deepEqual(decryptAesEcb(Buffer.from(postedBytes!), key), silk);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('uploadVoiceToCdn throws when the CDN omits x-encrypted-param', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    if (String(url).includes('getuploadurl')) {
+      return new Response(JSON.stringify({ upload_full_url: 'https://cdn.example/u' }), { status: 200 });
+    }
+    return new Response(null, { status: 200 }); // no header
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      () =>
+        uploadVoiceToCdn({
+          baseUrl: 'https://bot.example/',
+          token: 'tok',
+          bytes: randomBytes(8),
+          toUserId: 'p',
+        }),
+      /x-encrypted-param/,
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/docs/channel-adapter.md
+++ b/docs/channel-adapter.md
@@ -21,7 +21,7 @@ Not bundled in the CLI. Operators install them with `hermit channel install <pkg
 | Platform | Package | Connection |
 |----------|---------|------------|
 | Signal | `@openhermit/channel-signal` | signal-cli-rest-api WebSocket (`MODE=json-rpc`); QR-link setup wizard; text + media (files/images, audio transcribed) |
-| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text + inbound images + inbound voice (SILK→STT) |
+| WeChat (personal) | `@openhermit/channel-wechat` | iLink long-poll (`getUpdates`) — text + inbound images + voice notes (SILK↔STT/TTS) |
 | WhatsApp | `@openhermit/channel-whatsapp` | WhatsApp Web via Baileys; QR setup wizard — text + media (image/video/document/voice) |
 
 External plugins follow the same manifest contract as bundled ones — there is no special-case loading path. Adding a new external plugin requires no gateway code change, only a config edit and a restart.
@@ -188,7 +188,8 @@ WeChat (external plugin):
 - iLink long-poll loop on `bot_token` — no per-message webhook
 - QR-link setup wizard exchanges scan+confirmation for `bot_token` + IDC-pinned `base_url`; both persist on the channel row
 - inbound images: photos are downloaded from the WeChat C2C CDN and AES-128-ECB decrypted, then uploaded as session attachments (vision input); over the 25 MiB cap they are skipped
-- inbound voice: SILK voice notes are downloaded + decrypted, transcoded to WAV via `silk-wasm`, and transcribed via the agent's STT (prefixed with a `[Voice message, transcribed.]` marker); WeChat's own `voice_item.text` transcript is used directly when present. Inbound file/video and all outbound media are not handled yet
+- inbound voice: SILK voice notes are downloaded + decrypted, transcoded to WAV via `silk-wasm`, and transcribed via the agent's STT (prefixed with a `[Voice message, transcribed.]` marker); WeChat's own `voice_item.text` transcript is used directly when present
+- outbound voice (DM replies to a voice note): the reply is synthesized via TTS (`audio/pcm` → 24 kHz mono), encoded to SILK, uploaded to the C2C CDN (`getuploadurl` + AES-128-ECB encrypt, download ref read from the `x-encrypted-param` upload-response header), and sent as a voice item; unspeakable/failed replies fall back to text, group replies stay text. The reference plugin has no outbound-voice path so the voice-item shape is unverified against the live protocol. Inbound file/video and other outbound media (images/files) are not handled yet
 - no group filtering
 - `errcode === -14` from `getUpdates` is treated as long-poll cursor reset, **not** auth failure
 

--- a/docs/manual/17-channels.md
+++ b/docs/manual/17-channels.md
@@ -24,7 +24,7 @@ A **channel** is a transport for messages: the CLI, the web UI, a Telegram bot, 
 
 **Installable as npm packages** (add via `hermit channel install`):
 
-- **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text, inbound images, and inbound voice (transcribed).
+- **WeChat (personal)** — `@openhermit/channel-wechat`. Pair an existing personal WeChat account with the agent using a QR-scan wizard. Text, inbound images, and two-way voice notes (transcribed in, spoken back).
 - **WhatsApp** — `@openhermit/channel-whatsapp`. Link a WhatsApp account through WhatsApp Web / Linked Devices using a QR-scan wizard. Supports text plus media (images/video/documents as attachments; voice notes transcribed).
 
 Each non-CLI channel needs a credential (a bot token, app secret, or linked-device auth state). Operator-entered tokens are stored as secrets — see [Chapter 18](18-secrets.md). Channel-owned auth state, such as WhatsApp Web credentials, is stored in encrypted channel credential rows.
@@ -74,7 +74,7 @@ A gateway restart (`hermit gateway stop && hermit gateway start`) is required fo
 - Install with `hermit channel install @openhermit/channel-wechat`, then restart the gateway.
 - Pair the bot through *Manage → Channels → Add channel → WeChat*: the UI renders a QR code that you scan with the WeChat mobile app and confirm. The setup wizard exchanges the scan + confirmation for a long-lived `bot_token` and IDC-pinned `base_url`, which the gateway stores on the channel row.
 - Restarts preserve the login: the gateway reloads `bot_token` from the channel row and resumes the iLink long-poll without re-scanning. You only need to re-pair if you unlink the bot from inside the WeChat client.
-- Media: inbound images are decrypted from the WeChat CDN and uploaded to the agent as vision input (over 25 MiB skipped). Inbound voice notes are decrypted, transcoded from SILK to WAV via `silk-wasm`, and transcribed via the agent's STT (WeChat's own transcript is used when present). Inbound file/video and all outbound media aren't handled yet. No group filtering.
+- Media: inbound images are decrypted from the WeChat CDN and uploaded to the agent as vision input (over 25 MiB skipped). Inbound voice notes are decrypted, transcoded from SILK to WAV via `silk-wasm`, and transcribed via the agent's STT (WeChat's own transcript is used when present). DM replies to a voice note are spoken back: synthesized via TTS, encoded to SILK, uploaded to the CDN, and sent as a voice note (falling back to text when unspeakable or on error). Inbound file/video and other outbound media aren't handled yet. No group filtering.
 
 ### WhatsApp (external plugin)
 


### PR DESCRIPTION
Phase 2b of WeChat media support: the agent can now **speak back**. (Re-opened against main — #190 auto-closed when its stacked base branch was deleted on the #189 merge. Now rebased onto main; diff is outbound-only.)

## What
When a user sends a voice note in a **DM**, the agent replies with a voice note:
1. reply text → TTS (`audio/pcm` → ElevenLabs `pcm_24000`, mono 24 kHz)
2. PCM → **SILK** via `silk-wasm` `encode`
3. SILK → WeChat C2C CDN: `getuploadurl` (media_type=VOICE) → AES-128-ECB encrypt → POST ciphertext → download ref from the **`x-encrypted-param`** response header
4. send a `voice_item` referencing the uploaded clip

**Graceful fallback everywhere**: unspeakable replies (code blocks, >1000 chars) and any failure (TTS/encode/upload/send) fall back to a text reply. Group replies always stay text.

## ⚠️ Unverified protocol
The reference `openclaw-weixin` implements outbound image/video/file but **NOT voice** — so the outbound `voice_item` shape (`encode_type`, `sample_rate`, `playtime`, `media.aes_key` encoding) and the SILK encode params are my best inference from the inbound `VoiceItem` + the outbound-image pattern. **Not verified against the live protocol.** The text fallback ensures a wrong guess never breaks a conversation. Needs real-device verification after deploy.

## Tests
15 pass (4 new): `aesEcbPaddedSize` block math, `encryptAesEcb` round-trip, and the full `uploadVoiceToCdn` orchestration with a stubbed fetch. Build + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**New Features**
- WeChat direct messages now support outbound voice-note replies. When users send voice notes, agent responses are synthesized to audio and returned as voice notes, with automatic fallback to text replies if synthesis fails.

**Documentation**
- Updated WeChat channel documentation to reflect new bidirectional voice-note capabilities and media handling specifics.

**Tests**
- Added comprehensive test coverage for media encryption and CDN upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->