### PR TITLE
fix(gateway): listen() before channel-pool start (boot healthcheck hotfix)

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -504,12 +504,17 @@ export const main = async (): Promise<void> => {
 
   const host = process.env.GATEWAY_HOST ?? '127.0.0.1';
 
+  const { server, info } = await listen(app.fetch, port, host);
+
   instances.setAdminToken(adminToken);
 
-  // Boot the channel pool BEFORE we start accepting requests, so every
-  // channel's outbound adapter is registered before any runner can hydrate.
-  // Otherwise a runner that hydrates mid-start comes up missing outbounds
-  // (canSend:false / session_send fails) and, being hot, stays that way (#210).
+  // Boot the channel pool. We listen() FIRST so /health responds immediately
+  // and boot never exceeds the platform healthcheck window — channel-pool
+  // start() (DB reads, token decryption, starting pollers for every channel)
+  // can take minutes on large deployments. Outbound adapters registered here
+  // are still picked up by hot/hydrating runners via
+  // AgentInstanceManager.syncOutbounds(), which re-syncs on every serve, so
+  // canSend/session_send stay accurate regardless of start() timing (#210).
   // The pool owns Telegram/Slack/Discord bridges independently of runners;
   // bridges call back via loopback HTTP, hydrating the runner on demand.
   let channelPool: ChannelPool | undefined;
@@ -525,9 +530,9 @@ export const main = async (): Promise<void> => {
         secretStore,
         channelRegistry: channels,
         manifestRegistry,
-        // Channel adapters connect back from inside the host over loopback.
-        // Use the resolved `port` (the listener binds it just below).
-        gatewayBaseUrl: `http://127.0.0.1:${port}`,
+        // Channel adapters connect back from inside the host. Use
+        // 127.0.0.1 even when the public listener is 0.0.0.0.
+        gatewayBaseUrl: `http://127.0.0.1:${info.port}`,
         ...(publicGatewayBaseUrl ? { publicGatewayBaseUrl } : {}),
         getRunner: (agentId) => instances.getRunner(agentId),
         log: logStartup,
@@ -543,8 +548,6 @@ export const main = async (): Promise<void> => {
       logStartup('channel pool skipped (no secret store available)');
     }
   }
-
-  const { server, info } = await listen(app.fetch, port, host);
 
   attachGatewayWs(server as import('node:http').Server, {
     instances,


### PR DESCRIPTION
## Incident
`railway redeploy` of amiko-openhermit (pulling main with #217) **failed healthcheck** — `/health` never bound within the 3-minute window, `1/1 replicas never became healthy`, taking production down.

## Cause
#217 moved `channelPool.start()` **before** `listen()`. On amiko-openhermit (many channels), `start()` — DB reads, token decryption, starting Telegram/WeChat pollers — takes minutes. With it ahead of `listen()`, `/health` doesn't respond until it finishes, blowing past the 3-min healthcheck.

## Fix
Restore `listen()` before the pool boot so `/health` responds immediately. The canSend fix from #217 is **retained** — `AgentInstanceManager.syncOutbounds()` re-syncs the pool's outbounds onto every runner on every serve, so ordering no longer matters for correctness. Only the harmful reorder is reverted.

## Verification
Gateway builds + typechecks; tests 5/5. Deploying this to restore prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The gateway now starts accepting HTTP requests sooner, so health checks respond immediately instead of waiting for background startup work.
  * Request handling is no longer delayed by channel-pool initialization, improving startup responsiveness.
  * Gateway connections now use the actual listening port, helping ensure requests and WebSocket traffic route correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->