### PR TITLE
fix(wechat): inspect sendmessage ret; text fallback on voice reject

### DIFF
--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -192,6 +192,10 @@ export class WechatBridge implements ChannelOutbound {
         bytes: encoded.silk,
         toUserId,
       });
+      this.log(
+        `voice reply: silk=${encoded.silk.byteLength}B dur=${Math.round(encoded.durationMs)}ms ` +
+          `uploaded ref=${uploaded.downloadEncryptedQueryParam.length}ch`,
+      );
 
       return await this.sendVoice(toUserId, uploaded, encoded.durationMs, turnContextToken);
     } catch (err) {
@@ -229,11 +233,20 @@ export class WechatBridge implements ChannelOutbound {
       ...(contextToken ? { context_token: contextToken } : {}),
     };
     try {
-      await sendMessage({
+      const resp = await sendMessage({
         baseUrl: this.runtime.baseUrl,
         token: this.runtime.botToken,
         body: { msg },
       });
+      // sendmessage can return HTTP 200 with a non-zero ret/errcode when it
+      // rejects the payload. Treat that as a failure so we fall back to text.
+      if ((resp.ret && resp.ret !== 0) || (resp.errcode && resp.errcode !== 0)) {
+        this.log(
+          `voice send rejected by sendmessage: ret=${resp.ret} errcode=${resp.errcode} errmsg=${resp.errmsg ?? ''}`,
+        );
+        return false;
+      }
+      this.log(`voice send accepted (ret=${resp.ret ?? 0})`);
       return true;
     } catch (err) {
       this.log(`failed to send voice to ${toUserId}: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/channels/wechat/src/ilink/api.ts
+++ b/apps/channels/wechat/src/ilink/api.ts
@@ -28,6 +28,7 @@ import type {
   QrCodeResponse,
   QrStatusResponse,
   SendMessageReq,
+  SendMessageResp,
 } from './types.js';
 
 interface PackageJson {
@@ -245,8 +246,8 @@ export const getUpdates = async (
 
 export const sendMessage = async (
   opts: WeixinApiOptions & { body: SendMessageReq },
-): Promise<void> => {
-  await apiPost({
+): Promise<SendMessageResp> => {
+  const raw = await apiPost({
     baseUrl: opts.baseUrl,
     endpoint: 'ilink/bot/sendmessage',
     body: JSON.stringify({ ...opts.body, base_info: buildBaseInfo(opts.botAgent) }),
@@ -254,6 +255,11 @@ export const sendMessage = async (
     timeoutMs: DEFAULT_API_TIMEOUT_MS,
     label: 'sendMessage',
   });
+  try {
+    return raw ? (JSON.parse(raw) as SendMessageResp) : {};
+  } catch {
+    return {};
+  }
 };
 
 /**

--- a/apps/channels/wechat/src/ilink/types.ts
+++ b/apps/channels/wechat/src/ilink/types.ts
@@ -143,6 +143,14 @@ export interface SendMessageReq {
   msg?: WeixinMessage;
 }
 
+/** `ilink/bot/sendmessage` response. A non-zero `ret`/`errcode` means the
+ * server rejected the message even though the HTTP status was 200. */
+export interface SendMessageResp {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+}
+
 /** `GetUploadUrlReq.media_type` — kind of media being uploaded to the CDN. */
 export const UploadMediaType = {
   IMAGE: 1,


### PR DESCRIPTION
## Live-test follow-up
After #193, outbound voice produced **no reply at all**: TTS + SILK encode + CDN upload + `sendmessage` (HTTP 200) all succeeded, so `trySendVoiceReply` reported success and suppressed the text fallback — but WeChat never delivered a playable voice note (the inferred `voice_item` shape is likely wrong). iLink signals rejection via a non-zero `ret`/`errcode` inside a 200 body, which `sendMessage` was discarding.

## Change
- `sendMessage` parses + returns the response body (`SendMessageResp`).
- `sendVoice` logs the upload result, checks `ret`/`errcode`, and returns `false` on a non-zero code → the reply path falls back to **text**. So a rejected voice item degrades to text instead of silence, and the log shows the exact `ret`/`errcode`/`errmsg`.
- Adds a diagnostic log line (silk size, duration, upload ref length).

This is primarily diagnostics + a correctness fallback; it does not yet *fix* the voice-item shape (we need the live `ret`/`errcode` to know what WeChat wants). 17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice message delivery with enhanced error detection and automatic fallback to text replies when voice sending fails.
  * Added detailed delivery metrics logging for voice messages to improve monitoring and debugging.

This patch release ensures more reliable messaging and better visibility into voice delivery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->