### PR TITLE
fix(wechat): assemble voice upload URL when getuploadurl omits full_url

### DIFF
--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/ilink/media.ts
+++ b/apps/channels/wechat/src/ilink/media.ts
@@ -57,6 +57,19 @@ export function buildCdnDownloadUrl(encryptedQueryParam: string, cdnBaseUrl: str
   return `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptedQueryParam)}`;
 }
 
+/** Build a CDN upload URL from `upload_param` + `filekey` when the server
+ * returns no `upload_full_url` (mirrors the reference's fallback assembly). */
+export function buildCdnUploadUrl(
+  uploadParam: string,
+  filekey: string,
+  cdnBaseUrl: string,
+): string {
+  return (
+    `${cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(uploadParam)}` +
+    `&filekey=${encodeURIComponent(filekey)}`
+  );
+}
+
 /** Resolve the download URL for a media item, preferring the server's full_url. */
 export function resolveCdnUrl(
   encryptQueryParam: string | undefined,

--- a/apps/channels/wechat/src/ilink/upload.ts
+++ b/apps/channels/wechat/src/ilink/upload.ts
@@ -14,7 +14,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import { getUploadUrl, uploadToCdn, type WeixinApiOptions } from './api.js';
-import { aesEcbPaddedSize, encryptAesEcb } from './media.js';
+import { CDN_BASE_URL, aesEcbPaddedSize, buildCdnUploadUrl, encryptAesEcb } from './media.js';
 import { UploadMediaType } from './types.js';
 
 export interface UploadedMedia {
@@ -60,9 +60,17 @@ export async function uploadMediaToCdn(
     },
   });
 
-  const uploadUrl = slot.upload_full_url;
+  // Prefer the server's full URL; otherwise assemble one from upload_param +
+  // filekey against the CDN base (the reference's fallback). If neither is
+  // present the request was likely rejected — surface ret/errcode/errmsg.
+  const uploadUrl =
+    slot.upload_full_url ||
+    (slot.upload_param ? buildCdnUploadUrl(slot.upload_param, filekey, CDN_BASE_URL) : undefined);
   if (!uploadUrl) {
-    throw new Error('getUploadUrl returned no upload_full_url');
+    throw new Error(
+      `getUploadUrl returned no usable URL (ret=${slot.ret} errcode=${slot.errcode} ` +
+        `errmsg=${slot.errmsg ?? ''} keys=${Object.keys(slot).join(',')})`,
+    );
   }
 
   const ciphertext = encryptAesEcb(opts.bytes, aesKey);

--- a/apps/channels/wechat/test/upload.test.ts
+++ b/apps/channels/wechat/test/upload.test.ts
@@ -70,6 +70,55 @@ test('uploadVoiceToCdn declares plaintext/ciphertext sizes, encrypts, and return
   }
 });
 
+test('uploadVoiceToCdn assembles the upload URL from upload_param when full_url is absent', async () => {
+  let postedUrl: string | undefined;
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    void init;
+    const u = String(url);
+    if (u.includes('getuploadurl')) {
+      // No upload_full_url — only upload_param, as the live voice path returns.
+      return new Response(JSON.stringify({ ret: 0, upload_param: 'UP_PARAM_xyz' }), { status: 200 });
+    }
+    postedUrl = u;
+    return new Response(null, { status: 200, headers: { 'x-encrypted-param': 'DL' } });
+  }) as typeof fetch;
+
+  try {
+    const out = await uploadVoiceToCdn({
+      baseUrl: 'https://bot.example/',
+      token: 'tok',
+      bytes: randomBytes(8),
+      toUserId: 'p',
+    });
+    assert.equal(out.downloadEncryptedQueryParam, 'DL');
+    assert.ok(postedUrl?.includes('/upload?encrypted_query_param=UP_PARAM_xyz'));
+    assert.ok(postedUrl?.includes('filekey='));
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('uploadVoiceToCdn throws a diagnostic error when the slot has no usable URL', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    if (String(url).includes('getuploadurl')) {
+      return new Response(JSON.stringify({ ret: -1, errcode: 42, errmsg: 'nope' }), { status: 200 });
+    }
+    return new Response(null, { status: 200, headers: { 'x-encrypted-param': 'DL' } });
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      () =>
+        uploadVoiceToCdn({ baseUrl: 'https://bot.example/', token: 'tok', bytes: randomBytes(8), toUserId: 'p' }),
+      /errcode=42[\s\S]*errmsg=nope/,
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
 test('uploadVoiceToCdn throws when the CDN omits x-encrypted-param', async () => {
   const original = globalThis.fetch;
   globalThis.fetch = (async (url: string | URL | Request) => {


### PR DESCRIPTION
## Live-test fix
After deploying Phase 2, inbound voice worked (STT) and TTS ran, but the **outbound voice reply fell back to text** with:
```
[wechat] voice reply failed: getUploadUrl returned no upload_full_url
```

WeChat's `getuploadurl` response for voice returns `upload_param` (not a ready-made `upload_full_url`). The reference plugin assembles the upload URL in that case: `<cdnBase>/upload?encrypted_query_param=<param>&filekey=<filekey>`. I only honored `upload_full_url`.

## Fix
- `buildCdnUploadUrl(uploadParam, filekey, cdnBase)` in `media.ts`.
- `upload.ts` prefers `upload_full_url`, else assembles from `upload_param` + `filekey`.
- If **neither** is present the request was rejected, so the thrown error now includes `ret`/`errcode`/`errmsg`/response keys — turns a blind "no upload_full_url" into an actionable diagnosis on the next test.

## Tests
17 pass (2 new): the `upload_param` assembly path, and the diagnostic-error path. Build + typecheck green.

Still needs the live re-test to confirm WeChat accepts the assembled upload + the inferred voice-item shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for alternative CDN upload URL construction, enabling uploads when the full URL is unavailable.

* **Improvements**
  * Enhanced error handling with more detailed diagnostic information during upload failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->