### PR TITLE
feat(channels): resolve session_send recipient per channel

### DIFF
--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -242,8 +242,12 @@ export const resolveOutbound = (
   const adapter = channelOutbound.get(platform);
   if (!adapter) return undefined;
 
-  // Resolve recipient from session metadata.
-  // Each channel has its own metadata convention for the target chat.
+  // Prefer the channel's own recipient resolution — each channel knows its
+  // metadata convention (and this works for custom/external channels too).
+  const resolved = adapter.resolveRecipient?.(session);
+  if (resolved != null && resolved !== '') return { adapter, to: resolved };
+
+  // Back-compat fallback for adapters that predate resolveRecipient.
   if (platform === 'telegram') {
     const chatId = session.metadata?.telegram_chat_id;
     if (chatId !== undefined) return { adapter, to: String(chatId) };

--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -40,7 +40,11 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
   policy: { defaultGrants: [{ type: 'any' }] },
   name: 'session_list',
   label: 'List Sessions',
-  description: 'List sessions with their descriptions, last activity, message counts, and source. Optionally filter by channel.',
+  description:
+    'List sessions with their descriptions, last activity, message counts, and source. '
+    + 'Each entry includes `canSend` — whether session_send can deliver to it (its channel '
+    + 'supports outbound messaging and a recipient is resolvable); do not attempt session_send '
+    + 'when canSend is false. Optionally filter by channel.',
   parameters: SessionListParams,
   execute: async (_toolCallId, args: SessionListArgs) => {
     if (!context.sessionStore || !context.storeScope) {
@@ -85,6 +89,11 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
       lastActivity: s.lastActivityAt,
       createdAt: s.createdAt,
       lastMessagePreview: s.lastMessagePreview,
+      // Whether session_send can deliver to this session (its channel exposes an
+      // outbound adapter AND a recipient is resolvable from metadata).
+      canSend: context.channelOutbound
+        ? resolveOutbound(s, context.channelOutbound) !== undefined
+        : false,
     }));
 
     return {

--- a/apps/agent/test/resolve-outbound.test.ts
+++ b/apps/agent/test/resolve-outbound.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { ChannelOutbound, OutboundSession } from '@openhermit/protocol';
+import { resolveOutbound } from '../src/tools/session.js';
+
+/** Fake adapter that resolves the recipient from a given metadata key. */
+const adapterFor = (channel: string, key?: string): ChannelOutbound => ({
+  channel,
+  send: async () => ({ success: true }),
+  ...(key
+    ? {
+        resolveRecipient(session: OutboundSession): string | undefined {
+          const v = session.metadata?.[key];
+          return typeof v === 'string' && v ? v : undefined;
+        },
+      }
+    : {}),
+});
+
+const map = (...adapters: ChannelOutbound[]): Map<string, ChannelOutbound> =>
+  new Map(adapters.map((a) => [a.channel, a]));
+
+test('resolveOutbound uses the channel resolveRecipient hook', () => {
+  const out = resolveOutbound(
+    { source: { platform: 'wechat' }, metadata: { wechat_peer_id: 'wxid_abc' } },
+    map(adapterFor('wechat', 'wechat_peer_id')),
+  );
+  assert.ok(out);
+  assert.equal(out!.to, 'wxid_abc');
+});
+
+test('resolveOutbound returns undefined when the hook finds no recipient', () => {
+  const out = resolveOutbound(
+    { source: { platform: 'wechat' }, metadata: {} },
+    map(adapterFor('wechat', 'wechat_peer_id')),
+  );
+  assert.equal(out, undefined);
+});
+
+test('resolveOutbound returns undefined when no adapter is registered for the platform', () => {
+  const out = resolveOutbound(
+    { source: { platform: 'amiko' }, metadata: { x: 'y' } },
+    map(adapterFor('wechat', 'wechat_peer_id')),
+  );
+  assert.equal(out, undefined);
+});
+
+test('resolveOutbound falls back to telegram_chat_id for a hook-less adapter', () => {
+  const out = resolveOutbound(
+    { source: { platform: 'telegram' }, metadata: { telegram_chat_id: '12345' } },
+    map(adapterFor('telegram')), // no resolveRecipient
+  );
+  assert.ok(out);
+  assert.equal(out!.to, '12345');
+});
+
+test('resolveOutbound returns undefined for a session with no platform', () => {
+  assert.equal(resolveOutbound({ source: {} }, map(adapterFor('telegram'))), undefined);
+});

--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
-import type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
+import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
 import type { DiscordApi, DiscordMessageEvent } from './discord-api.js';
@@ -60,6 +60,12 @@ export class DiscordBridge implements ChannelOutbound {
       this.log(`failed to send message to ${params.to}: ${message}`);
       return { success: false, error: message };
     }
+  }
+
+  /** Recipient for `session_send`: the Discord channel id from session metadata. */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.discord_channel_id;
+    return typeof v === 'string' && v ? v : undefined;
   }
 
   private static generateSessionId(): string {

--- a/apps/channels/signal/package.json
+++ b/apps/channels/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-signal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenHermit channel plugin for Signal via signal-cli-rest-api (json-rpc receive WS + QR-link setup wizard) with text, media, and voice transcription.",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -5,6 +5,7 @@ import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
+  OutboundSession,
 } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -125,6 +126,16 @@ export class SignalBridge implements ChannelOutbound {
       this.log(`failed to send to ${redactTarget(params.to)}: ${message}`);
       return { success: false, error: message };
     }
