### PR TITLE
fix(wechat): disable outbound voice replies by default (iLink drops them)

### DIFF
--- a/apps/channels/wechat/README.md
+++ b/apps/channels/wechat/README.md
@@ -17,14 +17,16 @@ gateway-managed OpenHermit agent over Tencent's **iLink** HTTP protocol.
   it is downloaded, decrypted, transcoded to WAV via
   [`silk-wasm`](https://www.npmjs.com/package/silk-wasm), and sent through the
   agent's STT; non-SILK codecs are skipped.
-- **Outbound voice** (DM replies to a voice note): the reply is synthesized via
-  the agent's TTS as **Ogg/Opus @ 48 kHz** (`audio/ogg`), uploaded to the WeChat
-  C2C CDN (`getuploadurl` media_type=VOICE + AES-128-ECB encrypt), and sent as a
-  voice item with `encode_type: 8` (Ogg/Opus) — the format WeChat renders for
-  bot-sent voice, matching Tencent's own `openclaw-weixin` `voice-outbound.ts`.
-  (SILK is the QQ format and is silently dropped by iLink on the bot→user
-  direction.) Anything unspeakable (code blocks, very long text) or any failure
-  falls back to a text reply. Group replies always stay text.
+- **Outbound voice** (DM replies, **off by default**): set
+  `OPENHERMIT_WECHAT_VOICE_REPLY=1` to enable. When on, a reply to a voice note
+  is synthesized via TTS as **Ogg/Opus @ 48 kHz** (`audio/ogg`), uploaded to the
+  WeChat C2C CDN, and sent as a voice item (`encode_type: 8`). **⚠️ Known
+  limitation:** iLink **silently drops bot→user VOICE messages** — the send is
+  accepted (`ret=0`) but the WeChat client never renders it (confirmed live for
+  both SILK and Ogg/Opus; documented by reverse-engineered iLink SDKs). The code
+  path is kept for a possible future iLink change / QQ reuse, but **voice replies
+  do not currently reach the user**, which is why it is disabled by default. With
+  it off, voice notes are transcribed inbound and answered with text.
 - Inbound file / video and other outbound media (images/files) are not handled
   yet.
 - QR-link wizard (`ChannelSetup`) returns the QR URL as a plain string;

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, inbound images, and voice notes (STT in, TTS out).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -31,13 +31,23 @@ import { oggOpusPlaytimeMs } from './ilink/opus.js';
 import { uploadVoiceToCdn } from './ilink/upload.js';
 
 /**
- * Marker prepended to a transcribed voice note. It both tells the agent the
- * user spoke and asks for a speech-friendly reply, since when the inbound was
- * voice we try to answer with a voice note.
+ * Outbound voice replies are OFF by default: iLink silently drops bot→user
+ * VOICE messages (the send is accepted with ret=0 but the WeChat client never
+ * renders it — confirmed live for both SILK and Ogg/Opus, and documented by
+ * reverse-engineered iLink SDKs). The full TTS→Opus→CDN→voice_item path is kept
+ * for a possible future iLink change / QQ reuse; enable with
+ * OPENHERMIT_WECHAT_VOICE_REPLY=1. When off, voice notes are still transcribed
+ * inbound and answered with text.
  */
-const VOICE_MARKER =
-  '[Voice message, transcribed. Your reply will be spoken aloud, so keep it brief — ' +
-  'a sentence or two — in plain prose without code blocks, markdown, or lists.]';
+const VOICE_REPLY_ENABLED =
+  process.env.OPENHERMIT_WECHAT_VOICE_REPLY === '1' ||
+  process.env.OPENHERMIT_WECHAT_VOICE_REPLY === 'true';
+
+/** Marker prepended to a transcribed voice note so the agent knows the user spoke. */
+const VOICE_MARKER = VOICE_REPLY_ENABLED
+  ? '[Voice message, transcribed. Your reply will be spoken aloud, so keep it brief — ' +
+    'a sentence or two — in plain prose without code blocks, markdown, or lists.]'
+  : '[Voice message, transcribed.]';
 
 /** Cap on text we'll synthesize into a voice reply — longer stays text. Kept
  * small: the upload link to the WeChat CDN is slow (~8 KB/s observed), so a
@@ -470,11 +480,12 @@ export class WechatBridge implements ChannelOutbound {
       const stripped = stripSilenceTokens(replyText);
       if (!stripped.isSilent) {
         const outText = stripped.hadToken ? stripped.text : replyText;
-        // When the user sent voice (DM only), answer with a voice note; fall
-        // back to text if TTS/encode/upload/send fails or the text isn't
-        // speakable. Group replies always stay text.
+        // When the user sent voice (DM only) AND voice replies are enabled,
+        // answer with a voice note; fall back to text if it isn't speakable or
+        // anything fails. Voice replies are off by default (iLink drops them);
+        // group replies always stay text.
         const sentVoice =
-          resolved.wasVoice && !isGroup
+          VOICE_REPLY_ENABLED && resolved.wasVoice && !isGroup
             ? await this.trySendVoiceReply(peer, outText, turnContextToken)
             : false;
         if (!sentVoice) {


### PR DESCRIPTION
## Conclusion of the outbound-voice investigation
Confirmed live across multiple attempts: **iLink silently drops bot→user VOICE messages.** With a short **Ogg/Opus** clip, the CDN upload *succeeded* (~12 KB/s, `uploaded ref=360ch in 12915ms`) and `sendmessage` returned **`ret=0`**, yet the WeChat client rendered nothing — identical to the SILK attempts. This matches the reverse-engineered `zongrongjin/weixin-ilink` SDK, which documents *"iLink 通道会静默丢弃 bot 方向的 VOICE 消息"*. It is a protocol limitation, not a format bug.

Because `ret=0` looks like success, the text fallback was suppressed → the user got **no reply at all**.

## Change
- Gate the voice-reply attempt behind **`OPENHERMIT_WECHAT_VOICE_REPLY`** (default **off**). With it off, voice notes are still transcribed inbound and answered with **text** (restores replies).
- The full TTS→Opus→CDN→`voice_item` path is preserved for a future iLink change / QQ reuse.
- README documents the limitation.

20 tests pass.

## Net Phase 2 status
- ✅ Inbound voice (STT) — works.
- ⚠️ Outbound voice — implemented end-to-end and correct (upload + `ret=0`), but **iLink does not deliver bot voice**, so it's off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Voice reply behavior updated: voice replies now disabled by default and require explicit configuration to enable
  * Clarified known limitation where outbound voice messages are silently dropped despite successful acceptance

* **Chores**
  * WeChat channel adapter version updated to 0.4.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->