### PR TITLE
fix(wechat): shorten voice replies, raise timeout, log upload speed

### DIFF
--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -39,12 +39,14 @@ const VOICE_MARKER =
   '[Voice message, transcribed. Your reply will be spoken aloud, so keep it brief — ' +
   'a sentence or two — in plain prose without code blocks, markdown, or lists.]';
 
-/** Cap on text we'll synthesize into a voice reply — longer stays text. A voice
- * note should be short; this also keeps the uploaded audio small. */
-const VOICE_MAX_TEXT_LENGTH = 600;
+/** Cap on text we'll synthesize into a voice reply — longer stays text. Kept
+ * small: the upload link to the WeChat CDN is slow (~8 KB/s observed), so a
+ * voice note must be short to upload before the timeout. */
+const VOICE_MAX_TEXT_LENGTH = 300;
 
-/** Timeout for the (larger) voice CDN upload — audio is bigger than text. */
-const VOICE_UPLOAD_TIMEOUT_MS = 45_000;
+/** Timeout for the (larger) voice CDN upload — audio is bigger than text and
+ * the CDN upload link is slow. */
+const VOICE_UPLOAD_TIMEOUT_MS = 60_000;
 
 /** Whether a reply is fit for voice delivery (mirrors the Telegram bridge). */
 const shouldSpeak = (text: string): boolean => {
@@ -190,6 +192,7 @@ export class WechatBridge implements ChannelOutbound {
       const playtimeMs = oggOpusPlaytimeMs(bytes) ?? 0;
       this.log(`voice reply: opus=${bytes.byteLength}B playtime=${playtimeMs}ms; uploading`);
 
+      const uploadStart = Date.now();
       const uploaded = await uploadVoiceToCdn({
         baseUrl: this.runtime.baseUrl,
         token: this.runtime.botToken,
@@ -197,7 +200,11 @@ export class WechatBridge implements ChannelOutbound {
         toUserId,
         timeoutMs: VOICE_UPLOAD_TIMEOUT_MS,
       });
-      this.log(`voice reply: uploaded ref=${uploaded.downloadEncryptedQueryParam.length}ch`);
+      const uploadMs = Date.now() - uploadStart;
+      const kbps = uploadMs > 0 ? Math.round((bytes.byteLength / 1024 / uploadMs) * 1000) : 0;
+      this.log(
+        `voice reply: uploaded ref=${uploaded.downloadEncryptedQueryParam.length}ch in ${uploadMs}ms (~${kbps}KB/s)`,
+      );
 
       return await this.sendVoice(toUserId, uploaded, playtimeMs, turnContextToken);
     } catch (err) {


### PR DESCRIPTION
Live test: a 20.8s / 391 KB Opus reply still timed out at the 45s upload limit — the upload link to the WeChat CDN from the test server is ~8 KB/s. Cap voice replies to 300 chars (longer → text), raise the upload timeout to 60s, and log upload duration + KB/s to confirm throughput. 20 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WeChat channel to version 0.4.5

* **Bug Fixes**
  * Optimized voice reply synthesis parameters
  * Enhanced voice upload timeout and reliability handling
  * Improved voice upload performance diagnostics and metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->