### PR TITLE
fix(wechat): raise voice upload timeout; cap + shorten voice replies

### DIFF
--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -36,11 +36,15 @@ import { uploadVoiceToCdn } from './ilink/upload.js';
  * voice we try to answer with a voice note.
  */
 const VOICE_MARKER =
-  '[Voice message, transcribed. Your reply will be converted to speech, so respond in ' +
-  'plain prose without code blocks, markdown formatting, or long lists.]';
+  '[Voice message, transcribed. Your reply will be spoken aloud, so keep it brief — ' +
+  'a sentence or two — in plain prose without code blocks, markdown, or lists.]';
 
-/** Cap on text we'll synthesize into a voice reply — longer stays text. */
-const VOICE_MAX_TEXT_LENGTH = 1000;
+/** Cap on text we'll synthesize into a voice reply — longer stays text. A voice
+ * note should be short; this also keeps the uploaded audio small. */
+const VOICE_MAX_TEXT_LENGTH = 600;
+
+/** Timeout for the (larger) voice CDN upload — audio is bigger than text. */
+const VOICE_UPLOAD_TIMEOUT_MS = 45_000;
 
 /** Whether a reply is fit for voice delivery (mirrors the Telegram bridge). */
 const shouldSpeak = (text: string): boolean => {
@@ -184,17 +188,16 @@ export class WechatBridge implements ChannelOutbound {
       const tts = await this.client.synthesizeAudio({ text, outputMimeType: 'audio/ogg' });
       const bytes = Buffer.from(tts.bytes);
       const playtimeMs = oggOpusPlaytimeMs(bytes) ?? 0;
+      this.log(`voice reply: opus=${bytes.byteLength}B playtime=${playtimeMs}ms; uploading`);
 
       const uploaded = await uploadVoiceToCdn({
         baseUrl: this.runtime.baseUrl,
         token: this.runtime.botToken,
         bytes,
         toUserId,
+        timeoutMs: VOICE_UPLOAD_TIMEOUT_MS,
       });
-      this.log(
-        `voice reply: opus=${bytes.byteLength}B playtime=${playtimeMs}ms ` +
-          `uploaded ref=${uploaded.downloadEncryptedQueryParam.length}ch`,
-      );
+      this.log(`voice reply: uploaded ref=${uploaded.downloadEncryptedQueryParam.length}ch`);
 
       return await this.sendVoice(toUserId, uploaded, playtimeMs, turnContextToken);
     } catch (err) {

--- a/apps/channels/wechat/src/ilink/api.ts
+++ b/apps/channels/wechat/src/ilink/api.ts
@@ -268,14 +268,14 @@ export const sendMessage = async (
  * POSTed separately via {@link uploadToCdn}.
  */
 export const getUploadUrl = async (
-  opts: WeixinApiOptions & { req: GetUploadUrlReq },
+  opts: WeixinApiOptions & { req: GetUploadUrlReq; timeoutMs?: number },
 ): Promise<GetUploadUrlResp> => {
   const raw = await apiPost({
     baseUrl: opts.baseUrl,
     endpoint: 'ilink/bot/getuploadurl',
     body: JSON.stringify({ ...opts.req, base_info: buildBaseInfo(opts.botAgent) }),
     token: opts.token,
-    timeoutMs: DEFAULT_API_TIMEOUT_MS,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_API_TIMEOUT_MS,
     label: 'getUploadUrl',
   });
   return JSON.parse(raw) as GetUploadUrlResp;

--- a/apps/channels/wechat/src/ilink/upload.ts
+++ b/apps/channels/wechat/src/ilink/upload.ts
@@ -35,6 +35,8 @@ export async function uploadMediaToCdn(
     bytes: Buffer;
     mediaType: number;
     toUserId: string;
+    /** Timeout for the getUploadUrl + CDN upload legs. */
+    timeoutMs?: number;
   },
 ): Promise<UploadedMedia> {
   const aesKey = randomBytes(16);
@@ -48,6 +50,7 @@ export async function uploadMediaToCdn(
     baseUrl: opts.baseUrl,
     token: opts.token,
     ...(opts.botAgent ? { botAgent: opts.botAgent } : {}),
+    ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
     req: {
       filekey,
       media_type: opts.mediaType,
@@ -74,14 +77,18 @@ export async function uploadMediaToCdn(
   }
 
   const ciphertext = encryptAesEcb(opts.bytes, aesKey);
-  const { downloadEncryptedQueryParam } = await uploadToCdn({ uploadUrl, ciphertext });
+  const { downloadEncryptedQueryParam } = await uploadToCdn({
+    uploadUrl,
+    ciphertext,
+    ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+  });
 
   return { downloadEncryptedQueryParam, aeskeyHex, rawsize };
 }
 
-/** Convenience wrapper for uploading a SILK voice clip. */
+/** Convenience wrapper for uploading a voice clip (Ogg/Opus). */
 export function uploadVoiceToCdn(
-  opts: WeixinApiOptions & { bytes: Buffer; toUserId: string },
+  opts: WeixinApiOptions & { bytes: Buffer; toUserId: string; timeoutMs?: number },
 ): Promise<UploadedMedia> {
   return uploadMediaToCdn({ ...opts, mediaType: UploadMediaType.VOICE });
 }


### PR DESCRIPTION
## Live test
With the Ogg/Opus fix (#196), TTS succeeded but the **CDN upload hit the 15s timeout** (`operation was aborted due to timeout`) and fell back to text. Opus audio is larger than the SILK was, and the replies were ~30s of speech.

## Fix
- Thread `timeoutMs` through `uploadVoiceToCdn → getUploadUrl / uploadToCdn`; use **45s** for the voice upload.
- Log opus size/playtime **before** the upload so a failing upload is visible in the log.
- Lower the voice cap to **600 chars** and ask the agent (via the inbound marker) to keep spoken replies to a sentence or two — a voice note should be short, which also keeps the upload small/fast.

20 tests pass. Build + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced voice message transcription and upload reliability with configurable timeout controls
  * Optimized voice response settings and adjusted maximum message length constraints
  * Improved CDN upload stability with better timeout management
  * Updated voice marker text handling

* **Chores**
  * Version bumped to 0.4.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->