### PR TITLE
fix(gateway): isolate per-agent skill mount sync failures

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -2217,8 +2217,15 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     const ids = agentId === '*' ? instances.getRunningAgentIds() : [agentId];
     for (const id of ids) {
       const runner = instances.getRunner(id);
-      if (runner) {
+      if (!runner) continue;
+      // Best-effort per-agent: a runner whose exec backend has been shut down
+      // (e.g. idle timeout) throws "Sandbox is probably not running anymore".
+      // That must not fail the whole operation — the DB enable/disable already
+      // succeeded, and the sandbox re-mounts from listEnabled() on next start.
+      try {
         await syncSkillMounts(id, runner, store);
+      } catch (err) {
+        log(`[${id}] skill mount sync skipped: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   };


### PR DESCRIPTION
## Problem
Enabling a skill for `*` agents on a busy deployment returns:
```
500: {"error":{"code":"internal_error","message":"Sandbox is probably not running anymore"}}
```

## Root cause
`POST /api/admin/skills/:id/enable` does two things:
1. `store.enable('*', skillId)` — writes the DB row (**succeeds**).
2. `syncAffectedAgentSkillMounts('*')` — loops over **every running agent** and awaits `syncSkillMounts` serially, **with no per-agent error isolation**.

On a deployment with dozens of hot runners, some sandboxes have been shut down by idle timeout (`exec backends shut down (idle timeout)` in logs). The first dead sandbox makes `syncSkillMounts` throw `"Sandbox is probably not running anymore"`, aborting the loop → the endpoint 500s. The skill is actually enabled in the DB; only the live mount-sync failed.

## Fix
Wrap each agent's `syncSkillMounts` in try/catch (log + continue) — exactly what agent hydration (`agent-instance.ts:226`) already does. A dead/idle sandbox re-mounts enabled skills from `listEnabled()` on its next start, so skipping the live sync for it is safe.

The helper is shared by enable / disable / sync (5 call sites), so all of them stop being all-or-nothing.

## Verification
Gateway builds + typechecks; existing gateway tests pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill mount synchronization to be more resilient when an agent is unavailable or its runner is not active.
  * Skill enable/disable/sync actions now continue processing other agents even if one synchronization step fails, reducing request failures from backend issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->