### PR TITLE
fix(store): scale fleetStats — derive session counts from sessions table (#208)

### DIFF
--- a/packages/store/drizzle/0034_fleet_stats_error_index.sql
+++ b/packages/store/drizzle/0034_fleet_stats_error_index.sql
@@ -1,0 +1,10 @@
+-- Fleet dashboard fleetStats() at scale (issue #208). The errors24h metric
+-- filters session_events by (agent_id IN (...), event_type = 'error', ts > since);
+-- no existing index matches that predicate, so it scans per agent. This index
+-- serves it directly.
+--
+-- IF NOT EXISTS makes it idempotent: on a very large session_events table an
+-- operator may prefer to build it manually with CREATE INDEX CONCURRENTLY
+-- (which cannot run inside a migration transaction) before deploying — this
+-- statement then becomes a no-op.
+CREATE INDEX IF NOT EXISTS "idx_session_events_agent_type_ts" ON "session_events" USING btree ("agent_id","event_type","ts");

--- a/packages/store/drizzle/meta/_journal.json
+++ b/packages/store/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1780100000000,
       "tag": "0033_channel_credentials",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1780200000000,
+      "tag": "0034_fleet_stats_error_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/store/src/impl/agent-store.ts
+++ b/packages/store/src/impl/agent-store.ts
@@ -167,18 +167,22 @@ export class DbAgentStore implements AgentStore {
     }
     if (agentIds.length === 0) return result;
 
-    // Sessions touched in the last 24h (distinct session_id with any event).
+    // Sessions active in the last 24h. Derived from the `sessions` table
+    // (`last_activity_at > since`) rather than `count(distinct session_id)` over
+    // the high-volume `session_events` table — the latter times out at fleet
+    // scale (see issue #208). Backed by idx_sessions_agent (agent_id,
+    // last_activity_at).
     const sessionRows = await this.db
       .select({
-        agentId: sessionEvents.agentId,
-        count: sql<number>`count(distinct ${sessionEvents.sessionId})::int`,
+        agentId: sessions.agentId,
+        count: sql<number>`count(*)::int`,
       })
-      .from(sessionEvents)
+      .from(sessions)
       .where(and(
-        inArray(sessionEvents.agentId, agentIds),
-        gt(sessionEvents.ts, since),
+        inArray(sessions.agentId, agentIds),
+        gt(sessions.lastActivityAt, since),
       ))
-      .groupBy(sessionEvents.agentId);
+      .groupBy(sessions.agentId);
     for (const r of sessionRows) {
       const entry = result.get(r.agentId);
       if (entry) entry.sessions24h = r.count;
@@ -202,15 +206,17 @@ export class DbAgentStore implements AgentStore {
       if (entry) entry.errors24h = r.count;
     }
 
-    // Last activity timestamp (max ts across all events).
+    // Last activity timestamp (max last_activity_at across the agent's
+    // sessions). From the `sessions` table (idx_sessions_agent) instead of
+    // max(ts) over all session_events, which scanned every event per agent.
     const lastRows = await this.db
       .select({
-        agentId: sessionEvents.agentId,
-        lastTs: sql<string>`max(${sessionEvents.ts})`,
+        agentId: sessions.agentId,
+        lastTs: sql<string>`max(${sessions.lastActivityAt})`,
       })
-      .from(sessionEvents)
-      .where(inArray(sessionEvents.agentId, agentIds))
-      .groupBy(sessionEvents.agentId);
+      .from(sessions)
+      .where(inArray(sessions.agentId, agentIds))
+      .groupBy(sessions.agentId);
     for (const r of lastRows) {
       const entry = result.get(r.agentId);
       if (entry && r.lastTs) entry.lastActivity = r.lastTs;

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -79,6 +79,8 @@ export const sessionEvents = pgTable('session_events', {
 }, (table) => [
   index('idx_session_events_agent_session').on(table.agentId, table.sessionId, table.ts),
   index('idx_session_events_type').on(table.agentId, table.sessionId, table.eventType, table.id),
+  // Serves fleetStats errors24h: agent_id IN (...) AND event_type = 'error' AND ts > since (issue #208).
+  index('idx_session_events_agent_type_ts').on(table.agentId, table.eventType, table.ts),
 ]);
 
 /**


### PR DESCRIPTION
Fixes #208 — the `/admin/fleet` dashboard 500s at scale.

## Root cause
`AgentStore.fleetStats()` ran `count(distinct session_id)` over the high-volume `session_events` table for the **whole fleet** in one query, exceeding Postgres `statement_timeout` (observed at ~1489 agents on Supabase). The `ts` range predicate can't be served by the existing `(agent_id, session_id, ts)` index, so it scanned + deduped per agent.

## Fix (the issue's "preferred" approach)
- **`sessions24h`** → derived from the **`sessions`** table (`last_activity_at > since`) instead of `count(distinct session_id)` over `session_events`. Equivalent ("distinct sessions with an event after `since`" == "sessions with `last_activity_at > since`") and served by the existing `idx_sessions_agent (agent_id, last_activity_at)`.
- **`lastActivity`** → `max(last_activity_at)` from `sessions` instead of `max(ts)` over **all** `session_events` (that query had no `ts` filter → full per-agent scan).
- **`errors24h`** → still over `session_events`, now backed by a matching index **`idx_session_events_agent_type_ts (agent_id, event_type, ts)`** (migration `0034`, registered in `_journal.json`).

Net: the two worst `session_events` scans are gone from the dashboard path; the remaining `errors24h` scan is index-served.

The migration uses `CREATE INDEX IF NOT EXISTS` (idempotent) — on a very large `session_events` table an operator can pre-build it with `CREATE INDEX CONCURRENTLY` (can't run inside a migration txn), making the migration a no-op.

## Not included (follow-up)
**Paginating the fleet endpoint** (`app.ts:1630` passes every agent id in one `IN (...)` — currently the whole fleet). Worthwhile for O(fleet-size) growth, but the query changes above resolve the timeout; leaving pagination as a separate change to keep this focused.

## Verification
Result shape unchanged (`sessions24h/errors24h/lastActivity/skillsCount/mcpCount`), so consumers are unaffected. Store builds + typechecks. (No fleetStats unit tests exist — these are DB-level queries needing a live Postgres; change is SQL-level with the equivalence documented above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fleet error dashboard query performance with a new database index, helping error-related metrics load faster.

* **Bug Fixes**
  * Updated fleet activity calculations to use session activity data for more accurate 24-hour counts and last-seen timestamps.
  * Added support for faster lookups when filtering error events by agent and time range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->