### PR TITLE
fix(agent): group local models beside their family in the model picker

### DIFF
--- a/apps/agent/src/model-catalog.ts
+++ b/apps/agent/src/model-catalog.ts
@@ -17,6 +17,38 @@ export interface ProviderCatalogEntry {
  * a warning when a user explicitly disables thinking on a model that
  * needs it server-side.
  */
+/** Length of the shared leading substring of two ids. */
+const commonPrefixLen = (a: string, b: string): number => {
+  const n = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < n && a[i] === b[i]) i += 1;
+  return i;
+};
+
+/**
+ * Insert `entry` next to its closest existing sibling (the one sharing the
+ * longest id prefix, e.g. `minimax/minimax-m3` beside `minimax/minimax-m2.7`)
+ * so model families stay grouped in the picker, rather than appending local
+ * models at the very end. Falls back to append when there is no clear sibling.
+ */
+const insertGrouped = (
+  models: { id: string; reasoning: boolean }[],
+  entry: { id: string; reasoning: boolean },
+): void => {
+  const MIN_SHARED = 4;
+  let bestIdx = -1;
+  let bestLen = MIN_SHARED - 1;
+  for (let i = 0; i < models.length; i += 1) {
+    const len = commonPrefixLen(models[i]!.id, entry.id);
+    if (len >= MIN_SHARED && len >= bestLen) {
+      bestLen = len;
+      bestIdx = i; // `>=` keeps the last sibling so we insert after the family
+    }
+  }
+  if (bestIdx === -1) models.push(entry);
+  else models.splice(bestIdx + 1, 0, entry);
+};
+
 export const listProviderCatalog = (): ProviderCatalogEntry[] => {
   const providers = getProviders();
   return providers.map((provider) => {
@@ -24,10 +56,11 @@ export const listProviderCatalog = (): ProviderCatalogEntry[] => {
       id: m.id,
       reasoning: Boolean((m as { reasoning?: boolean }).reasoning),
     }));
-    // Append local-only models the pi-ai registry lacks.
+    // Merge local-only models the pi-ai registry lacks, placing each next to
+    // its family rather than at the end of the list.
     for (const lm of listLocalModels(provider)) {
       if (!models.some((m) => m.id === lm.id)) {
-        models.push({ id: lm.id, reasoning: Boolean(lm.reasoning) });
+        insertGrouped(models, { id: lm.id, reasoning: Boolean(lm.reasoning) });
       }
     }
     return { provider, models };

--- a/apps/agent/test/minimax-m3.test.ts
+++ b/apps/agent/test/minimax-m3.test.ts
@@ -59,6 +59,19 @@ test('MiniMax-M3 appears in the picker catalog under openrouter', () => {
   assert.equal(m3!.reasoning, true);
 });
 
+test('MiniMax-M3 is grouped next to the other minimax models under openrouter (not appended last)', () => {
+  const openrouter = listProviderCatalog().find((p) => p.provider === 'openrouter');
+  assert.ok(openrouter);
+  const ids = openrouter!.models.map((m) => m.id);
+  const idx = ids.indexOf('minimax/minimax-m3');
+  assert.ok(idx > 0, 'minimax/minimax-m3 present and not first');
+  // The entry immediately before it belongs to the same minimax family.
+  assert.ok(
+    ids[idx - 1]!.startsWith('minimax/'),
+    `expected a minimax sibling before m3, got ${ids[idx - 1]}`,
+  );
+});
+
 test('MiniMax-M2.7 is left untouched and stays text-only (removed only after migration)', () => {
   const m = resolveModel(modelConfig('minimax', 'MiniMax-M2.7'));
   assert.equal(m.id, 'MiniMax-M2.7');


### PR DESCRIPTION
Follow-up to #212. After MiniMax-M3 was added under openrouter, it appeared **at the very bottom** of the picker instead of grouped with the other minimax models — because `listProviderCatalog()` appends local-only models after all pi-ai models.

## Fix
Insert each merged local model **next to its closest existing sibling** (the one sharing the longest id prefix, e.g. `minimax/minimax-m3` beside `minimax/minimax-m2.7`) rather than at the end; fall back to append when there is no clear sibling (shared prefix < 4 chars).

## Tests
8 pass (1 new): asserts `minimax/minimax-m3` is grouped (the entry immediately before it is a `minimax/` model), not appended last. Agent builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local models now appear grouped alongside closely related models in the picker instead of always being listed at the end.
  * Model lists now better preserve family-based ordering, making it easier to find related entries.
* **Bug Fixes**
  * Improved placement of `MiniMax-M3` so it shows up next to other `minimax` models rather than as an out-of-place entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->