### PR TITLE
add MiniMax-M3 multimodal model to registry and picker

### DIFF
--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -73,8 +73,6 @@ export const listLocalModels = (provider: string): Model<any>[] =>
 const tryRegistry = (provider: string, modelId: string): Model<any> | undefined => {
   let registry: Model<any> | undefined;
   try {
-    // getModel returns undefined (never throws) for unknown models, so coalesce
-    // below; the catch only guards pi-ai versions that throw.
     registry = getModel(provider as never, modelId as never) as Model<any>;
   } catch {
     registry = undefined;

--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -61,27 +61,20 @@ const LOCAL_MODELS: Record<string, Model<any>> = {
   'minimax-cn/MiniMax-M3': minimaxM3('minimax-cn', 'https://api.minimaxi.com/anthropic'),
 };
 
-// Local Model entries for a provider for surfacing in the picker catalog
 export const listLocalModels = (provider: string): Model<any>[] =>
   Object.values(LOCAL_MODELS).filter((m) => m.provider === provider);
 
 /**
- * Try to fetch a Model entry from pi-ai's built-in registry, falling back to
- * our local overrides for models pi-ai does not carry yet. Returns undefined
- * when neither knows the (provider, model id) pair.
- *
- * Registry first: pi-ai's entries carry authoritative `reasoning`, `compat`,
- * and other capability flags, so we prefer them over guesses (thinking-only
- * models like deepseek-v4-pro, o1 stay flagged correctly even with an explicit
- * base_url). LOCAL_MODELS only fills gaps; once pi-ai registers a model its
- * maintained metadata takes over and the local override can be dropped.
+ * Resolve a Model from pi-ai's registry, falling back to LOCAL_MODELS for
+ * models pi-ai doesn't carry yet. Registry wins when present so its
+ * authoritative capability flags aren't overridden; drop the local entry once
+ * pi-ai registers the model.
  */
 const tryRegistry = (provider: string, modelId: string): Model<any> | undefined => {
   let registry: Model<any> | undefined;
   try {
-    // getModel returns undefined (never throws) for an unknown provider/model,
-    // so we coalesce below rather than rely on catch. The catch is a guard for
-    // pi-ai versions that throw instead.
+    // getModel returns undefined (never throws) for unknown models, so coalesce
+    // below; the catch only guards pi-ai versions that throw.
     registry = getModel(provider as never, modelId as never) as Model<any>;
   } catch {
     registry = undefined;

--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -43,9 +43,32 @@ const OPENAI_COMPATIBLE_PROVIDERS: Record<string, { api: string; baseUrl: string
   openrouter: { api: 'openai-completions', baseUrl: 'https://openrouter.ai/api/v1' },
 };
 
+const minimaxM3 = (provider: string, baseUrl: string): Model<any> => ({
+  id: 'MiniMax-M3',
+  name: 'MiniMax-M3',
+  api: 'anthropic-messages',
+  provider,
+  baseUrl,
+  reasoning: true,
+  input: ['text', 'image'],
+  cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0.375 },
+  contextWindow: 1000000,
+  maxTokens: 131072,
+} as Model<any>);
+
+const LOCAL_MODELS: Record<string, Model<any>> = {
+  'minimax/MiniMax-M3': minimaxM3('minimax', 'https://api.minimax.io/anthropic'),
+  'minimax-cn/MiniMax-M3': minimaxM3('minimax-cn', 'https://api.minimaxi.com/anthropic'),
+};
+
+// Local Model entries for a provider for surfacing in the picker catalog
+export const listLocalModels = (provider: string): Model<any>[] =>
+  Object.values(LOCAL_MODELS).filter((m) => m.provider === provider);
+
 /**
- * Try to fetch a Model entry from pi-ai's built-in registry. Returns
- * undefined when the (provider, model id) pair is not registered.
+ * Try to fetch a Model entry from pi-ai's built-in registry (or our local
+ * overrides). Returns undefined when the (provider, model id) pair is not
+ * registered.
  *
  * pi-ai's registry carries authoritative `reasoning`, `compat`, and
  * other capability flags. We always prefer registry values over guesses
@@ -53,6 +76,8 @@ const OPENAI_COMPATIBLE_PROVIDERS: Record<string, { api: string; baseUrl: string
  * correctly even when the agent config provides an explicit base_url.
  */
 const tryRegistry = (provider: string, modelId: string): Model<any> | undefined => {
+  const local = LOCAL_MODELS[`${provider}/${modelId}`];
+  if (local) return local;
   try {
     return getModel(provider as never, modelId as never) as Model<any>;
   } catch {

--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -66,23 +66,27 @@ export const listLocalModels = (provider: string): Model<any>[] =>
   Object.values(LOCAL_MODELS).filter((m) => m.provider === provider);
 
 /**
- * Try to fetch a Model entry from pi-ai's built-in registry (or our local
- * overrides). Returns undefined when the (provider, model id) pair is not
- * registered.
+ * Try to fetch a Model entry from pi-ai's built-in registry, falling back to
+ * our local overrides for models pi-ai does not carry yet. Returns undefined
+ * when neither knows the (provider, model id) pair.
  *
- * pi-ai's registry carries authoritative `reasoning`, `compat`, and
- * other capability flags. We always prefer registry values over guesses
- * so that thinking-only models (deepseek-v4-pro, o1, etc.) are flagged
- * correctly even when the agent config provides an explicit base_url.
+ * Registry first: pi-ai's entries carry authoritative `reasoning`, `compat`,
+ * and other capability flags, so we prefer them over guesses (thinking-only
+ * models like deepseek-v4-pro, o1 stay flagged correctly even with an explicit
+ * base_url). LOCAL_MODELS only fills gaps; once pi-ai registers a model its
+ * maintained metadata takes over and the local override can be dropped.
  */
 const tryRegistry = (provider: string, modelId: string): Model<any> | undefined => {
-  const local = LOCAL_MODELS[`${provider}/${modelId}`];
-  if (local) return local;
+  let registry: Model<any> | undefined;
   try {
-    return getModel(provider as never, modelId as never) as Model<any>;
+    // getModel returns undefined (never throws) for an unknown provider/model,
+    // so we coalesce below rather than rely on catch. The catch is a guard for
+    // pi-ai versions that throw instead.
+    registry = getModel(provider as never, modelId as never) as Model<any>;
   } catch {
-    return undefined;
+    registry = undefined;
   }
+  return registry ?? LOCAL_MODELS[`${provider}/${modelId}`];
 };
 
 export const resolveModel = (config: AgentConfig): Model<any> => {

--- a/apps/agent/src/model-catalog.ts
+++ b/apps/agent/src/model-catalog.ts
@@ -1,5 +1,7 @@
 import { getProviders, getModels } from '@mariozechner/pi-ai';
 
+import { listLocalModels } from './agent-runner/model-utils.js';
+
 export interface ProviderCatalogEntry {
   provider: string;
   models: { id: string; reasoning: boolean }[];
@@ -17,11 +19,17 @@ export interface ProviderCatalogEntry {
  */
 export const listProviderCatalog = (): ProviderCatalogEntry[] => {
   const providers = getProviders();
-  return providers.map((provider) => ({
-    provider,
-    models: getModels(provider).map((m) => ({
+  return providers.map((provider) => {
+    const models = getModels(provider).map((m) => ({
       id: m.id,
       reasoning: Boolean((m as { reasoning?: boolean }).reasoning),
-    })),
-  }));
+    }));
+    // Append local-only models the pi-ai registry lacks.
+    for (const lm of listLocalModels(provider)) {
+      if (!models.some((m) => m.id === lm.id)) {
+        models.push({ id: lm.id, reasoning: Boolean(lm.reasoning) });
+      }
+    }
+    return { provider, models };
+  });
 };

--- a/apps/agent/test/minimax-m3.test.ts
+++ b/apps/agent/test/minimax-m3.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { AgentConfig } from '../src/core/index.js';
+import { resolveModel } from '../src/agent-runner/model-utils.js';
+import { listProviderCatalog } from '../src/model-catalog.js';
+
+const modelConfig = (provider: string, model: string): AgentConfig =>
+  ({ model: { provider, model, max_tokens: 131072 } } as unknown as AgentConfig);
+
+test('MiniMax-M3 resolves as a multimodal (image-capable) model', () => {
+  const m = resolveModel(modelConfig('minimax', 'MiniMax-M3'));
+  assert.equal(m.id, 'MiniMax-M3');
+  assert.equal(m.api, 'anthropic-messages');
+  assert.equal(m.baseUrl, 'https://api.minimax.io/anthropic');
+  assert.equal(m.contextWindow, 1000000, 'M3 context window is 1M per MiniMax docs');
+  assert.ok(
+    Array.isArray(m.input) && (m.input as string[]).includes('image'),
+    'M3 must accept image input or the agent downgrades attachments to text',
+  );
+});
+
+test('MiniMax-M3 on the CN provider uses the minimaxi.com endpoint', () => {
+  const m = resolveModel(modelConfig('minimax-cn', 'MiniMax-M3'));
+  assert.equal(m.baseUrl, 'https://api.minimaxi.com/anthropic');
+  assert.ok((m.input as string[]).includes('image'));
+});
+
+test('MiniMax-M3 appears in the picker catalog under minimax with the reasoning flag', () => {
+  const minimax = listProviderCatalog().find((p) => p.provider === 'minimax');
+  assert.ok(minimax, 'minimax provider present in catalog');
+  const m3 = minimax!.models.find((m) => m.id === 'MiniMax-M3');
+  assert.ok(m3, 'MiniMax-M3 listed in the catalog');
+  assert.equal(m3!.reasoning, true);
+});
+
+test('MiniMax-M3 appears in the picker catalog under minimax-cn too', () => {
+  const minimaxCn = listProviderCatalog().find((p) => p.provider === 'minimax-cn');
+  assert.ok(minimaxCn, 'minimax-cn provider present in catalog');
+  const m3 = minimaxCn!.models.find((m) => m.id === 'MiniMax-M3');
+  assert.ok(m3, 'MiniMax-M3 listed under minimax-cn');
+  assert.equal(m3!.reasoning, true);
+});
+
+test('MiniMax-M2.7 is left untouched and stays text-only (removed only after migration)', () => {
+  const m = resolveModel(modelConfig('minimax', 'MiniMax-M2.7'));
+  assert.equal(m.id, 'MiniMax-M2.7');
+  assert.ok(!(m.input as string[]).includes('image'), 'M2.7 is text-only');
+});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Expanded the model catalog to include locally available MiniMax M3 models, surfacing them in the appropriate provider listings.
* **Bug Fixes**
  * Improved model resolution to prefer locally available MiniMax matches, falling back to the standard registry only when no local model exists.
  * Updated provider catalog metadata so reasoning capability and model entries reflect the added local models.
* **Tests**
  * Added unit tests covering MiniMax M3 resolution details (base URL, context window, and image/multimodal input) and verifying MiniMax M2.7 remains text-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->