### PR TITLE
fix: reconnect MCP server on next tool call after a transport error

### DIFF
--- a/apps/agent/src/mcp-client.ts
+++ b/apps/agent/src/mcp-client.ts
@@ -25,6 +25,8 @@ interface McpToolInfo {
 interface McpConnectionState {
   serverId: string;
   serverName: string;
+  /** Kept so a tool call that finds this connection in 'error' can reconnect. */
+  server: McpServerRecord;
   status: McpConnectionStatusValue;
   client?: Client;
   transport?: StreamableHTTPClientTransport;
@@ -61,6 +63,7 @@ export class McpClientManager {
     const state: McpConnectionState = {
       serverId: server.id,
       serverName: server.name,
+      server,
       status: 'connecting',
       tools: [],
     };
@@ -167,23 +170,38 @@ export class McpClientManager {
       description: mcpTool.description ?? `MCP tool from ${state.serverName}`,
       parameters: Type.Unsafe(mcpTool.inputSchema),
       execute: async (_toolCallId, params) => {
-        if (state.status === 'connecting') {
+        // Re-read the live connection state rather than the one captured when
+        // this tool wrapper was built — a prior call may have flipped it to
+        // 'error' (e.g. a transport failure mid-session), and a tool built
+        // before that happened would otherwise be stuck referencing a dead
+        // client forever with no way to recover.
+        let current = this.connections.get(state.serverId) ?? state;
+
+        if (current.status === 'error') {
+          // The upstream session may have simply expired; try once to
+          // reconnect before giving up, so the agent self-heals instead of
+          // requiring an owner to manually run mcp_enable again.
+          await this.connect(current.server).catch(() => {});
+          current = this.connections.get(state.serverId) ?? current;
+        }
+
+        if (current.status === 'connecting') {
           return {
             content: asTextContent(
-              `MCP server "${state.serverName}" is still connecting. Try again in a moment.`,
+              `MCP server "${current.serverName}" is still connecting. Try again in a moment.`,
             ),
             details: {},
           };
         }
-        if (!state.client || state.status !== 'connected') {
-          const detail = state.lastError ? ` (last error: ${state.lastError})` : '';
+        if (!current.client || current.status !== 'connected') {
+          const detail = current.lastError ? ` (last error: ${current.lastError})` : '';
           return {
-            content: asTextContent(`MCP server "${state.serverName}" is not connected${detail}.`),
+            content: asTextContent(`MCP server "${current.serverName}" is not connected${detail}.`),
             details: {},
           };
         }
         try {
-          const result = await state.client.callTool({
+          const result = await current.client.callTool({
             name: mcpTool.name,
             arguments: params as Record<string, unknown>,
           });
@@ -204,8 +222,8 @@ export class McpClientManager {
           };
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          state.status = 'error';
-          state.lastError = msg;
+          current.status = 'error';
+          current.lastError = msg;
           return {
             content: asTextContent(`MCP tool call failed: ${msg}`),
             details: {},

--- a/apps/agent/test/mcp-client.test.ts
+++ b/apps/agent/test/mcp-client.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { test } from 'node:test';
+import { randomUUID } from 'node:crypto';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import type { McpServerRecord } from '@openhermit/store';
+
+import { McpClientManager } from '../src/mcp-client.js';
+
+/**
+ * Spins up a real MCP server over Streamable HTTP, backed by a `flaky_tool`
+ * whose behavior is controlled at runtime via `behavior.mode`. This exercises
+ * the actual `StreamableHTTPClientTransport` code path in McpClientManager
+ * rather than mocking the transport away.
+ */
+async function startFlakyMcpServer(): Promise<{
+  url: string;
+  behavior: { mode: 'ok' | 'fail' };
+  close: () => Promise<void>;
+}> {
+  const behavior: { mode: 'ok' | 'fail' } = { mode: 'ok' };
+
+  // Each reconnect from the client sends a fresh `initialize` request, which
+  // a real MCP server treats as a new session. To exercise that faithfully
+  // (rather than a single pinned transport that would reject a second
+  // initialize), route requests to a transport-per-session-id, mirroring how
+  // a real stateful MCP HTTP server is typically wired.
+  const sessions = new Map<string, StreamableHTTPServerTransport>();
+
+  const createSession = (): StreamableHTTPServerTransport => {
+    const server = new McpServer({ name: 'flaky-test-server', version: '1.0.0' });
+    server.registerTool(
+      'flaky_tool',
+      { description: 'Returns ok.' },
+      async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    );
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => sessions.set(sessionId, transport),
+    });
+    void server.connect(transport);
+    return transport;
+  };
+
+  // `behavior.mode = 'fail'` simulates a dead/expired upstream session at the
+  // transport level (connection reset), which is what actually causes
+  // McpClientManager's callTool() promise to reject — as opposed to a tool
+  // handler returning `isError: true`, which is a normal in-band result and
+  // correctly does NOT tear down the connection.
+  const httpServer = http.createServer((req, res) => {
+    if (behavior.mode === 'fail') {
+      req.destroy();
+      return;
+    }
+    const sessionId = req.headers['mcp-session-id'];
+    const existing = typeof sessionId === 'string' ? sessions.get(sessionId) : undefined;
+    const transport = existing ?? createSession();
+    void transport.handleRequest(req, res);
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to bind test MCP server');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    behavior,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+test('[BUG REPRO] MCP client never recovers after a tool call fails mid-session', async () => {
+  const { url, behavior, close } = await startFlakyMcpServer();
+  try {
+    const manager = new McpClientManager();
+    const record: McpServerRecord = {
+      id: 'flaky',
+      name: 'Flaky Server',
+      description: 'test',
+      url,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+
+    await manager.connect(record);
+    assert.equal(manager.getStatus()[0]?.status, 'connected');
+
+    const [toolset] = manager.getToolsets();
+    const tool = toolset?.tools.find((t) => t.name === 'mcp__flaky__flaky_tool');
+    assert.ok(tool, 'expected flaky_tool to be present after connecting');
+
+    // First call succeeds.
+    const first = await tool.execute('call-1', {});
+    assert.equal((first.content[0] as { text: string }).text, 'ok');
+
+    // Upstream now fails (simulating an expired/dead session on the server side).
+    behavior.mode = 'fail';
+    const second = await tool.execute('call-2', {});
+    assert.match((second.content[0] as { text: string }).text, /MCP tool call failed/);
+    assert.equal(manager.getStatus()[0]?.status, 'error');
+
+    // Upstream recovers, but a healthy client should reconnect and let the
+    // twin keep using the tool instead of being stuck in 'error' forever.
+    behavior.mode = 'ok';
+    const third = await tool.execute('call-3', {});
+    assert.equal(
+      (third.content[0] as { text: string }).text,
+      'ok',
+      `expected the client to self-heal after upstream recovered, got: ${JSON.stringify(third)}`,
+    );
+    assert.equal(manager.getStatus()[0]?.status, 'connected');
+
+    await manager.disconnectAll();
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary
- `McpClientManager` marks a server connection `'error'` on any connect or `callTool` failure but never retries — every subsequent tool call against that server returns "not connected" forever, even after the upstream MCP server (e.g. a Composio Tool Router session) recovers. The only way out was an owner manually running `mcp_enable` again.
- `adaptTool`'s `execute()` now re-reads the live connection state (instead of the one captured when the tool wrapper was built) and attempts one reconnect via the stored `McpServerRecord` when it finds `status === 'error'`, before giving up.
- This is a generic fix at the MCP client layer — it protects any MCP server integration from this failure mode, not just Composio.

## Test plan
- [x] Added a regression test (`apps/agent/test/mcp-client.test.ts`) that spins up a real Streamable HTTP MCP server, kills the connection mid-session, and verifies the client self-heals on the next call. Fails on the original code, passes with the fix.
- [x] `npm run typecheck` in `apps/agent` — clean for this diff (2 pre-existing, unrelated errors in `test/tools.test.ts`/`test/user-store.test.ts` confirmed present with or without this change)
- [x] `npm run build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool-call handling so the app checks the current server connection status before running a tool.
  * Added automatic recovery when a server is in an error state, with better retry behavior and clearer failure messages.
  * Ensured connection failures are recorded against the active session so status updates stay accurate.

* **Tests**
  * Added end-to-end coverage for MCP self-healing after a failed tool call, including reconnect and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->