### PR TITLE
feat(gateway): outbound delivery for API-created external channels (#210)

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -9,6 +9,7 @@
     "build:ui": "vite build ui",
     "dev:ui": "vite dev ui",
     "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
+    "test": "node --import tsx --test test/*.test.ts",
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {

--- a/apps/gateway/src/channel-pool.ts
+++ b/apps/gateway/src/channel-pool.ts
@@ -32,6 +32,7 @@ import type {
 } from '@openhermit/store';
 
 import type { ChannelRegistry } from './auth.js';
+import { buildExternalOutboundHandle } from './external-outbound.js';
 
 export interface ChannelPoolOptions {
   agentStore: AgentStore;
@@ -123,6 +124,14 @@ export class ChannelPool {
         });
       }
 
+      // External (API-created) channels have no plugin/bridge, but may opt
+      // into outbound via config (outboundUrl + recipientMetadataKey). Register
+      // a synthesized HTTP outbound so session_send / canSend reach them (#210).
+      const enabledExternals = channels.filter((c) => c.kind === 'external' && c.enabled);
+      for (const row of enabledExternals) {
+        this.registerExternalOutbound(agentId, row);
+      }
+
       const enabledBuiltins = channels.filter((c) => c.kind === 'builtin' && c.enabled);
       if (enabledBuiltins.length === 0) continue;
 
@@ -134,6 +143,28 @@ export class ChannelPool {
         );
       }
     }
