### PR TITLE
fix(agent): register MiniMax-M3 under the openrouter provider (#212)

### DIFF
--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -59,6 +59,21 @@ const minimaxM3 = (provider: string, baseUrl: string): Model<any> => ({
 const LOCAL_MODELS: Record<string, Model<any>> = {
   'minimax/MiniMax-M3': minimaxM3('minimax', 'https://api.minimax.io/anthropic'),
   'minimax-cn/MiniMax-M3': minimaxM3('minimax-cn', 'https://api.minimaxi.com/anthropic'),
+  // OpenRouter routes MiniMax under the lowercase, slashed id and an
+  // OpenAI-compatible API (not anthropic-messages). pi-ai's registry lacks it
+  // through 0.73.1, so add it locally (issue #212). Drop once pi-ai carries it.
+  'openrouter/minimax/minimax-m3': {
+    id: 'minimax/minimax-m3',
+    name: 'MiniMax-M3 (OpenRouter)',
+    api: 'openai-completions',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0.375 },
+    contextWindow: 1000000,
+    maxTokens: 131072,
+  } as Model<any>,
 };
 
 export const listLocalModels = (provider: string): Model<any>[] =>

--- a/apps/agent/test/minimax-m3.test.ts
+++ b/apps/agent/test/minimax-m3.test.ts
@@ -42,6 +42,23 @@ test('MiniMax-M3 appears in the picker catalog under minimax-cn too', () => {
   assert.equal(m3!.reasoning, true);
 });
 
+test('MiniMax-M3 resolves under the openrouter provider (OpenAI-compatible, slashed id)', () => {
+  const m = resolveModel(modelConfig('openrouter', 'minimax/minimax-m3'));
+  assert.equal(m.id, 'minimax/minimax-m3');
+  assert.equal(m.api, 'openai-completions');
+  assert.equal(m.baseUrl, 'https://openrouter.ai/api/v1');
+  assert.equal(m.contextWindow, 1000000);
+  assert.ok((m.input as string[]).includes('image'), 'openrouter M3 must be image-capable');
+});
+
+test('MiniMax-M3 appears in the picker catalog under openrouter', () => {
+  const openrouter = listProviderCatalog().find((p) => p.provider === 'openrouter');
+  assert.ok(openrouter, 'openrouter provider present in catalog');
+  const m3 = openrouter!.models.find((m) => m.id === 'minimax/minimax-m3');
+  assert.ok(m3, 'minimax/minimax-m3 listed under openrouter');
+  assert.equal(m3!.reasoning, true);
+});
+
 test('MiniMax-M2.7 is left untouched and stays text-only (removed only after migration)', () => {
   const m = resolveModel(modelConfig('minimax', 'MiniMax-M2.7'));
   assert.equal(m.id, 'MiniMax-M2.7');


### PR DESCRIPTION
Fixes #212.

## Problem
`minimax/minimax-m3` didn't appear in the picker (or resolve) for **openrouter**-based deployments — which is how the amiko production deployment routes MiniMax. #205 registered M3 only under the **direct** MiniMax providers, and pi-ai's generated registry lacks `minimax/minimax-m3` under openrouter through 0.73.1 (bumping pi-ai wouldn't help).

## Fix
Add an `openrouter/minimax/minimax-m3` entry to `LOCAL_MODELS` in `model-utils.ts`, using OpenRouter's conventions (OpenAI-compatible API, lowercase slashed id) rather than the direct providers' `anthropic-messages` / `MiniMax-M3`:

```ts
'openrouter/minimax/minimax-m3': {
  id: 'minimax/minimax-m3', name: 'MiniMax-M3 (OpenRouter)',
  api: 'openai-completions', provider: 'openrouter',
  baseUrl: 'https://openrouter.ai/api/v1',
  reasoning: true, input: ['text','image'],
  contextWindow: 1000000, maxTokens: 131072,
  cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0.375 },
}
```

Now `listLocalModels('openrouter')` surfaces it in the catalog and `resolveModel('openrouter', 'minimax/minimax-m3')` resolves it. Drop once a pi-ai release carries the model.

## Tests
7 pass (2 new): openrouter resolution (openai-completions API, slashed id, 1M context, image-capable) + catalog presence under openrouter. Agent builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the MiniMax M3 model through the OpenRouter provider.
  * The model now appears in the model picker and can be selected with the correct capabilities, including image input and reasoning support.

* **Tests**
  * Added coverage to ensure the model resolves correctly and is listed for the OpenRouter provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->