### PR TITLE
chore: sync package-lock wechat version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0",


### PR DESCRIPTION
One-line lockfile sync: #191's squash left the lockfile's `apps/channels/wechat` version at 0.3.0 while package.json is 0.4.0. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)