+  }
+
+  /**
+   * Register a synthesized outbound for an external channel row that opted in
+   * via config. No-op if the row has no outbound-callback config. The handle is
+   * tracked in `this.handles` so agent hydration picks it up like a plugin's.
+   */
+  private registerExternalOutbound(
+    agentId: string,
+    row: { channelType: string; token: string; config?: Record<string, unknown> },
+  ): void {
+    const handle = buildExternalOutboundHandle(row, (msg) => this.opts.log(`[${agentId}] ${msg}`));
+    if (!handle) return;
+    const handles = this.handles.get(agentId) ?? [];
+    // Replace any existing handle for this channel name.
+    const idx = handles.findIndex((h) => h.name === handle.name);
+    if (idx !== -1) handles.splice(idx, 1);
+    handles.push(handle);
+    this.handles.set(agentId, handles);
+    const runner = this.opts.getRunner(agentId);
+    if (runner && handle.outbound) runner.registerChannelOutbound(handle.outbound);
+    this.opts.log(`[${agentId}] registered external outbound: ${handle.name}`);
   }
 
   /**

--- a/apps/gateway/src/external-outbound.ts
+++ b/apps/gateway/src/external-outbound.ts
@@ -1,0 +1,108 @@
+/**
+ * Synthesized outbound adapter for API-created external channels.
+ *
+ * Plugin channels get a `ChannelOutbound` from their `start()` handle, which is
+ * how `session_send`/`canSend` reach them (see resolveOutbound + issue #210).
+ * Channels created purely via `POST /api/agents/:id/channels` have no plugin, so
+ * they had no outbound path at all. This lets such a channel opt into outbound
+ * by putting two fields in its `config`:
+ *
+ *   - `outboundUrl`           — gateway POSTs `{ sessionId, to, text }` here.
+ *   - `recipientMetadataKey`  — which `session.metadata` field holds the `to`.
+ *
+ * The gateway then registers the resulting `ChannelOutbound` into the runner's
+ * outbound map, exactly like a plugin's, so `session_send` works and
+ * `session_list.canSend` reports true.
+ */
+import type { ChannelHandle, ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
+
+/** Timeout for the outbound delivery POST. */
+const DELIVERY_TIMEOUT_MS = 15_000;
+
+interface ExternalOutboundConfig {
+  outboundUrl: string;
+  recipientMetadataKey: string;
+}
+
+/** Extract + validate the outbound-callback config from a channel row's config. */
+export const parseExternalOutboundConfig = (
+  config: Record<string, unknown> | undefined,
+): ExternalOutboundConfig | undefined => {
+  const url = config?.outboundUrl;
+  const key = config?.recipientMetadataKey;
+  if (typeof url === 'string' && url.trim() && typeof key === 'string' && key.trim()) {
+    return { outboundUrl: url.trim(), recipientMetadataKey: key.trim() };
+  }
+  return undefined;
+};
+
+/**
+ * A `ChannelOutbound` that delivers via an authenticated HTTP POST to the
+ * integrator's configured endpoint and resolves the recipient from a
+ * configured session-metadata key.
+ */
+export class HttpChannelOutbound implements ChannelOutbound {
+  constructor(
+    readonly channel: string,
+    private readonly cfg: ExternalOutboundConfig,
+    private readonly token: string,
+    private readonly log: (msg: string) => void = () => {},
+  ) {}
+
+  async send(params: {
+    sessionId: string;
+    to: string;
+    text: string;
+  }): Promise<ChannelOutboundResult> {
+    try {
+      const res = await fetch(this.cfg.outboundUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify({ sessionId: params.sessionId, to: params.to, text: params.text }),
+        signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return { success: false, error: `delivery ${res.status}: ${body.slice(0, 200)}` };
+      }
+      // Integrator may return a message id; otherwise treat 2xx as delivered.
+      const messageId = await res
+        .json()
+        .then((j) => (j && typeof (j as { messageId?: unknown }).messageId === 'string'
+          ? (j as { messageId: string }).messageId
+          : undefined))
+        .catch(() => undefined);
+      return messageId ? { success: true, messageId } : { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log(`external outbound delivery failed for ${this.channel}: ${message}`);
+      return { success: false, error: message };
+    }
+  }
+
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.[this.cfg.recipientMetadataKey];
+    return typeof v === 'string' && v ? v : undefined;
+  }
+}
+
+/**
+ * Build a synthetic {@link ChannelHandle} for an external channel row that has
+ * an outbound-callback config, or `undefined` if it doesn't opt in. The handle
+ * carries only `outbound` (there is no bridge to stop).
+ */
+export const buildExternalOutboundHandle = (
+  row: { channelType: string; token: string; config?: Record<string, unknown> },
+  log: (msg: string) => void = () => {},
+): ChannelHandle | undefined => {
+  const cfg = parseExternalOutboundConfig(row.config);
+  if (!cfg) return undefined;
+  return {
+    name: row.channelType,
+    outbound: new HttpChannelOutbound(row.channelType, cfg, row.token, log),
+    stop: async () => {},
+  };
+};

--- a/apps/gateway/test/external-outbound.test.ts
+++ b/apps/gateway/test/external-outbound.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  HttpChannelOutbound,
+  buildExternalOutboundHandle,
+  parseExternalOutboundConfig,
+} from '../src/external-outbound.js';
+
+test('parseExternalOutboundConfig requires both outboundUrl and recipientMetadataKey', () => {
+  assert.deepEqual(
+    parseExternalOutboundConfig({ outboundUrl: 'https://x/deliver', recipientMetadataKey: 'amiko_peer' }),
+    { outboundUrl: 'https://x/deliver', recipientMetadataKey: 'amiko_peer' },
+  );
+  assert.equal(parseExternalOutboundConfig({ outboundUrl: 'https://x/deliver' }), undefined);
+  assert.equal(parseExternalOutboundConfig({ recipientMetadataKey: 'k' }), undefined);
+  assert.equal(parseExternalOutboundConfig({}), undefined);
+  assert.equal(parseExternalOutboundConfig(undefined), undefined);
+});
+
+test('buildExternalOutboundHandle returns a handle only when opted in', () => {
+  const ok = buildExternalOutboundHandle({
+    channelType: 'amiko',
+    token: 'tok',
+    config: { outboundUrl: 'https://x/deliver', recipientMetadataKey: 'amiko_peer' },
+  });
+  assert.ok(ok);
+  assert.equal(ok!.name, 'amiko');
+  assert.ok(ok!.outbound);
+
+  assert.equal(buildExternalOutboundHandle({ channelType: 'amiko', token: 't', config: {} }), undefined);
+});
+
+test('HttpChannelOutbound.resolveRecipient reads the configured metadata key', () => {
+  const ob = new HttpChannelOutbound('amiko', {
+    outboundUrl: 'https://x/deliver',
+    recipientMetadataKey: 'amiko_peer',
+  }, 'tok');
+  assert.equal(
+    ob.resolveRecipient({ source: { platform: 'amiko' }, metadata: { amiko_peer: 'u_123' } }),
+    'u_123',
+  );
+  assert.equal(ob.resolveRecipient({ source: { platform: 'amiko' }, metadata: {} }), undefined);
+  assert.equal(ob.resolveRecipient({ source: { platform: 'amiko' } }), undefined);
+});
+
+test('HttpChannelOutbound.send POSTs {sessionId,to,text} with the channel token', async () => {
+  let captured: { url?: string; auth?: string; body?: unknown } = {};
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    captured = {
+      url: String(url),
+      auth: (init?.headers as Record<string, string>)?.authorization,
+      body: JSON.parse(String(init?.body)),
+    };
+    return new Response(JSON.stringify({ messageId: 'm1' }), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const ob = new HttpChannelOutbound('amiko', {
+      outboundUrl: 'https://x/deliver',
+      recipientMetadataKey: 'amiko_peer',
+    }, 'sekret');
+    const res = await ob.send({ sessionId: 's1', to: 'u_123', text: 'hi' });
+    assert.deepEqual(res, { success: true, messageId: 'm1' });
+    assert.equal(captured.url, 'https://x/deliver');
+    assert.equal(captured.auth, 'Bearer sekret');
+    assert.deepEqual(captured.body, { sessionId: 's1', to: 'u_123', text: 'hi' });
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('HttpChannelOutbound.send reports failure on a non-2xx delivery', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => new Response('nope', { status: 502 })) as typeof fetch;
+  try {
+    const ob = new HttpChannelOutbound('amiko', {
+      outboundUrl: 'https://x/deliver',
+      recipientMetadataKey: 'amiko_peer',
+    }, 'tok');
+    const res = await ob.send({ sessionId: 's', to: 'u', text: 't' });
+    assert.equal(res.success, false);
+    assert.match(res.error ?? '', /502/);
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
Fixes #210 (follow-up to #207).

## Problem
`session_send`/`canSend` could never reach channels created purely via the API (`POST /api/agents/:id/channels`). They have no plugin, no `start()`, no `handle.outbound`, so `channelOutbound` never had an entry — `resolveOutbound` returned `undefined` before it could even call `resolveRecipient`. **amiko is one such channel.**

## Fix
An external channel opts into outbound by putting two fields in its `config`:
- **`outboundUrl`** — the gateway POSTs `{ sessionId, to, text }` here.
- **`recipientMetadataKey`** — which `session.metadata` field holds the `to`.

The gateway synthesizes an **`HttpChannelOutbound`**:
- `send({sessionId,to,text})` → authenticated `POST` to `outboundUrl` (channel token as `Bearer`); 2xx = delivered (optional `messageId` from the response), non-2xx/throw = failure.
- `resolveRecipient(session)` → reads `recipientMetadataKey` from `session.metadata`.

It's registered into the runner's outbound map at **`channel-pool.start()` / agent hydration** — the same lifecycle point as plugin outbounds (`buildExternalOutboundHandle` → tracked in `this.handles` → `agent-instance` registers it). So `session_send` delivers and `session_list.canSend` is `true`. The `send()` result flows back through the existing `session_send` tool, which records the assistant message + delivery metadata exactly like plugin channels.

**Back-compat:** external channels without the config are unchanged (inbound-only, `canSend:false`); unresolvable recipient → `undefined` → no false positives.

## Scope / follow-up
Registration happens at **hydrate/boot** — covers gateway restart, which is the amiko rollout pattern (create channel + config, deploy). Registering on runtime **create / PATCH-enable without a restart** is a follow-up: `channelPool` isn't currently threaded into `app.ts`. Called out so it's tracked.

## Tests
New `apps/gateway/test/external-outbound.test.ts` (5 cases: config parse/validation, handle build opt-in, `resolveRecipient`, `send` POST shape + auth, non-2xx failure) — all pass. Adds a `test` script to the gateway package (it had none). Gateway builds + typechecks clean.

## Integrator side (amiko, separate repo)
amiko-chat must (a) implement the `outboundUrl` delivery endpoint and (b) write the recipient id into `session.metadata[recipientMetadataKey]` at inbound/session creation — then set both config fields on its channel. Lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API-created external channels to send outbound messages through a configured HTTP endpoint.
  * External channel messages now include recipient metadata, session details, and message text in the request.

* **Tests**
  * Added coverage for external channel configuration, outbound delivery, recipient lookup, and error handling.

* **Chores**
  * Added a test script to run the gateway’s TypeScript test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->