### PR TITLE
feat(agent): session_list shows who + adds filters and pagination

### DIFF
--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -112,6 +112,19 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
       },
     );
 
+    // Resolve user id -> name once (best-effort). Enables filtering by a user's
+    // name via `search` and labeling participants without per-row lookups.
+    const nameById = new Map<string, string>();
+    if (context.userStore) {
+      try {
+        for (const u of await context.userStore.list()) {
+          if (u.name) nameById.set(u.userId, u.name);
+        }
+      } catch {
+        // Names are best-effort; fall back to userId-only participants.
+      }
+    }
+
     // ── Filters ──────────────────────────────────────────────────────
     if (args.channel) {
       const ch = args.channel.trim().toLowerCase();
@@ -135,6 +148,7 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
           s.description,
           s.lastMessagePreview,
           describeCounterpart(s.source.platform, s.metadata),
+          ...(s.userIds ?? []).map((id) => nameById.get(id)),
         ]
           .filter((v): v is string => typeof v === 'string')
           .some((v) => v.toLowerCase().includes(q)),
@@ -148,18 +162,9 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
     const offset = Math.max(args.offset ?? 0, 0);
     const page = sessions.slice(offset, offset + limit);
 
-    // Batch-resolve participant names for the page's users only. Cross-channel
-    // identities are intentionally NOT included here — they'd bloat every list
-    // row; use `user_list` to see a user's identities.
-    const uids = [...new Set(page.flatMap((s) => s.userIds ?? []))];
-    const nameById = new Map<string, string>();
-    if (uids.length > 0 && context.userStore) {
-      const records = await Promise.all(uids.map((id) => context.userStore!.get(id)));
-      records.forEach((r, i) => {
-        if (r?.name) nameById.set(uids[i]!, r.name);
-      });
-    }
-
+    // participants carry { userId, name } (name from the map above). Cross-channel
+    // identities are intentionally omitted — they'd bloat every row; use
+    // `user_list` to see a user's identities.
     const result = page.map((s) => ({
       sessionId: s.sessionId,
       type: s.type ?? s.source.type ?? (s.source.platform ? 'direct' : undefined),

--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -88,8 +88,9 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
   label: 'List Sessions',
   description:
     'List sessions, most-recently-active first. Each entry shows who the session is with '
-    + '(`participants` = linked OpenHermit users with names/identities; `counterpart` = the '
-    + 'channel-side identity), `type` (direct/group), source, activity, and `canSend` (whether '
+    + '(`participants` = linked OpenHermit users with names — use user_list for their '
+    + 'cross-channel identities; `counterpart` = the channel-side identity), `type` '
+    + '(direct/group), source, activity, and `canSend` (whether '
     + 'session_send can deliver — do not attempt session_send when false). '
     + 'Filter by `channel`, `type`, `user_id`, or `search`; page with `limit`/`offset` '
     + '(details carry `total` and `hasMore`).',
@@ -147,19 +148,16 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
     const offset = Math.max(args.offset ?? 0, 0);
     const page = sessions.slice(offset, offset + limit);
 
-    // Batch-resolve participant names + identities for the page's users only.
+    // Batch-resolve participant names for the page's users only. Cross-channel
+    // identities are intentionally NOT included here — they'd bloat every list
+    // row; use `user_list` to see a user's identities.
     const uids = [...new Set(page.flatMap((s) => s.userIds ?? []))];
     const nameById = new Map<string, string>();
-    let identsById = new Map<string, { channel: string; channelUserId: string }[]>();
     if (uids.length > 0 && context.userStore) {
-      const [records, idents] = await Promise.all([
-        Promise.all(uids.map((id) => context.userStore!.get(id))),
-        context.userStore.listIdentitiesByUserIds(uids),
-      ]);
+      const records = await Promise.all(uids.map((id) => context.userStore!.get(id)));
       records.forEach((r, i) => {
         if (r?.name) nameById.set(uids[i]!, r.name);
       });
-      identsById = idents;
     }
 
     const result = page.map((s) => ({
@@ -170,7 +168,6 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
       participants: (s.userIds ?? []).map((id) => ({
         userId: id,
         ...(nameById.has(id) ? { name: nameById.get(id) } : {}),
-        identities: (identsById.get(id) ?? []).map((idn) => `${idn.channel}:${idn.channelUserId}`),
       })),
       counterpart: describeCounterpart(s.source.platform, s.metadata),
       messageCount: s.messageCount,

--- a/apps/agent/src/tools/session.ts
+++ b/apps/agent/src/tools/session.ts
@@ -13,12 +13,58 @@ import {
 // ── Parameters ──────────────────────────────────────────────────────
 
 const SessionListParams = Type.Object({
-  channel: Type.Optional(Type.String({ description: 'Filter by channel/platform (e.g. "telegram", "cli", "web").' })),
-  limit: Type.Optional(Type.Number({ description: 'Maximum number of sessions to return (default 20).' })),
+  channel: Type.Optional(Type.String({ description: 'Filter by channel/platform (e.g. "telegram", "wechat", "web").' })),
+  type: Type.Optional(Type.String({ description: 'Filter by session type: "direct" or "group".' })),
+  user_id: Type.Optional(Type.String({ description: 'Only sessions that involve this OpenHermit user id.' })),
+  search: Type.Optional(Type.String({ description: 'Case-insensitive substring match over description, last message preview, counterpart, and session id.' })),
   include_inactive: Type.Optional(Type.Boolean({ description: 'Include inactive sessions that were replaced by /new (default false).' })),
+  limit: Type.Optional(Type.Number({ description: 'Page size (default 20, max 100).' })),
+  offset: Type.Optional(Type.Number({ description: 'Number of sessions to skip for pagination (default 0). Results are ordered by most-recent activity first.' })),
 });
 
 type SessionListArgs = Static<typeof SessionListParams>;
+
+/** Trim a value to a non-empty string, or undefined. */
+const asStr = (v: unknown): string | undefined =>
+  typeof v === 'string' && v.trim() ? v.trim() : v != null && typeof v === 'number' ? String(v) : undefined;
+
+/**
+ * Human-readable label for the session's counterpart, derived from the
+ * channel-specific identity fields each bridge writes into session metadata.
+ * Returns undefined when nothing identifying is present.
+ */
+const describeCounterpart = (
+  platform: string | undefined,
+  md: Record<string, unknown> | undefined,
+): string | undefined => {
+  const m = md ?? {};
+  switch (platform) {
+    case 'telegram': {
+      const title = asStr(m.telegram_chat_title);
+      if (title) return title;
+      const name = asStr(m.telegram_first_name);
+      const user = asStr(m.telegram_username);
+      const id = asStr(m.telegram_user_id);
+      if (name && user) return `${name} (@${user})`;
+      return name ?? (user ? `@${user}` : id);
+    }
+    case 'wechat': {
+      const group = asStr(m.wechat_group_id);
+      if (group) return `group ${group}`;
+      return asStr(m.wechat_from_user_id) ?? asStr(m.wechat_peer_id);
+    }
+    case 'signal':
+      return asStr(m.signal_source_number) ?? asStr(m.signal_source);
+    case 'whatsapp':
+      return asStr(m.whatsapp_group_jid) ?? asStr(m.whatsapp_sender_number) ?? asStr(m.whatsapp_chat_jid);
+    case 'slack':
+      return asStr(m.slack_channel_id ?? m.slack_user_id);
+    case 'discord':
+      return asStr(m.discord_channel_id);
+    default:
+      return undefined;
+  }
+};
 
 const SessionReadParams = Type.Object({
   session_id: Type.String({ description: 'Session ID to read messages from.' }),
@@ -41,20 +87,21 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
   name: 'session_list',
   label: 'List Sessions',
   description:
-    'List sessions with their descriptions, last activity, message counts, and source. '
-    + 'Each entry includes `canSend` — whether session_send can deliver to it (its channel '
-    + 'supports outbound messaging and a recipient is resolvable); do not attempt session_send '
-    + 'when canSend is false. Optionally filter by channel.',
+    'List sessions, most-recently-active first. Each entry shows who the session is with '
+    + '(`participants` = linked OpenHermit users with names/identities; `counterpart` = the '
+    + 'channel-side identity), `type` (direct/group), source, activity, and `canSend` (whether '
+    + 'session_send can deliver — do not attempt session_send when false). '
+    + 'Filter by `channel`, `type`, `user_id`, or `search`; page with `limit`/`offset` '
+    + '(details carry `total` and `hasMore`).',
   parameters: SessionListParams,
   execute: async (_toolCallId, args: SessionListArgs) => {
     if (!context.sessionStore || !context.storeScope) {
       throw new ValidationError('session_list is unavailable: no session store is configured.');
     }
 
-    // Owner sees every session on the agent (so it can answer
-    // questions like "who else has chatted with you?" or
-    // "which other identity is also me?"). Non-owners only see
-    // sessions they participate in.
+    // Owner sees every session on the agent (so it can answer questions like
+    // "who else has chatted with you?"). Non-owners only see sessions they
+    // participate in.
     const isOwner = context.currentUserRole === 'owner';
     let sessions = await context.sessionStore.list(
       context.storeScope,
@@ -64,33 +111,74 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
       },
     );
 
-    // Filter by channel/platform if specified
+    // ── Filters ──────────────────────────────────────────────────────
     if (args.channel) {
       const ch = args.channel.trim().toLowerCase();
       sessions = sessions.filter(
-        (s) =>
-          s.source.platform?.toLowerCase() === ch ||
-          s.source.kind?.toLowerCase() === ch,
+        (s) => s.source.platform?.toLowerCase() === ch || s.source.kind?.toLowerCase() === ch,
+      );
+    }
+    if (args.type) {
+      const t = args.type.trim().toLowerCase();
+      sessions = sessions.filter((s) => (s.type ?? s.source.type)?.toLowerCase() === t);
+    }
+    if (args.user_id) {
+      const uid = args.user_id.trim();
+      sessions = sessions.filter((s) => s.userIds?.includes(uid));
+    }
+    if (args.search) {
+      const q = args.search.trim().toLowerCase();
+      sessions = sessions.filter((s) =>
+        [
+          s.sessionId,
+          s.description,
+          s.lastMessagePreview,
+          describeCounterpart(s.source.platform, s.metadata),
+        ]
+          .filter((v): v is string => typeof v === 'string')
+          .some((v) => v.toLowerCase().includes(q)),
       );
     }
 
-    // Sort by last activity (most recent first)
+    // Most recent activity first, then paginate.
     sessions.sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt));
+    const total = sessions.length;
+    const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+    const offset = Math.max(args.offset ?? 0, 0);
+    const page = sessions.slice(offset, offset + limit);
 
-    // Apply limit
-    const limit = args.limit ?? 20;
-    const limited = sessions.slice(0, limit);
+    // Batch-resolve participant names + identities for the page's users only.
+    const uids = [...new Set(page.flatMap((s) => s.userIds ?? []))];
+    const nameById = new Map<string, string>();
+    let identsById = new Map<string, { channel: string; channelUserId: string }[]>();
+    if (uids.length > 0 && context.userStore) {
+      const [records, idents] = await Promise.all([
+        Promise.all(uids.map((id) => context.userStore!.get(id))),
+        context.userStore.listIdentitiesByUserIds(uids),
+      ]);
+      records.forEach((r, i) => {
+        if (r?.name) nameById.set(uids[i]!, r.name);
+      });
+      identsById = idents;
+    }
 
-    const result = limited.map((s) => ({
+    const result = page.map((s) => ({
       sessionId: s.sessionId,
+      type: s.type ?? s.source.type ?? (s.source.platform ? 'direct' : undefined),
       description: s.description ?? '(no description)',
       source: s.source,
+      participants: (s.userIds ?? []).map((id) => ({
+        userId: id,
+        ...(nameById.has(id) ? { name: nameById.get(id) } : {}),
+        identities: (identsById.get(id) ?? []).map((idn) => `${idn.channel}:${idn.channelUserId}`),
+      })),
+      counterpart: describeCounterpart(s.source.platform, s.metadata),
       messageCount: s.messageCount,
       lastActivity: s.lastActivityAt,
       createdAt: s.createdAt,
       lastMessagePreview: s.lastMessagePreview,
-      // Whether session_send can deliver to this session (its channel exposes an
-      // outbound adapter AND a recipient is resolvable from metadata).
+      // Whether session_send can deliver (channel exposes an outbound adapter
+      // AND a recipient resolves from metadata).
       canSend: context.channelOutbound
         ? resolveOutbound(s, context.channelOutbound) !== undefined
         : false,
@@ -98,11 +186,9 @@ export const createSessionListTool = (context: ToolContext): PolicyAwareTool<typ
 
     return {
       content: asTextContent(
-        result.length > 0
-          ? formatJson(result)
-          : 'No sessions found.\n',
+        result.length > 0 ? formatJson(result) : 'No sessions found.\n',
       ),
-      details: { count: result.length, total: sessions.length },
+      details: { count: result.length, total, offset, limit, hasMore: offset + result.length < total },
     };
   },
 });

--- a/apps/agent/test/session-list.test.ts
+++ b/apps/agent/test/session-list.test.ts
@@ -50,6 +50,7 @@ const ctx = (): ToolContext =>
     sessionStore: { list: async () => ENTRIES.slice() },
     userStore: {
       get: async (id: string) => (NAMES[id] ? { userId: id, name: NAMES[id] } : { userId: id }),
+      list: async () => Object.entries(NAMES).map(([userId, name]) => ({ userId, name })),
     },
   }) as unknown as ToolContext;
 
@@ -90,6 +91,11 @@ test('filter by user_id', async () => {
 test('search matches description / counterpart', async () => {
   assert.deepEqual((await run({ search: 'alice' })).rows.map((r) => r.sessionId), ['s-tg']);
   assert.deepEqual((await run({ search: 'team group' })).rows.map((r) => r.sessionId), ['s-wx']);
+});
+
+test('search matches a participant name (find a user\'s sessions by name)', async () => {
+  // "Bob" is u2's name, present in neither description nor counterpart.
+  assert.deepEqual((await run({ search: 'bob' })).rows.map((r) => r.sessionId), ['s-wx']);
 });
 
 test('pagination via limit + offset with total/hasMore', async () => {

--- a/apps/agent/test/session-list.test.ts
+++ b/apps/agent/test/session-list.test.ts
@@ -43,10 +43,6 @@ const ENTRIES: any[] = [
 ];
 
 const NAMES: Record<string, string> = { u1: 'Alice OH', u2: 'Bob' };
-const IDENTS: Record<string, { channel: string; channelUserId: string }[]> = {
-  u1: [{ channel: 'telegram', channelUserId: '123' }, { channel: 'wechat', channelUserId: 'wxid_a' }],
-};
-
 const ctx = (): ToolContext =>
   ({
     storeScope: {},
@@ -54,8 +50,6 @@ const ctx = (): ToolContext =>
     sessionStore: { list: async () => ENTRIES.slice() },
     userStore: {
       get: async (id: string) => (NAMES[id] ? { userId: id, name: NAMES[id] } : { userId: id }),
-      listIdentitiesByUserIds: async (ids: string[]) =>
-        new Map(ids.map((id) => [id, IDENTS[id] ?? []])),
     },
   }) as unknown as ToolContext;
 
@@ -72,11 +66,7 @@ test('session_list is ordered by most-recent activity and shows participants + c
   assert.equal(rows[0].sessionId, 's-tg'); // most recent
   assert.equal(rows[0].counterpart, 'Alice (@alice)');
   assert.equal(rows[0].type, 'direct');
-  assert.deepEqual(rows[0].participants[0], {
-    userId: 'u1',
-    name: 'Alice OH',
-    identities: ['telegram:123', 'wechat:wxid_a'],
-  });
+  assert.deepEqual(rows[0].participants[0], { userId: 'u1', name: 'Alice OH' });
   assert.equal(rows[1].sessionId, 's-wx');
   assert.equal(rows[1].counterpart, 'group g1');
 });

--- a/apps/agent/test/session-list.test.ts
+++ b/apps/agent/test/session-list.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { ToolContext } from '../src/tools/shared.js';
+import { createSessionListTool } from '../src/tools/session.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const ENTRIES: any[] = [
+  {
+    sessionId: 's-tg',
+    source: { kind: 'channel', platform: 'telegram', interactive: true, type: 'direct' },
+    type: 'direct',
+    metadata: { telegram_first_name: 'Alice', telegram_username: 'alice', telegram_user_id: 123 },
+    userIds: ['u1'],
+    description: 'chat about widgets',
+    lastMessagePreview: 'see you',
+    messageCount: 5,
+    lastActivityAt: '2026-07-02T10:00:00Z',
+    createdAt: '2026-07-01T00:00:00Z',
+  },
+  {
+    sessionId: 's-wx',
+    source: { kind: 'channel', platform: 'wechat', interactive: true, type: 'group' },
+    type: 'group',
+    metadata: { wechat_group_id: 'g1' },
+    userIds: ['u2'],
+    description: 'team group',
+    messageCount: 2,
+    lastActivityAt: '2026-07-02T09:00:00Z',
+    createdAt: '2026-07-01T00:00:00Z',
+  },
+  {
+    sessionId: 's-old',
+    source: { kind: 'channel', platform: 'telegram', interactive: true, type: 'direct' },
+    type: 'direct',
+    metadata: { telegram_first_name: 'Zed' },
+    userIds: [],
+    messageCount: 1,
+    lastActivityAt: '2026-06-30T00:00:00Z',
+    createdAt: '2026-06-01T00:00:00Z',
+  },
+];
+
+const NAMES: Record<string, string> = { u1: 'Alice OH', u2: 'Bob' };
+const IDENTS: Record<string, { channel: string; channelUserId: string }[]> = {
+  u1: [{ channel: 'telegram', channelUserId: '123' }, { channel: 'wechat', channelUserId: 'wxid_a' }],
+};
+
+const ctx = (): ToolContext =>
+  ({
+    storeScope: {},
+    currentUserRole: 'owner',
+    sessionStore: { list: async () => ENTRIES.slice() },
+    userStore: {
+      get: async (id: string) => (NAMES[id] ? { userId: id, name: NAMES[id] } : { userId: id }),
+      listIdentitiesByUserIds: async (ids: string[]) =>
+        new Map(ids.map((id) => [id, IDENTS[id] ?? []])),
+    },
+  }) as unknown as ToolContext;
+
+async function run(args: Record<string, unknown> = {}): Promise<{ rows: any[]; details: any }> {
+  const tool = createSessionListTool(ctx());
+  const res = await tool.execute('tc', args as any);
+  const text = (res.content as any[]).map((c) => c.text ?? '').join('');
+  const rows = text.startsWith('No sessions') ? [] : JSON.parse(text);
+  return { rows, details: (res as any).details };
+}
+
+test('session_list is ordered by most-recent activity and shows participants + counterpart', async () => {
+  const { rows } = await run();
+  assert.equal(rows[0].sessionId, 's-tg'); // most recent
+  assert.equal(rows[0].counterpart, 'Alice (@alice)');
+  assert.equal(rows[0].type, 'direct');
+  assert.deepEqual(rows[0].participants[0], {
+    userId: 'u1',
+    name: 'Alice OH',
+    identities: ['telegram:123', 'wechat:wxid_a'],
+  });
+  assert.equal(rows[1].sessionId, 's-wx');
+  assert.equal(rows[1].counterpart, 'group g1');
+});
+
+test('filter by channel', async () => {
+  const { rows } = await run({ channel: 'wechat' });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].sessionId, 's-wx');
+});
+
+test('filter by type=group', async () => {
+  const { rows } = await run({ type: 'group' });
+  assert.deepEqual(rows.map((r) => r.sessionId), ['s-wx']);
+});
+
+test('filter by user_id', async () => {
+  const { rows } = await run({ user_id: 'u1' });
+  assert.deepEqual(rows.map((r) => r.sessionId), ['s-tg']);
+});
+
+test('search matches description / counterpart', async () => {
+  assert.deepEqual((await run({ search: 'alice' })).rows.map((r) => r.sessionId), ['s-tg']);
+  assert.deepEqual((await run({ search: 'team group' })).rows.map((r) => r.sessionId), ['s-wx']);
+});
+
+test('pagination via limit + offset with total/hasMore', async () => {
+  const p1 = await run({ limit: 1, offset: 0 });
+  assert.equal(p1.rows.length, 1);
+  assert.equal(p1.rows[0].sessionId, 's-tg');
+  assert.equal(p1.details.total, 3);
+  assert.equal(p1.details.hasMore, true);
+
+  const p2 = await run({ limit: 1, offset: 2 });
+  assert.equal(p2.rows[0].sessionId, 's-old');
+  assert.equal(p2.details.hasMore, false);
+});

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ OpenHermit builds toolsets per turn from available runtime capabilities and the 
 | `user_merge` | Merge one user into another (owner) |
 | `identity_link_request` | Issue a short-lived token for cross-channel identity linking (any role) |
 | `identity_link_confirm` | Redeem a link token from a different channel to join identities (any role) |
-| `session_list` | List sessions |
+| `session_list` | List sessions (who it's with, type, canSend) — filter by channel/type/user_id/search, paginate, newest first |
 | `session_read` | Read session history |
 | `session_summary` | Read description, working memory, and recent activity |
 | `session_send` | Send a proactive message through a connected channel |


### PR DESCRIPTION
## Problem
Even as **owner**, `session_list` didn't show *who* a session was with — only `source.platform` (e.g. "telegram"), never which user/chat. The returned fields (`sessionId/description/source/messageCount/lastActivity/lastMessagePreview/canSend`) carry no counterpart identity; `description` is an AI summary, not identity.

The identifying data existed but wasn't surfaced: `entry.userIds` (resolvable to names via the `userStore` already in ToolContext), `entry.metadata` (per-channel identity fields), and `entry.type`.

## Changes
Each entry now includes:
- **`participants`** — the session's OpenHermit users resolved via `userStore` to `{ userId, name, identities: ["telegram:123","wechat:wxid_…"] }` (batched per page, so O(1) extra queries).
- **`counterpart`** — human-readable channel-side label from session metadata per platform (telegram `Name (@handle)` / chat title, wechat from_user/group, signal number, whatsapp jid, slack/discord ids).
- **`type`** — direct/group.

Plus:
- **Filters**: `type`, `user_id`, `search` (over id/description/preview/counterpart) added to the existing `channel`.
- **Pagination**: `limit` (default 20, max 100) + `offset`; `details` carries `total` and `hasMore`.
- **Default order** unchanged: most-recently-active first.
- Tool description + `docs/tools.md` updated so the agent uses the new fields.

## Tests
New `apps/agent/test/session-list.test.ts` (6 cases: ordering + participants/identities + counterpart, each filter, search, pagination with total/hasMore). Agent builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced session listing with optional filters for channel, type, user ID, and text search.
  * Added offset/limit pagination (with capped limit), newest-first sorting, and enriched session output including participant identity/name and a readable counterpart label.
* **Bug Fixes**
  * Improved search coverage across multiple session fields and derived labels; updated pagination metadata to include `offset`, `limit`, and `hasMore`.
* **Tests**
  * Expanded automated coverage for sorting, filtering, search (including participant-name matching), and pagination.
* **Documentation**
  * Updated `session_list` tool documentation to describe the new filters, pagination, ordering, and output details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->