### PR TITLE
fix(store): clamp negative per-event costs in usage aggregation

### DIFF
--- a/packages/store/src/impl/agent-store.ts
+++ b/packages/store/src/impl/agent-store.ts
@@ -335,7 +335,7 @@ export class DbAgentStore implements AgentStore {
         SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text      AS output_tokens,
         SUM(COALESCE((payload->'usage'->>'cacheRead')::bigint, 0))::text   AS cache_read_tokens,
         SUM(COALESCE((payload->'usage'->>'cacheWrite')::bigint, 0))::text  AS cache_write_tokens,
-        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+        SUM(GREATEST(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0), 0))::float8 AS usd_total
       FROM buckets
       GROUP BY agent_id, bucket
     `);
@@ -400,7 +400,7 @@ export class DbAgentStore implements AgentStore {
         SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text      AS output_tokens,
         SUM(COALESCE((payload->'usage'->>'cacheRead')::bigint, 0))::text   AS cache_read_tokens,
         SUM(COALESCE((payload->'usage'->>'cacheWrite')::bigint, 0))::text  AS cache_write_tokens,
-        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+        SUM(GREATEST(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0), 0))::float8 AS usd_total
       FROM buckets
       GROUP BY bucket
     `);
@@ -459,7 +459,7 @@ export class DbAgentStore implements AgentStore {
         COUNT(*)::text       AS calls,
         SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text  AS input_tokens,
         SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text AS output_tokens,
-        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+        SUM(GREATEST(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0), 0))::float8 AS usd_total
       FROM ${sessionEvents}
       WHERE event_type = 'assistant'
         AND payload ? 'usage'
@@ -478,7 +478,7 @@ export class DbAgentStore implements AgentStore {
         to_char(date_trunc('day', ts::timestamptz), 'YYYY-MM-DD') AS day,
         SUM(COALESCE((payload->'usage'->>'input')::bigint, 0))::text  AS input_tokens,
         SUM(COALESCE((payload->'usage'->>'output')::bigint, 0))::text AS output_tokens,
-        SUM(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0))::float8 AS usd_total
+        SUM(GREATEST(COALESCE((payload->'usage'->'cost'->>'total')::numeric, 0), 0))::float8 AS usd_total
       FROM ${sessionEvents}
       WHERE event_type = 'assistant'
         AND payload ? 'usage'


### PR DESCRIPTION
## Bug
Production **all-time cost showed `$-275212.74`**.

## Root cause (confirmed against the prod DB)
19 `assistant` events from the **`openrouter/auto`** pseudo-model stored a **negative `usage.cost.total`** — `cost = −(tokens)` (that route carries a `−1` "unknown pricing" rate in pi-ai's registry, so pi-ai computes `tokens × −1`). Example event: `cost:{input:-21095,total:-21333}` for `input:21095` tokens. Those 19 events summed to **−$275,742**, swamping the ~+$530 of real costs.

The usage queries sum `payload.usage.cost.total` verbatim, so the negatives corrupted the total.

## Fix
A per-event cost is never negative — wrap each summed `cost.total` in `GREATEST(…, 0)` across all four aggregation queries (`fleetUsage` window buckets, `usageTotals`, `agentUsageDetail` per-model + daily). Drops bad negatives; heals existing rows and future ones in every usage view.

## Verification (prod data)
```
all-time cost  BEFORE: -275212.57   AFTER clamp: 529.43
```
Store builds + typechecks.

## Follow-up (not in this PR)
Clamp cost at **write time** (and/or treat `openrouter/auto`'s `−1` pricing as unknown/0) so stored data stays clean going forward — the aggregation clamp already makes every reader correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage cost totals now prevent negative values from appearing in usage summaries and detail views.
  * Cost figures are now clamped at zero when source data would otherwise produce a negative total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->