### PR TITLE
feat(agent): pdf_read tool — in-process PDF text extraction

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -68,6 +68,7 @@
     "mime-types": "^3.0.2",
     "prom-client": "^15.1.3",
     "undici": "^7.25.0",
+    "unpdf": "^1.6.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -19,6 +19,7 @@ import { createScheduleToolset } from './tools/schedule.js';
 import { createPolicyToolset } from './tools/policy.js';
 import { createApprovalToolset } from './tools/approval-request.js';
 import { createAttachmentToolset } from './tools/attachment.js';
+import { createPdfToolset } from './tools/pdf.js';
 
 export type {
   ApprovalCallback,
@@ -76,6 +77,7 @@ export const createBuiltInToolsets = (
   }
   if (context.attachmentStore && context.attachmentStorage) {
     toolsets.push(createAttachmentToolset(context));
+    toolsets.push(createPdfToolset(context));
   }
   // working_memory_update is intentionally excluded from the main agent —
   // it is only available to the introspection agent to prevent overwrite conflicts.

--- a/apps/agent/src/tools/pdf.ts
+++ b/apps/agent/src/tools/pdf.ts
@@ -1,0 +1,277 @@
+import { Type, type Static } from '@mariozechner/pi-ai';
+import { ValidationError } from '@openhermit/shared';
+import { extractText, getDocumentProxy, getMeta } from 'unpdf';
+
+import {
+  type PolicyAwareTool,
+  type Toolset,
+  type ToolContext,
+  asTextContent,
+} from './shared.js';
+import type { ExecBackend } from '../core/index.js';
+import { DEFAULT_ATTACHMENT_MAX_BYTES } from '../attachments/helpers.js';
+
+const PdfReadParams = Type.Object({
+  attachment_id: Type.Optional(
+    Type.String({
+      description:
+        'Id of an uploaded PDF (e.g. `att_xxx`) from `attachment_list`/`attachment_upload`. Provide exactly one of attachment_id or sandbox_path.',
+    }),
+  ),
+  sandbox_path: Type.Optional(
+    Type.String({
+      description:
+        'Absolute path to a PDF inside the sandbox (e.g. one the agent generated or that was materialized from an upload). Provide exactly one of attachment_id or sandbox_path.',
+    }),
+  ),
+  pages: Type.Optional(
+    Type.String({
+      description:
+        "Page selection, 1-based, like '1-5' or '1,3,7-9'. Omit to read every page.",
+    }),
+  ),
+  password: Type.Optional(
+    Type.String({ description: 'Password for an encrypted PDF.' }),
+  ),
+  max_bytes: Type.Optional(
+    Type.Number({
+      description:
+        'Maximum input size in bytes (default 25 MiB). Larger PDFs are rejected — read them with file_read + an exec converter (e.g. pdftotext) instead.',
+    }),
+  ),
+  sandbox: Type.Optional(
+    Type.String({
+      description: 'Sandbox alias for sandbox_path reads. Omit to use the default sandbox.',
+    }),
+  ),
+});
+
+type PdfReadArgs = Static<typeof PdfReadParams>;
+
+const resolveBackend = (context: ToolContext, alias?: string): ExecBackend => {
+  if (!context.execBackendManager) {
+    throw new ValidationError(
+      'pdf_read sandbox_path is unavailable: no execution backend is configured for this agent.',
+    );
+  }
+  return context.execBackendManager.get(alias);
+};
+
+/** Read a stream into a Buffer, throwing once the byte cap is exceeded. */
+async function readCapped(stream: NodeJS.ReadableStream, cap: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let seen = 0;
+  for await (const chunk of stream) {
+    const b = typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer);
+    seen += b.length;
+    if (seen > cap) {
+      throw new ValidationError(
+        `pdf_read: PDF exceeds max_bytes=${cap}. Use file_read on the sandbox path with an exec converter (e.g. pdftotext) for very large PDFs.`,
+      );
+    }
+    chunks.push(b);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** PDFs carry a `%PDF-` signature; real readers tolerate a little leading junk. */
+const looksLikePdf = (buf: Buffer): boolean =>
+  buf.subarray(0, 1024).includes(Buffer.from('%PDF-', 'latin1'));
+
+const PAGE_SPEC_RE = /^\s*\d+(\s*-\s*\d+)?(\s*,\s*\d+(\s*-\s*\d+)?)*\s*$/;
+
+/** Parse a 1-based page spec ('1-5' | '1,3,7-9') into a clamped, sorted, deduped list. */
+const parsePageRange = (spec: string, totalPages: number): number[] => {
+  if (!PAGE_SPEC_RE.test(spec)) {
+    throw new ValidationError(
+      `pdf_read: invalid pages value "${spec}". Use formats like "1-5" or "1,3,7-9".`,
+    );
+  }
+  const wanted = new Set<number>();
+  for (const part of spec.split(',')) {
+    const bounds = part.split('-').map((s) => Number.parseInt(s.trim(), 10));
+    const start = bounds[0]!;
+    const end = bounds[1] ?? start;
+    if (start < 1 || end < start) {
+      throw new ValidationError(`pdf_read: invalid page range "${part.trim()}" in pages="${spec}".`);
+    }
+    for (let p = start; p <= end && p <= totalPages; p++) wanted.add(p);
+  }
+  if (wanted.size === 0) {
+    throw new ValidationError(
+      `pdf_read: pages="${spec}" selects no pages in a ${totalPages}-page document.`,
+    );
+  }
+  return [...wanted].sort((x, y) => x - y);
+};
+
+const isPasswordError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false;
+  const name = (err as { name?: unknown }).name;
+  const msg = (err as { message?: unknown }).message;
+  return name === 'PasswordException' || (typeof msg === 'string' && /password/i.test(msg));
+};
+
+export const createPdfReadTool = (
+  context: ToolContext,
+): PolicyAwareTool<typeof PdfReadParams> => ({
+  // Reads attachment/sandbox content: owner + user, like file_read (guests excluded).
+  policy: {
+    defaultGrants: [
+      { type: 'role', value: 'owner' },
+      { type: 'role', value: 'user' },
+    ],
+  },
+  name: 'pdf_read',
+  label: 'Read PDF',
+  description:
+    'Extract text from a PDF (by attachment_id or sandbox_path) and return it to you. ' +
+    'Use this instead of attachment_fetch/file_read for PDFs — those return raw bytes, not readable text. ' +
+    'Supports page selection (pages) and encrypted PDFs (password). Born-digital PDFs only; ' +
+    'scanned/image-only PDFs have no extractable text (page-image rendering is not yet supported).',
+  parameters: PdfReadParams,
+  execute: async (_toolCallId, args: PdfReadArgs) => {
+    const hasId = typeof args.attachment_id === 'string' && args.attachment_id.trim() !== '';
+    const hasPath = typeof args.sandbox_path === 'string' && args.sandbox_path.trim() !== '';
+    if (hasId === hasPath) {
+      throw new ValidationError(
+        'pdf_read requires exactly one of attachment_id or sandbox_path.',
+      );
+    }
+
+    const cap = Math.max(1, args.max_bytes ?? DEFAULT_ATTACHMENT_MAX_BYTES);
+
+    let buf: Buffer;
+    let source: Record<string, unknown>;
+
+    if (hasId) {
+      if (!context.attachmentStore || !context.attachmentStorage || !context.storeScope) {
+        throw new ValidationError(
+          'pdf_read is unavailable: attachment storage is not configured.',
+        );
+      }
+      const id = args.attachment_id!.trim();
+      const row = await context.attachmentStore.get(id);
+      if (!row || row.agentId !== context.storeScope.agentId) {
+        throw new ValidationError(`pdf_read: no such attachment ${id}.`);
+      }
+      // Visibility: same session is always allowed; cross-session only for the
+      // owner or the original uploader (mirrors attachment_fetch).
+      const sameSession = row.sessionId === context.sessionId;
+      const isOwner = context.currentUserRole === 'owner';
+      const isUploader = !!row.uploaderUserId && row.uploaderUserId === context.currentUserId;
+      if (!sameSession && !isOwner && !isUploader) {
+        throw new ValidationError(`pdf_read: attachment ${id} is not visible in this session.`);
+      }
+      if (row.sizeBytes > cap) {
+        throw new ValidationError(
+          `pdf_read: attachment ${id} is ${row.sizeBytes} bytes which exceeds max_bytes=${cap}. ` +
+            'Use the sandbox path with file_read + an exec converter for very large PDFs.',
+        );
+      }
+      const stream = await context.attachmentStorage.readStream(row.storageKey);
+      buf = await readCapped(stream, cap);
+      source = { attachmentId: id, name: row.originalName };
+    } else {
+      const backend = resolveBackend(context, args.sandbox);
+      const path = args.sandbox_path!.trim();
+      const { data } = await backend.files.read(path);
+      if (data.byteLength > cap) {
+        throw new ValidationError(
+          `pdf_read: ${path} is ${data.byteLength} bytes which exceeds max_bytes=${cap}.`,
+        );
+      }
+      buf = data;
+      source = { path, sandbox: backend.id };
+    }
+
+    if (!looksLikePdf(buf)) {
+      throw new ValidationError(
+        'pdf_read: file does not look like a PDF (missing %PDF- signature). ' +
+          'Use attachment_fetch/file_read for non-PDF files.',
+      );
+    }
+
+    let pdf: Awaited<ReturnType<typeof getDocumentProxy>>;
+    try {
+      pdf = await getDocumentProxy(
+        new Uint8Array(buf),
+        args.password ? { password: args.password } : undefined,
+      );
+    } catch (err) {
+      if (isPasswordError(err)) {
+        throw new ValidationError(
+          args.password
+            ? 'pdf_read: incorrect password for this encrypted PDF.'
+            : 'pdf_read: this PDF is encrypted. Pass the `password` parameter to read it.',
+        );
+      }
+      throw new ValidationError(
+        `pdf_read: failed to open PDF: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const { totalPages, text } = await extractText(pdf, { mergePages: false });
+
+    const selected = args.pages
+      ? parsePageRange(args.pages, totalPages)
+      : Array.from({ length: totalPages }, (_, i) => i + 1);
+
+    const pageTexts = selected.map((p) => (text[p - 1] ?? '').trim());
+    const extractedChars = pageTexts.reduce((n, t) => n + t.length, 0);
+    const hadText = extractedChars > 0;
+
+    // Best-effort metadata; never fail the read over it.
+    let info: Record<string, unknown> = {};
+    try {
+      const meta = await getMeta(pdf);
+      info = (meta.info ?? {}) as Record<string, unknown>;
+    } catch {
+      /* metadata is optional */
+    }
+
+    const note = hadText
+      ? undefined
+      : 'No extractable text — this PDF is likely scanned/image-only. Page-image rendering (OCR/vision) is not yet supported by pdf_read.';
+
+    const body = hadText
+      ? selected.map((p, i) => `--- page ${p} ---\n${pageTexts[i]}`).join('\n\n')
+      : `[pdf_read] ${note}`;
+
+    return {
+      content: asTextContent(`${body}\n`),
+      details: {
+        source,
+        pageCount: totalPages,
+        pagesExtracted: selected,
+        extractedChars,
+        hadText,
+        encrypted: !!args.password,
+        extraction: 'unpdf',
+        ...(typeof info.Title === 'string' && info.Title ? { title: info.Title } : {}),
+        ...(typeof info.Producer === 'string' && info.Producer ? { producer: info.Producer } : {}),
+        ...(note ? { note } : {}),
+      },
+    };
+  },
+});
+
+const PDF_DESCRIPTION = `\
+### PDF
+
+\`pdf_read\` extracts text from a PDF and returns it to you as readable text.
+
+- Prefer it over \`attachment_fetch\` / \`file_read\` for PDFs: those return raw
+  bytes (unreadable), whereas \`pdf_read\` returns extracted text.
+- Accepts \`attachment_id\` (an uploaded PDF) **or** \`sandbox_path\` (a PDF in the
+  sandbox) — exactly one.
+- \`pages\` selects pages (\`"1-5"\`, \`"1,3,7-9"\`); \`password\` unlocks encrypted PDFs.
+- Born-digital PDFs only. Scanned/image-only PDFs return no text (page-image
+  rendering / OCR is not yet supported) — for those, render pages with an exec
+  converter (e.g. \`pdftoppm\`) and inspect the images.`;
+
+export const createPdfToolset = (context: ToolContext): Toolset => ({
+  id: 'pdf',
+  description: PDF_DESCRIPTION,
+  tools: [createPdfReadTool(context)],
+});

--- a/apps/agent/src/tools/pdf.ts
+++ b/apps/agent/src/tools/pdf.ts
@@ -175,12 +175,18 @@ export const createPdfReadTool = (
     } else {
       const backend = resolveBackend(context, args.sandbox);
       const path = args.sandbox_path!.trim();
-      const { data } = await backend.files.read(path);
-      if (data.byteLength > cap) {
+      // Check size via stat before reading so an oversized file is rejected
+      // without being materialized into memory (the read has no byte cap).
+      const stat = await backend.files.stat(path);
+      if (!stat || stat.type !== 'file') {
+        throw new ValidationError(`pdf_read: no such file in sandbox: ${path}.`);
+      }
+      if (stat.size > cap) {
         throw new ValidationError(
-          `pdf_read: ${path} is ${data.byteLength} bytes which exceeds max_bytes=${cap}.`,
+          `pdf_read: ${path} is ${stat.size} bytes which exceeds max_bytes=${cap}.`,
         );
       }
+      const { data } = await backend.files.read(path);
       buf = data;
       source = { path, sandbox: backend.id };
     }
@@ -230,6 +236,13 @@ export const createPdfReadTool = (
       /* metadata is optional */
     }
 
+    // Actual encryption status from pdf.js: `EncryptFilterName` is the
+    // encryption filter name when the PDF is encrypted (truthy), null when it
+    // is not. Fall back to "was a password supplied" only if metadata is
+    // unavailable.
+    const encrypted =
+      'EncryptFilterName' in info ? Boolean(info.EncryptFilterName) : !!args.password;
+
     const note = hadText
       ? undefined
       : 'No extractable text — this PDF is likely scanned/image-only. Page-image rendering (OCR/vision) is not yet supported by pdf_read.';
@@ -246,7 +259,7 @@ export const createPdfReadTool = (
         pagesExtracted: selected,
         extractedChars,
         hadText,
-        encrypted: !!args.password,
+        encrypted,
         extraction: 'unpdf',
         ...(typeof info.Title === 'string' && info.Title ? { title: info.Title } : {}),
         ...(typeof info.Producer === 'string' && info.Producer ? { producer: info.Producer } : {}),

--- a/apps/agent/test/fixtures/sample.pdf
+++ b/apps/agent/test/fixtures/sample.pdf
@@ -1,0 +1,43 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 /MediaBox [0 0 612 792] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 45 >>
+stream
+BT /F1 24 Tf 72 700 Td (Hello page one) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /Contents 6 0 R /Resources << /Font << /F1 7 0 R >> >> >>
+endobj
+6 0 obj
+<< /Length 45 >>
+stream
+BT /F1 24 Tf 72 700 Td (Hello page two) Tj ET
+endstream
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000145 00000 n 
+0000000247 00000 n 
+0000000342 00000 n 
+0000000444 00000 n 
+0000000539 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+609
+%%EOF

--- a/apps/agent/test/pdf-tool.test.ts
+++ b/apps/agent/test/pdf-tool.test.ts
@@ -106,7 +106,11 @@ const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): Exe
     },
     write: async () => { throw new Error('not used'); },
     list: async () => [],
-    stat: async () => null,
+    stat: async (filePath: string) => {
+      const data = files.get(filePath);
+      if (!data) return null;
+      return { type: 'file' as const, size: data.byteLength, mtime: '1970-01-01T00:00:00.000Z' };
+    },
     delete: async () => { throw new Error('not used'); },
   },
 });
@@ -147,6 +151,7 @@ test('pdf_read extracts text from an uploaded PDF by attachment_id', async (t) =
   assert.deepEqual(details.pagesExtracted, [1, 2]);
   assert.equal(details.hadText, true);
   assert.equal(details.extraction, 'unpdf');
+  assert.equal(details.encrypted, false, 'an unencrypted PDF reports encrypted=false');
 });
 
 test('pdf_read pages="1" returns only the first page', async (t) => {
@@ -217,6 +222,31 @@ test('pdf_read enforces attachment visibility (cross-session, non-owner, non-upl
   await assert.rejects(
     () => tool.execute('tc-6', { attachment_id: id }),
     (err: unknown) => err instanceof ValidationError && /not visible/.test(err.message),
+  );
+});
+
+test('pdf_read rejects an oversized sandbox file via stat, without reading it', async (t) => {
+  const { baseCtx } = await setup(t);
+  const agentHome = '/root';
+  const backend: ExecBackend = {
+    ...makeReadOnlyBackend(agentHome, new Map()),
+    files: {
+      read: async () => {
+        throw new Error('read must not be called for an oversized file');
+      },
+      write: async () => { throw new Error('not used'); },
+      list: async () => [],
+      stat: async () => ({ type: 'file' as const, size: 10_000_000, mtime: '1970-01-01T00:00:00.000Z' }),
+      delete: async () => { throw new Error('not used'); },
+    },
+  };
+  const ctx: ToolContext = { ...baseCtx, execBackendManager: new ExecBackendManager([backend]) };
+  const tool = createPdfReadTool(ctx);
+  // The rejection must be the max_bytes ValidationError (from the stat check),
+  // not the read() guard — proving the cap is enforced before materialization.
+  await assert.rejects(
+    () => tool.execute('tc-9', { sandbox_path: `${agentHome}/big.pdf`, max_bytes: 1000 }),
+    (err: unknown) => err instanceof ValidationError && /max_bytes/.test(err.message),
   );
 });
 

--- a/apps/agent/test/pdf-tool.test.ts
+++ b/apps/agent/test/pdf-tool.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { test } from 'node:test';
+
+import { DbAttachmentStore, LocalAttachmentStorage } from '@openhermit/store';
+import { ValidationError } from '@openhermit/shared';
+
+import { createPdfReadTool, createPdfToolset } from '../src/tools/pdf.js';
+import { createBuiltInTools } from '../src/tools.js';
+import type { ToolContext } from '../src/tools/shared.js';
+import { ExecBackendManager } from '../src/core/index.js';
+import type { ExecBackend } from '../src/core/index.js';
+import { createSecurityFixture } from './helpers.js';
+
+const SAMPLE_PDF = readFileSync(new URL('./fixtures/sample.pdf', import.meta.url));
+
+function bufferToStream(buf: Buffer): NodeJS.ReadableStream {
+  return Readable.from(buf);
+}
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+  const t = result.content.find((c) => c.type === 'text');
+  return typeof t?.text === 'string' ? t.text : '';
+}
+
+async function setup(t: import('node:test').TestContext) {
+  const store = await DbAttachmentStore.open();
+  t.after(() => store.close());
+
+  const root = await mkdtemp(path.join(tmpdir(), 'openhermit-pdf-tool-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const storage = new LocalAttachmentStorage({ root });
+
+  const fixture = await createSecurityFixture(t);
+  const agentId = fixture.agentId;
+  const sessionId = `s-${randomUUID().slice(0, 8)}`;
+
+  const baseCtx: ToolContext = {
+    security: fixture.security,
+    attachmentStore: store,
+    attachmentStorage: storage,
+    storeScope: { agentId },
+    sessionId,
+    currentUserId: 'usr-1',
+    currentUserRole: 'user',
+  };
+
+  return { store, storage, agentId, sessionId, baseCtx };
+}
+
+async function uploadFile(opts: {
+  store: DbAttachmentStore;
+  storage: LocalAttachmentStorage;
+  agentId: string;
+  sessionId: string;
+  name: string;
+  body: Buffer;
+  mime: string;
+  uploaderUserId?: string;
+}): Promise<string> {
+  const id = `att_${randomUUID()}`;
+  const { sha256, sizeBytes } = await opts.storage.put({
+    agentId: opts.agentId,
+    sessionId: opts.sessionId,
+    attachmentId: id,
+    filename: opts.name,
+    contentType: opts.mime,
+    body: bufferToStream(opts.body),
+  });
+  await opts.store.create({
+    id,
+    agentId: opts.agentId,
+    sessionId: opts.sessionId,
+    uploaderUserId: opts.uploaderUserId ?? 'usr-1',
+    originalName: opts.name,
+    safeName: opts.name,
+    mimeType: opts.mime,
+    sizeBytes,
+    sha256,
+    storageProvider: 'local',
+    storageKey: `${opts.agentId}/${opts.sessionId}/${id}/${opts.name}`,
+  });
+  return id;
+}
+
+const makeReadOnlyBackend = (agentHome: string, files: Map<string, Buffer>): ExecBackend => ({
+  id: 'host',
+  type: 'host',
+  label: 'host',
+  username: 'tester',
+  agentHome,
+  ensure: async () => {},
+  exec: async () => ({ stdout: '', stderr: '', exitCode: 0, durationMs: 0 }),
+  syncSkills: async () => {},
+  shutdown: async () => {},
+  files: {
+    read: async (filePath: string) => {
+      const data = files.get(filePath);
+      if (!data) throw new Error(`fake backend: file not found: ${filePath}`);
+      return { data };
+    },
+    write: async () => { throw new Error('not used'); },
+    list: async () => [],
+    stat: async () => null,
+    delete: async () => { throw new Error('not used'); },
+  },
+});
+
+// ── toolset shape ───────────────────────────────────────────────────────
+
+test('createPdfToolset exposes a single pdf_read tool with owner+user grants', async (t) => {
+  const { baseCtx } = await setup(t);
+  const toolset = createPdfToolset(baseCtx);
+  assert.equal(toolset.id, 'pdf');
+  assert.equal(toolset.tools.length, 1);
+  const tool = toolset.tools[0]!;
+  assert.equal(tool.name, 'pdf_read');
+  assert.deepEqual(tool.policy?.defaultGrants, [
+    { type: 'role', value: 'owner' },
+    { type: 'role', value: 'user' },
+  ]);
+});
+
+// ── text extraction ───────────────────────────────────────────────────────
+
+test('pdf_read extracts text from an uploaded PDF by attachment_id', async (t) => {
+  const { store, storage, agentId, sessionId, baseCtx } = await setup(t);
+  const id = await uploadFile({
+    store, storage, agentId, sessionId,
+    name: 'sample.pdf', body: SAMPLE_PDF, mime: 'application/pdf',
+  });
+
+  const tool = createPdfReadTool(baseCtx);
+  const out = await tool.execute('tc-1', { attachment_id: id });
+
+  const text = firstText(out);
+  assert.match(text, /Hello page one/);
+  assert.match(text, /Hello page two/);
+
+  const details = out.details as Record<string, unknown>;
+  assert.equal(details.pageCount, 2);
+  assert.deepEqual(details.pagesExtracted, [1, 2]);
+  assert.equal(details.hadText, true);
+  assert.equal(details.extraction, 'unpdf');
+});
+
+test('pdf_read pages="1" returns only the first page', async (t) => {
+  const { store, storage, agentId, sessionId, baseCtx } = await setup(t);
+  const id = await uploadFile({
+    store, storage, agentId, sessionId,
+    name: 'sample.pdf', body: SAMPLE_PDF, mime: 'application/pdf',
+  });
+
+  const tool = createPdfReadTool(baseCtx);
+  const out = await tool.execute('tc-2', { attachment_id: id, pages: '1' });
+
+  const text = firstText(out);
+  assert.match(text, /Hello page one/);
+  assert.doesNotMatch(text, /Hello page two/);
+  assert.deepEqual((out.details as Record<string, unknown>).pagesExtracted, [1]);
+});
+
+test('pdf_read reads a PDF from a sandbox_path via the exec backend', async (t) => {
+  const { baseCtx } = await setup(t);
+  const agentHome = '/root';
+  const pdfPath = `${agentHome}/sample.pdf`;
+  const backend = makeReadOnlyBackend(agentHome, new Map([[pdfPath, SAMPLE_PDF]]));
+  const ctx: ToolContext = { ...baseCtx, execBackendManager: new ExecBackendManager([backend]) };
+
+  const tool = createPdfReadTool(ctx);
+  const out = await tool.execute('tc-3', { sandbox_path: pdfPath });
+
+  assert.match(firstText(out), /Hello page one/);
+  const details = out.details as { source: { path?: string } };
+  assert.equal(details.source.path, pdfPath);
+});
+
+// ── input validation & guards ─────────────────────────────────────────────
+
+test('pdf_read requires exactly one of attachment_id / sandbox_path', async (t) => {
+  const { baseCtx } = await setup(t);
+  const tool = createPdfReadTool(baseCtx);
+  await assert.rejects(() => tool.execute('tc-4a', {}), ValidationError);
+  await assert.rejects(
+    () => tool.execute('tc-4b', { attachment_id: 'att_x', sandbox_path: '/root/x.pdf' }),
+    ValidationError,
+  );
+});
+
+test('pdf_read rejects a non-PDF file (missing %PDF- signature)', async (t) => {
+  const { store, storage, agentId, sessionId, baseCtx } = await setup(t);
+  const id = await uploadFile({
+    store, storage, agentId, sessionId,
+    name: 'notes.txt', body: Buffer.from('just plain text, not a pdf'), mime: 'text/plain',
+  });
+  const tool = createPdfReadTool(baseCtx);
+  await assert.rejects(
+    () => tool.execute('tc-5', { attachment_id: id }),
+    (err: unknown) => err instanceof ValidationError && /does not look like a PDF/.test(err.message),
+  );
+});
+
+test('pdf_read enforces attachment visibility (cross-session, non-owner, non-uploader)', async (t) => {
+  const { store, storage, agentId, baseCtx } = await setup(t);
+  // Uploaded in a different session by a different user; current ctx is a plain
+  // user in its own session — must be denied, mirroring attachment_fetch.
+  const id = await uploadFile({
+    store, storage, agentId, sessionId: 'other-session',
+    name: 'secret.pdf', body: SAMPLE_PDF, mime: 'application/pdf', uploaderUserId: 'usr-2',
+  });
+  const tool = createPdfReadTool(baseCtx);
+  await assert.rejects(
+    () => tool.execute('tc-6', { attachment_id: id }),
+    (err: unknown) => err instanceof ValidationError && /not visible/.test(err.message),
+  );
+});
+
+test('pdf_read rejects an input larger than max_bytes', async (t) => {
+  const { store, storage, agentId, sessionId, baseCtx } = await setup(t);
+  const id = await uploadFile({
+    store, storage, agentId, sessionId,
+    name: 'sample.pdf', body: SAMPLE_PDF, mime: 'application/pdf',
+  });
+  const tool = createPdfReadTool(baseCtx);
+  await assert.rejects(
+    () => tool.execute('tc-7', { attachment_id: id, max_bytes: 10 }),
+    (err: unknown) => err instanceof ValidationError && /max_bytes/.test(err.message),
+  );
+});
+
+test('pdf_read rejects an unknown attachment_id', async (t) => {
+  const { baseCtx } = await setup(t);
+  const tool = createPdfReadTool(baseCtx);
+  await assert.rejects(
+    () => tool.execute('tc-8', { attachment_id: 'att_does_not_exist' }),
+    (err: unknown) => err instanceof ValidationError && /no such attachment/.test(err.message),
+  );
+});
+
+// ── registration in createBuiltInTools ────────────────────────────────────
+
+test('pdf_read is registered when attachment storage is configured', async (t) => {
+  const { baseCtx } = await setup(t);
+  const names = createBuiltInTools(baseCtx).map((tool) => tool.name);
+  assert.ok(names.includes('pdf_read'), 'pdf_read should be registered');
+});
+
+test('pdf_read is absent when attachment storage is not configured', async (t) => {
+  const fixture = await createSecurityFixture(t);
+  const names = createBuiltInTools({
+    security: fixture.security,
+    storeScope: { agentId: fixture.agentId },
+  }).map((tool) => tool.name);
+  assert.ok(!names.includes('pdf_read'), 'pdf_read should not be registered without attachment storage');
+});

--- a/docs/file-attachments-design.md
+++ b/docs/file-attachments-design.md
@@ -333,11 +333,20 @@ Phase 1 tools:
 - existing `file_read`, `file_list`, `file_stat`, `exec` — once a file has a
   `sandbox_path`, it is just a file
 
-Dedicated parsing tools (PDF page extraction, spreadsheet preview, archive
-listing, OCR, transcription, media probe, etc.) are out of scope for this
-proposal. They can be considered separately once the availability loop is
-reliable, and only with explicit, auditable invocation — upload itself must
-never silently extract or summarize content.
+Dedicated parsing tools (spreadsheet preview, archive listing, OCR,
+transcription, media probe, etc.) are out of scope for this proposal. They can
+be considered separately once the availability loop is reliable, and only with
+explicit, auditable invocation — upload itself must never silently extract or
+summarize content.
+
+> **Shipped since:** a dedicated `pdf_read` tool now provides explicit,
+> on-demand PDF text extraction. It reads a PDF by `attachment_id` (durable
+> store, with the same visibility rule as `attachment_fetch`) or by
+> `sandbox_path`, extracts text **in-process** via the pure-JS `unpdf` library
+> (no sandbox tooling required, backend-agnostic), supports page selection and
+> encrypted PDFs, and returns the text to the model. It is read-only and does
+> not run at upload time. Scanned/image-only PDFs (no extractable text) and
+> page-image rendering / OCR remain future work — see `docs/tools.md`.
 
 ## Security
 

--- a/docs/manual/10-files-and-workspace.md
+++ b/docs/manual/10-files-and-workspace.md
@@ -65,6 +65,7 @@ You will see these in the *tool calls* view if you expand a reply:
 - **File write** — create or overwrite a file.
 - **File search / list** — grep, glob, ls equivalents.
 - **Exec** — run a shell command in the sandbox.
+- **PDF read** — extract text from an uploaded or sandbox PDF (so "summarise this PDF" works without any setup). Born-digital PDFs only; scanned/image-only PDFs have no extractable text yet.
 
 Exec is the most powerful and the most policy-sensitive. By default, owners and users have it; guests do not. Sensitive commands can be deny-listed via policy (see [Chapter 15](15-policy-and-approval.md)).
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -13,6 +13,7 @@ OpenHermit builds toolsets per turn from available runtime capabilities and the 
 | `file_list` | List directory entries (files + subdirectories) |
 | `file_stat` | Stat a path: type, size, mtime (returns null if missing) |
 | `file_delete` | Delete a single file (no recursive) |
+| `pdf_read` | Extract text from a PDF (by `attachment_id` or `sandbox_path`); supports page selection and encrypted PDFs |
 | `web_search` | Search the web through the configured web provider |
 | `web_fetch` | Fetch and extract web page content |
 | `memory_get` | Read one memory by ID |
@@ -60,6 +61,7 @@ mcp__{serverId}__{toolName}
 |-----------|---------------------|
 | exec | `agentId`, workspace, `ExecBackendManager` |
 | file | `agentId`, workspace, `ExecBackendManager` (delegates to `FileBackend` on the exec backend) |
+| pdf | `attachmentStore` + `attachmentStorage`; `sandbox_path` reads also need `ExecBackendManager`. Text extraction runs in-process via `unpdf` (no sandbox tooling required) |
 | web | configured web provider |
 | memory | `memoryProvider` |
 | instruction | `instructionStore` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "mime-types": "^3.0.2",
         "prom-client": "^15.1.3",
         "undici": "^7.25.0",
+        "unpdf": "^1.6.2",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -151,7 +152,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0",
@@ -672,7 +673,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
       "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1459,7 +1459,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1744,8 +1743,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.9",
@@ -1788,7 +1786,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -1887,7 +1884,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1910,7 +1906,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2126,6 +2121,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3100,6 +3096,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3116,6 +3113,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3138,6 +3136,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3160,6 +3159,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3176,6 +3176,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3192,6 +3193,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3208,6 +3210,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3224,6 +3227,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3240,6 +3244,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3256,6 +3261,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3272,6 +3278,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3288,6 +3295,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3304,6 +3312,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3320,6 +3329,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3342,6 +3352,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3364,6 +3375,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3386,6 +3398,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3408,6 +3421,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3430,6 +3444,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3452,6 +3467,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3474,6 +3490,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3493,6 +3510,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -3515,6 +3533,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3534,6 +3553,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3553,6 +3573,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3886,7 +3907,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5903,7 +5923,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5914,7 +5933,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -5947,7 +5965,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6043,7 +6060,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6422,7 +6438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6930,6 +6945,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7780,7 +7796,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7945,7 +7960,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8615,7 +8629,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8882,7 +8895,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -9035,7 +9047,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -9842,7 +9853,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10434,7 +10444,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10802,6 +10811,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -10845,6 +10855,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11473,7 +11484,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11524,7 +11534,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11574,6 +11583,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unpipe": {
@@ -11647,7 +11670,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12339,7 +12361,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12428,7 +12449,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

  Adds a read-only `pdf_read` tool so agents can read PDF **content**. Until now a
  PDF dead-ended: the multimodal router (`prepareAttachmentContent`) only inlines
  `png/jpeg/gif/webp`, so `application/pdf` was downgraded to a text reference, and
  `attachment_fetch` returned opaque bytes with a note to "run a converter via Bash"
  — but the default sandbox (`ubuntu:24.04`) ships no PDF tooling. pi-ai has no
  native document content block, so the model never saw PDFs at all.

  `pdf_read` extracts text **in-process** via the pure-JS/WASM [`unpdf`] library —
  no sandbox tooling, identical across docker/e2b/daytona, zero cold-start — and
  returns it as a normal tool result. Inspired by openclaw's `/tools/pdf` (a
  read/analyze tool); its "native PDF to provider" mode doesn't map onto OpenHermit
  because pi-ai lacks a document block.

## BEFORE

<img width="1858" height="1042" alt="image" src="https://github.com/user-attachments/assets/9db97606-721b-465b-bbca-19e45689dc7f" />

## AFTER

<img width="923" height="228" alt="Screenshot from 2026-06-23 19-45-07" src="https://github.com/user-attachments/assets/73456343-fe96-444b-be52-c9441c739242" />

<img width="1847" height="1130" alt="Screenshot from 2026-06-23 19-53-40" src="https://github.com/user-attachments/assets/ef7cf468-128c-4bf1-81dd-5aa02d84e22a" />

  ## What it does

  - Input: `attachment_id` **or** `sandbox_path` (exactly one).
    - `attachment_id` resolves via the attachment store with the same visibility
      rule as `attachment_fetch` (same-session OR owner OR uploader).
    - `sandbox_path` reads through the traversal-guarded `FileBackend`.
  - `pages` selection (`"1-5"`, `"1,3,7-9"`), `password` for encrypted PDFs,
    `max_bytes` cap (default 25 MiB), and a `%PDF-` magic-byte guard.
  - Returns extracted text + `details` (pageCount, pagesExtracted, extractedChars,
    hadText, encrypted, title/producer).
  - Scanned/image-only PDFs (no extractable text) return a clear note —
    page-image rendering / OCR is deferred to a follow-up.

  ## Integration

  - New `pdf` toolset registered behind the existing
    `attachmentStore && attachmentStorage` gate in `tools.ts`; auto-wrapped by
    `withApproval`.
  - Tool-level policy only (`owner` + `user`, mirroring `file_read`) — no new
    policy resource kind, no changes to the model/multimodal pipeline.

  ## Changes

  - New: `apps/agent/src/tools/pdf.ts`, `apps/agent/test/pdf-tool.test.ts`,
    `apps/agent/test/fixtures/sample.pdf`
  - Edited: `apps/agent/src/tools.ts` (registration), `apps/agent/package.json`
    (+`unpdf`), `docs/tools.md`, `docs/file-attachments-design.md`,
    `docs/manual/10-files-and-workspace.md`

  ## Testing

  - `npm run build -w @openhermit/agent` (`tsc -b`, src) — clean.
  - `pdf-tool.test.ts`: 11/11 pass — extraction, page selection, sandbox-path,
    cross-session visibility denial, non-PDF guard, oversize, unknown id, and
    toolset registration on/off.
  - No regressions: the only failures in neighboring suites (`tools.test.ts`
    `web_fetch` / `withApproval`) are pre-existing — reproduced identically with
    these changes stashed.

  ## Notes / follow-ups

  - `details.encrypted` reflects "a password was supplied" rather than a true
    encryption probe (a PDF with an empty user password reads fine and reports
    `false`).
  - Deferred: scanned/image-only PDF page rendering → PNG image blocks (would add
    `@napi-rs/canvas` + a `supportsImageInput` plumb-through and a `mode` param).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a built-in `pdf_read` tool that extracts text from PDFs provided via `attachment_id` (uploaded) or `sandbox_path`.
  * Supports page selection, password-protected/encrypted PDFs, and `max_bytes` size limits; rejects non-PDF inputs and oversized files.
* **Documentation**
  * Updated guides to describe `pdf_read` capabilities, requirements, and current limitations (e.g., scanned PDFs).
* **Tests**
  * Added test coverage for tool behavior, validation, access control, page filtering, and size enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->