### PR TITLE
Fix MiniMax-M3 400 (2013) by not sending Anthropic-native thinking param

### DIFF
--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -49,7 +49,8 @@ const minimaxM3 = (provider: string, baseUrl: string): Model<any> => ({
   api: 'anthropic-messages',
   provider,
   baseUrl,
-  reasoning: true,
+  // reasoning off: MiniMax's /anthropic rejects pi-ai's Anthropic-native thinking param with 400 (2013)
+  reasoning: false,
   input: ['text', 'image'],
   cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0.375 },
   contextWindow: 1000000,
@@ -103,13 +104,16 @@ export const resolveModel = (config: AgentConfig): Model<any> => {
   //    flag here, so derive it from the user's `thinking` level (anything
   //    other than off / unset implies reasoning capability).
   if (api && baseUrl) {
+    // no reasoning for anthropic-compat endpoints: they reject pi-ai's thinking param (400 2013)
+    const reasoning =
+      api !== 'anthropic-messages' && (config.model.thinking ?? 'off') !== 'off';
     return {
       id: config.model.model,
       name: config.model.model,
       api,
       provider: config.model.provider,
       baseUrl,
-      reasoning: (config.model.thinking ?? 'off') !== 'off',
+      reasoning,
       input: ['text'],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 128000,

--- a/apps/agent/test/model-utils-resolve.test.ts
+++ b/apps/agent/test/model-utils-resolve.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { resolveModel } from '../src/agent-runner/model-utils.js';
+import type { AgentConfig } from '../src/core/index.js';
+
+const makeConfig = (model: Record<string, unknown>): AgentConfig =>
+  ({ model } as unknown as AgentConfig);
+
+describe('resolveModel reasoning derivation', () => {
+  test('MiniMax-M3 resolves with reasoning off (its factory suppresses thinking)', () => {
+    const resolved = resolveModel(
+      makeConfig({ provider: 'minimax', model: 'MiniMax-M3', max_tokens: 131072, thinking: 'medium' }),
+    );
+    // MiniMax's /anthropic rejects pi-ai's {type:"enabled",...} thinking param
+    // with 400 (2013); reasoning:false makes pi-ai emit no thinking param.
+    assert.equal(resolved.reasoning, false);
+    assert.equal(resolved.api, 'anthropic-messages');
+    assert.equal(resolved.id, 'MiniMax-M3');
+  });
+
+  test('real Anthropic registry model keeps its reasoning flag (unaffected)', () => {
+    const resolved = resolveModel(
+      makeConfig({ provider: 'anthropic', model: 'claude-opus-4-5', max_tokens: 8192, thinking: 'high' }),
+    );
+    assert.equal(resolved.reasoning, true);
+  });
+
+  test('synthesized openai-completions model derives reasoning from thinking', () => {
+    const resolved = resolveModel(
+      makeConfig({ provider: 'some-oai-compat', model: 'thinky-1', api: 'openai-completions', base_url: 'https://example.com/v1', max_tokens: 8192, thinking: 'medium' }),
+    );
+    assert.equal(resolved.reasoning, true);
+  });
+
+  test('synthesized anthropic-compat model never flags reasoning, even with thinking on', () => {
+    const resolved = resolveModel(
+      makeConfig({ provider: 'custom-anthropic-compat', model: 'some-model', api: 'anthropic-messages', base_url: 'https://example.com/anthropic', max_tokens: 8192, thinking: 'high' }),
+    );
+    assert.equal(resolved.reasoning, false);
+  });
+});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reasoning capability detection so reasoning is disabled by default for MiniMax M3.
  * Refined reasoning support for synthesized models to require both a non-Anthropic-messages endpoint and `thinking` not set to off.
  * Ensured compatible behavior across MiniMax, Anthropic, and OpenAI-compatible configurations when `thinking` is adjusted.
* **Tests**
  * Added automated coverage for `resolveModel` reasoning derivation across MiniMax, Anthropic, and OpenAI-compatible scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->