+  }
+
+  /**
+   * Recipient for `session_send`: the Signal group id, or the DM source
+   * (uuid:<uuid> or phone number) from session metadata.
+   */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const m = session.metadata ?? {};
+    const pick = m.signal_group_id ?? m.signal_source;
+    return typeof pick === 'string' && pick ? pick : undefined;
   }
 
   private async sendChunkToTarget(

--- a/apps/channels/slack/src/bridge.ts
+++ b/apps/channels/slack/src/bridge.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
-import type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
+import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
 import type { SlackApi, SlackMessageEvent } from './slack-api.js';
@@ -56,6 +56,12 @@ export class SlackBridge implements ChannelOutbound {
       this.log(`failed to send message to ${params.to}: ${message}`);
       return { success: false, error: message };
     }
+  }
+
+  /** Recipient for `session_send`: the Slack channel id from session metadata. */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.slack_channel_id;
+    return typeof v === 'string' && v ? v : undefined;
   }
 
   private static generateSessionId(): string {

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
-import type { ChannelMessageAction, ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
+import type { ChannelMessageAction, ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
 import type { TelegramApi, TelegramCallbackQuery, TelegramMessage, TelegramMessageEntity, TelegramUser } from './telegram-api.js';
@@ -195,6 +195,12 @@ export class TelegramBridge implements ChannelOutbound {
       this.log(`failed to send message to chat ${chatId}: ${message}`);
       return { success: false, error: message };
     }
+  }
+
+  /** Recipient for `session_send`: the Telegram chat id from session metadata. */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.telegram_chat_id;
+    return v != null && v !== '' ? String(v) : undefined;
   }
 
   private buildReplyMarkup(actions?: ChannelMessageAction[]): unknown | undefined {

--- a/apps/channels/wechat/package.json
+++ b/apps/channels/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-wechat",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "OpenHermit channel plugin for personal WeChat (Weixin) via Tencent iLink. Text, full media in both directions: inbound images/voice/file/video and outbound images/video/files (outbound voice gated; iLink drops it).",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -13,6 +13,7 @@ import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
+  OutboundSession,
 } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -176,6 +177,16 @@ export class WechatBridge implements ChannelOutbound {
     // v0 ignores `actions` — iLink has no inline-button equivalent we use yet.
     void params.actions;
     return this.sendText(params.to, params.text);
+  }
+
+  /**
+   * Resolve the `to` for `session_send`: a group id (sent as `to_user_id`), or
+   * the DM peer / sender id. Enables proactive sends to WeChat sessions.
+   */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const m = session.metadata ?? {};
+    const pick = m.wechat_group_id ?? m.wechat_peer_id ?? m.wechat_from_user_id;
+    return typeof pick === 'string' && pick ? pick : undefined;
   }
 
   private async sendText(

--- a/apps/channels/whatsapp/package.json
+++ b/apps/channels/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhermit/channel-whatsapp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "OpenHermit channel plugin for WhatsApp Web via Baileys with text, media, and voice-note support.",
   "license": "MIT",
   "type": "module",

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -3,6 +3,7 @@ import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
+  OutboundSession,
 } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -120,6 +121,12 @@ export class WhatsAppBridge implements ChannelOutbound {
       this.log(`failed to send WhatsApp message: ${message}`);
       return { success: false, error: message };
     }
