### PR TITLE
fix(gateway): keep runner outbounds in sync with the channel pool

### DIFF
--- a/apps/gateway/src/agent-instance.ts
+++ b/apps/gateway/src/agent-instance.ts
@@ -218,14 +218,9 @@ export class AgentInstanceManager {
     // 6. Wire outbounds from the gateway-level channel pool. Bridges are
     //    owned by the pool and persist across runner eviction; we just
     //    register their send-callbacks on this freshly hydrated runner.
-    if (this.channelPool) {
-      const handles = this.channelPool.getOutbounds(agentId);
-      for (const handle of handles) {
-        if (handle.outbound) runner.registerChannelOutbound(handle.outbound);
-      }
-      if (handles.length > 0) {
-        log(`[${agentId}] attached ${handles.length} pool channel(s): ${handles.map((h) => h.name).join(', ')}`);
-      }
+    const attached = this.syncOutbounds(runner, agentId);
+    if (attached.length > 0) {
+      log(`[${agentId}] attached ${attached.length} pool channel(s): ${attached.join(', ')}`);
     }
 
     // 7. Sync platform skills into the runner's exec backends.
@@ -251,6 +246,28 @@ export class AgentInstanceManager {
     const runner = this.runners.get(agentId);
     if (runner) this.touch(agentId);
     return runner;
+  }
+
+  /**
+   * (Re)register the agent's outbound adapters from the ChannelPool onto the
+   * runner and return the attached channel names. Idempotent
+   * (`registerChannelOutbound` is keyed by channel), so it is safe to call on
+   * every serve — this keeps a hot runner's outbound set current even when a
+   * channel's outbound was registered *after* the runner hydrated (e.g. external
+   * channels registered later during channel-pool start(), or config changes).
+   * Without this, an early-hydrated hot runner would report `canSend:false` /
+   * fail `session_send` for a channel it should be able to reach (#210).
+   */
+  private syncOutbounds(runner: AgentRunner, agentId: string): string[] {
+    if (!this.channelPool) return [];
+    const attached: string[] = [];
+    for (const handle of this.channelPool.getOutbounds(agentId)) {
+      if (handle.outbound) {
+        runner.registerChannelOutbound(handle.outbound);
+        attached.push(handle.name);
+      }
+    }
+    return attached;
   }
 
   /** Mark the agent as recently active so eviction skips it. */
@@ -310,6 +327,10 @@ export class AgentInstanceManager {
     const existing = this.runners.get(agentId);
     if (existing) {
       this.touch(agentId);
+      // Re-sync outbounds: a hot runner may have hydrated before some channel
+      // outbounds were registered (externals are registered as channel-pool
+      // start() progresses). Idempotent; keeps canSend/session_send accurate.
+      this.syncOutbounds(existing, agentId);
       return existing;
     }
 

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -504,14 +504,14 @@ export const main = async (): Promise<void> => {
 
   const host = process.env.GATEWAY_HOST ?? '127.0.0.1';
 
-  const { server, info } = await listen(app.fetch, port, host);
-
   instances.setAdminToken(adminToken);
 
-  // Boot the channel pool — owns Telegram/Slack/Discord bridges
-  // independently of runners. Channels stay alive across runner
-  // eviction; the bridge calls back via HTTP, hydrating the runner on
-  // demand for inbound messages.
+  // Boot the channel pool BEFORE we start accepting requests, so every
+  // channel's outbound adapter is registered before any runner can hydrate.
+  // Otherwise a runner that hydrates mid-start comes up missing outbounds
+  // (canSend:false / session_send fails) and, being hot, stays that way (#210).
+  // The pool owns Telegram/Slack/Discord bridges independently of runners;
+  // bridges call back via loopback HTTP, hydrating the runner on demand.
   let channelPool: ChannelPool | undefined;
   if (agentChannelStore && agentStore && configStore) {
     const secretStore = instances.getSecretStore();
@@ -525,9 +525,9 @@ export const main = async (): Promise<void> => {
         secretStore,
         channelRegistry: channels,
         manifestRegistry,
-        // Channel adapters connect back from inside the host. Use
-        // 127.0.0.1 even when the public listener is 0.0.0.0.
-        gatewayBaseUrl: `http://127.0.0.1:${info.port}`,
+        // Channel adapters connect back from inside the host over loopback.
+        // Use the resolved `port` (the listener binds it just below).
+        gatewayBaseUrl: `http://127.0.0.1:${port}`,
         ...(publicGatewayBaseUrl ? { publicGatewayBaseUrl } : {}),
         getRunner: (agentId) => instances.getRunner(agentId),
         log: logStartup,
@@ -543,6 +543,8 @@ export const main = async (): Promise<void> => {
       logStartup('channel pool skipped (no secret store available)');
     }
   }
+
+  const { server, info } = await listen(app.fetch, port, host);
 
   attachGatewayWs(server as import('node:http').Server, {
     instances,


### PR DESCRIPTION
Follow-up to #210/#211. Fixes `canSend:false` / `session_send` failing for a channel the agent should reach — reproduced on production amiko (an **external** channel with no bridge; its outbound is a synthesized `HttpChannelOutbound` registered by `channel-pool start()`).

## Diagnosis (verified against prod)
For session `amiko:cmr2xbnzj…`: recipient present in metadata ✅, amiko channel `external`+`enabled`+configured ✅, token decrypts ✅, #211+#215 deployed ✅ — yet `canSend:false` even after a restart. Root cause is **runtime outbound registration timing**, two gaps:

1. **Boot ordering** (`index.ts`): the gateway called `listen()` (and can lazily hydrate runners) *before* `channelPool.start()` registered outbounds. A hot, always-busy twin that hydrates mid-start comes up missing outbounds and — never idle-evicted — stays that way.
2. **No refresh on serve** (`getOrHydrate`): a hot runner was returned without re-syncing its outbounds, so anything registered after it hydrated (externals register as `start()` progresses; config changes) never reached it.

## Fixes
- **Start the channel pool before `listen()`** so all outbounds are registered before the first request (loopback base URL uses the resolved `port`).
- **`syncOutbounds()`** on `AgentInstanceManager`, called on every serve (hot path in `getOrHydrate` + at hydration): idempotently re-registers the pool's outbounds onto the runner. A hot runner now always reflects live channels → `canSend`/`session_send` accurate **without a restart**.

## Verification
Gateway builds + typechecks; existing gateway tests pass. Post-deploy, `amiko:cmr2xbnzj…` should report `canSend:true` on the next `session_list` (recipient + channel config already correct).

Note: this is a core fix — **production amiko-openhermit must rebuild against updated openhermit** to pick it up (a plain `railway redeploy` reuses the old image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)