+  }
+
+  /** Recipient for `session_send`: the WhatsApp chat JID from session metadata. */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.whatsapp_chat_jid;
+    return typeof v === 'string' && v ? v : undefined;
   }
 
   async handleIncoming(event: WhatsAppIncomingMessage): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
     },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0",
@@ -156,7 +156,7 @@
     },
     "apps/channels/wechat": {
       "name": "@openhermit/channel-wechat",
-      "version": "0.4.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.6.0",
@@ -182,7 +182,7 @@
     },
     "apps/channels/whatsapp": {
       "name": "@openhermit/channel-whatsapp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@openhermit/sdk": "^0.7.0",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -333,6 +333,16 @@ export interface ChannelMessageAction {
 }
 
 /**
+ * Minimal shape of a session that {@link ChannelOutbound.resolveRecipient}
+ * needs to derive an outbound recipient. Each channel reads its own metadata
+ * convention (e.g. `telegram_chat_id`, `wechat_peer_id`).
+ */
+export interface OutboundSession {
+  source: { platform?: string };
+  metadata?: Record<string, unknown>;
+}
+
+/**
  * Interface for channel adapters that support outbound (proactive) messaging.
  * Implementations send the message via the channel API. The caller (e.g. the
  * `session_send` tool) is responsible for recording the delivery as an
@@ -346,6 +356,14 @@ export interface ChannelOutbound {
     text: string;
     actions?: ChannelMessageAction[];
   }): Promise<ChannelOutboundResult>;
+  /**
+   * Derive the outbound recipient (the `to` for {@link send}) for a session
+   * this channel created, from its session metadata. Returns `undefined` when
+   * the session has no resolvable recipient. Implementing this is what lets
+   * `session_send` target this channel — without it, the tool reports the
+   * session "does not support outbound messaging".
+   */
+  resolveRecipient?(session: OutboundSession): string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Problem
`session_send` only worked for **Telegram**. `resolveOutbound` (`apps/agent/src/tools/session.ts`) hardcoded `metadata.telegram_chat_id` and returned `undefined` for every other platform — so sends to **amiko / wechat / signal / discord / slack / whatsapp** sessions failed with *"Session … does not support outbound messaging"*, even when an outbound adapter was registered. (This is the Amiko error the user hit.)

Root cause: `ChannelOutbound` had no way to derive the recipient (`to`) from a session, so the tool could only guess, and it only knew Telegram's convention.

## Fix
Add an optional **`resolveRecipient(session)`** hook to the `ChannelOutbound` interface (+ an `OutboundSession` type). `resolveOutbound` now calls `adapter.resolveRecipient?.(session)` first, keeping the `telegram_chat_id` metadata path as a back-compat fallback for hook-less adapters.

Each channel implements it against its own metadata convention:

| channel | recipient |
|---|---|
| telegram | `telegram_chat_id` |
| discord | `discord_channel_id` |
| slack | `slack_channel_id` |
| signal | `signal_group_id ?? signal_source` |
| whatsapp | `whatsapp_chat_jid` |
| wechat | `wechat_group_id ?? wechat_peer_id ?? wechat_from_user_id` |

**Custom/external channels (e.g. amiko) enable `session_send` by implementing the same hook** — core no longer needs to know their metadata layout. (Amiko's own implementation lands separately in the amiko repo.)

## Tests
New `resolve-outbound.test.ts` (5 cases: hook resolution, no-recipient, no-adapter, telegram fallback, no-platform) — all pass. All 6 channels typecheck; wechat suite green (28). Agent src builds. (The agent test suite has 71 **pre-existing** typecheck errors unrelated to this change — verified identical on clean `main`.)

Bumps published channels: signal 0.3.0, whatsapp 0.4.0, wechat 0.7.0. Protocol change is an additive optional member (no version bump / pin cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved outbound message routing with per-session recipient resolution across Slack, Telegram, Discord, Signal, WhatsApp, and WeChat.
  * Added recipient-capability reporting (`canSend`) so sessions that can’t be targeted are identified earlier.
* **Bug Fixes**
  * Outbound sending now falls back more reliably when recipient metadata is missing or incomplete.
* **Tests**
  * Added coverage for outbound recipient resolution and adapter selection behavior.
* **Chores**
  * Updated channel package versions for upcoming releases (Signal, WeChat, WhatsApp).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->