### PR TITLE
fix(channels): recover from stale sessions across all channel bridges (root fix)

### DIFF
--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -206,7 +206,18 @@ export class DiscordBridge implements ChannelOutbound {
     sessionId: string,
     text: string,
   ): Promise<void> {
-    await this.ensureSession(sessionId, event);
+    // A recovered session id may no longer be reopenable (stale/migrated, or
+    // a different resolved identity) — the agent API returns 404 Session not
+    // found. Fall back to a fresh session instead of failing the message.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, event),
+      () => {
+        const fresh = DiscordBridge.generateSessionId();
+        this.channelSessions.set(event.channelId, fresh);
+        return fresh;
+      },
+    );
 
     const resolved = await this.resolveInbound(sessionId, event, text);
     // Nothing usable (e.g. all attachments failed to fetch and no text).

--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
@@ -163,9 +163,20 @@ export class SignalBridge implements ChannelOutbound {
     if (msg.isSelf) return;
 
     const key = conversationKey(msg);
-    const sessionId = await this.getSessionId(key, msg);
+    let sessionId = await this.getSessionId(key, msg);
     const senderChannelUserId = msg.sourceUuid ?? msg.sourceNumber ?? 'unknown';
-    await this.ensureSession(sessionId, msg, senderChannelUserId);
+    // A recovered session id may no longer be reopenable (stale/migrated, or
+    // a different resolved identity) — the agent API returns 404 Session not
+    // found. Fall back to a fresh session instead of failing the message.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, msg, senderChannelUserId),
+      () => {
+        const fresh = generateSessionId();
+        this.conversationSessions.set(key, fresh);
+        return fresh;
+      },
+    );
 
     // Resolve attachments: audio is transcribed via STT; other media is
     // uploaded as a durable session attachment (images become vision input).

--- a/apps/channels/slack/src/bridge.ts
+++ b/apps/channels/slack/src/bridge.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -194,7 +194,18 @@ export class SlackBridge implements ChannelOutbound {
     mentioned: boolean,
     threadTs?: string,
   ): Promise<void> {
-    await this.ensureSession(sessionId, event, isDm, threadTs);
+    // A recovered session id may no longer be reopenable (stale/migrated, or
+    // a different resolved identity) — the agent API returns 404 Session not
+    // found. Fall back to a fresh session instead of failing the message.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, event, isDm, threadTs),
+      () => {
+        const fresh = SlackBridge.generateSessionId();
+        this.channelSessions.set(this.sessionKey(channelId, threadTs), fresh);
+        return fresh;
+      },
+    );
 
     let displayName: string | undefined;
     if (event.user) {

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type { ChannelMessageAction, ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
 import { stripSilenceTokens } from '@openhermit/shared';
 
@@ -403,8 +403,6 @@ export class TelegramBridge implements ChannelOutbound {
   ): Promise<void> {
     const mentioned = isGroup ? await this.isMentioned(message) : true;
 
-    await this.ensureSession(sessionId, message, isGroup);
-
     const displayName = message.from?.first_name || message.from?.username;
     const senderPayload = message.from
       ? {
@@ -416,14 +414,30 @@ export class TelegramBridge implements ChannelOutbound {
         }
       : {};
 
+    // `getSessionId` may recover a persisted session id the current runner
+    // can no longer reopen (stale/migrated session, or one belonging to a
+    // different resolved identity) — the agent API then returns
+    // `404 Session not found`. Fall back to a fresh session so the message
+    // still gets through instead of surfacing "something went wrong".
+    const sid = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, message, isGroup),
+      () => {
+        const fresh = TelegramBridge.generateSessionId();
+        this.chatSessions.set(chatId, fresh);
+        this.log(`stale session ${sessionId} for chat ${chatId}; started fresh ${fresh}`);
+        return fresh;
+      },
+    );
+
     // Upload any inbound photo/document/video as a session attachment
     // (images become vision input automatically).
-    const attachments = await this.resolveMediaAttachment(message, sessionId);
+    const attachments = await this.resolveMediaAttachment(message, sid);
 
     // Media-only message whose upload failed: nothing usable to forward.
     if (!text && attachments.length === 0) return;
 
-    const postResult = await this.client.postMessage(sessionId, {
+    const postResult = await this.client.postMessage(sid, {
       text,
       mentioned,
       ...(attachments.length > 0 ? { attachments } : {}),
@@ -434,7 +448,7 @@ export class TelegramBridge implements ChannelOutbound {
 
     void this.telegram.sendChatAction(chatId).catch(() => undefined);
 
-    const result = await this.waitForAgentResponse(sessionId, chatId, inboundWasVoice);
+    const result = await this.waitForAgentResponse(sid, chatId, inboundWasVoice);
 
     if (result.error && !result.text) {
       await this.telegram.sendMessage(chatId, `Error: ${result.error}`);
@@ -442,10 +456,10 @@ export class TelegramBridge implements ChannelOutbound {
       if (inboundWasVoice) {
         const sent = await this.trySendVoiceReply(chatId, result.text);
         if (!sent) {
-          await this.send({ sessionId, to: String(chatId), text: result.text });
+          await this.send({ sessionId: sid, to: String(chatId), text: result.text });
         }
       } else {
-        await this.send({ sessionId, to: String(chatId), text: result.text });
+        await this.send({ sessionId: sid, to: String(chatId), text: result.text });
       }
     }
   }

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -8,7 +8,7 @@
  */
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
@@ -534,8 +534,19 @@ export class WechatBridge implements ChannelOutbound {
     const turnContextToken = msg.context_token?.trim();
 
     const isGroup = Boolean(msg.group_id?.trim());
-    const sessionId = await this.getSessionId(peer, isGroup);
-    await this.ensureSession(sessionId, msg, isGroup);
+    let sessionId = await this.getSessionId(peer, isGroup);
+    // A recovered session id may no longer be reopenable (stale/migrated, or
+    // a different resolved identity) — the agent API returns 404 Session not
+    // found. Fall back to a fresh session instead of failing the message.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, msg, isGroup),
+      () => {
+        const fresh = WechatBridge.generateSessionId();
+        this.peerSessions.set(peer, fresh);
+        return fresh;
+      },
+    );
 
     // Download + decrypt inbound images and upload them as session
     // attachments (images become vision input). Text/captions are kept.

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -1,4 +1,4 @@
-import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
@@ -157,8 +157,20 @@ export class WhatsAppBridge implements ChannelOutbound {
       return;
     }
 
-    const sessionId = await this.getSessionId(event.chatJid);
-    await this.ensureSession(sessionId, event);
+    let sessionId = await this.getSessionId(event.chatJid);
+    // A recovered session id may no longer be reopenable (stale/migrated, or
+    // a different resolved identity) — the agent API returns 404 Session not
+    // found. Fall back to a fresh session instead of failing the message.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, event),
+      () => {
+        const normalized = normalizeJid(event.chatJid);
+        const fresh = generateSessionId(isGroupJid(normalized));
+        this.chatSessions.set(normalized, fresh);
+        return fresh;
+      },
+    );
 
     // Resolve media: inbound voice/audio is transcribed via STT; other media
     // is uploaded as a durable attachment so the agent can read/see it.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -59,6 +59,52 @@ export interface AgentLocalClientOptions {
   fetch?: FetchLike;
 }
 
+/**
+ * True when an agent-local API error means the target session can't be
+ * (re)opened for the current caller — either it no longer exists, or the
+ * resolved sender isn't a participant. Channel bridges hit this when
+ * `getSessionId` recovers a persisted session id from a previous
+ * deployment / migration (or one belonging to a different identity): the
+ * runner rejects the reopen with `404 Session not found`.
+ */
+export const isSessionNotFoundError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('404') && msg.includes('Session not found');
+};
+
+/**
+ * Open a channel session, falling back to a fresh one when the recovered id
+ * can't be reopened (`404 Session not found`). Channel bridges recover a
+ * chat's most-recent session via `listSessions`, but that session may be
+ * stale (previous deployment) or belong to a different resolved identity —
+ * reopening it then 404s and, historically, surfaced to the user as
+ * "something went wrong". This retries once against a fresh session so the
+ * message still gets through.
+ *
+ * `open(id)` must open/create the session (i.e. call `openSession`).
+ * `freshSessionId()` must mint a new id AND update the bridge's per-chat
+ * cache so subsequent messages reuse it. Returns the id actually opened.
+ *
+ * Only the open/reopen step needs wrapping: once a session is open in the
+ * runner, the follow-up `postMessage` finds it in memory and won't 404.
+ * Errors other than a stale-session 404 propagate unchanged.
+ */
+export const openSessionWithFreshFallback = async (
+  sessionId: string,
+  open: (id: string) => Promise<unknown>,
+  freshSessionId: () => string,
+): Promise<string> => {
+  try {
+    await open(sessionId);
+    return sessionId;
+  } catch (err) {
+    if (!isSessionNotFoundError(err)) throw err;
+    const fresh = freshSessionId();
+    await open(fresh);
+    return fresh;
+  }
+};
+
 export class AgentLocalClient {
   private readonly fetchImpl: FetchLike;
 

--- a/packages/sdk/test/index.test.ts
+++ b/packages/sdk/test/index.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { AgentLocalClient, GatewayClient } from '../src/index.js';
+import { AgentLocalClient, GatewayClient, isSessionNotFoundError, openSessionWithFreshFallback } from '../src/index.js';
 
 test('AgentLocalClient surfaces network failures with a helpful local-agent message', async () => {
   const client = new AgentLocalClient({
@@ -234,4 +234,58 @@ test('synthesizeAudio decodes base64 response back into Uint8Array', async () =>
 
   assert.deepEqual(Array.from(result.bytes), [9, 8, 7]);
   assert.equal(result.mimeType, 'audio/ogg');
+});
+
+test('isSessionNotFoundError detects a stale-session 404 from the agent API', () => {
+  const err = new Error(
+    'Agent local API request failed (404): {"error":{"code":"not_found","message":"Session not found: telegram:2026-05-27-c6fb1431"}}',
+  );
+  assert.equal(isSessionNotFoundError(err), true);
+});
+
+test('isSessionNotFoundError ignores unrelated errors', () => {
+  assert.equal(isSessionNotFoundError(new Error('Agent local API request failed (500): boom')), false);
+  assert.equal(isSessionNotFoundError(new Error('404: Not Found')), false);
+  assert.equal(isSessionNotFoundError(new Error('Session not found')), false);
+  assert.equal(isSessionNotFoundError('random string'), false);
+});
+
+test('openSessionWithFreshFallback returns the original id when open succeeds', async () => {
+  const opened: string[] = [];
+  const id = await openSessionWithFreshFallback(
+    'telegram:orig',
+    async (sid) => { opened.push(sid); },
+    () => { throw new Error('should not mint a fresh id'); },
+  );
+  assert.equal(id, 'telegram:orig');
+  assert.deepEqual(opened, ['telegram:orig']);
+});
+
+test('openSessionWithFreshFallback mints a fresh session on a stale-session 404', async () => {
+  const opened: string[] = [];
+  const id = await openSessionWithFreshFallback(
+    'telegram:stale',
+    async (sid) => {
+      opened.push(sid);
+      if (sid === 'telegram:stale') {
+        throw new Error('Agent local API request failed (404): Session not found: telegram:stale');
+      }
+    },
+    () => 'telegram:fresh',
+  );
+  assert.equal(id, 'telegram:fresh');
+  assert.deepEqual(opened, ['telegram:stale', 'telegram:fresh']);
+});
+
+test('openSessionWithFreshFallback rethrows non-404 errors without retrying', async () => {
+  let calls = 0;
+  await assert.rejects(
+    openSessionWithFreshFallback(
+      'telegram:x',
+      async () => { calls += 1; throw new Error('Agent local API request failed (500): boom'); },
+      () => 'telegram:fresh',
+    ),
+    /500/,
+  );
+  assert.equal(calls, 1);
 });


### PR DESCRIPTION
Supersedes the telegram-only retry this PR originally contained — now a shared, all-channel root fix.

## Symptom
On production (agent `Will`, telegram), every inbound message failed with "Sorry, something went wrong. Please try again." — nothing reached the agent; only `/new` worked.

## Root cause (confirmed from prod logs)
```
[cmewkyjkh…] [telegram] error handling message from chat 656756615:
  Agent local API request failed (404):
  {"error":{"code":"not_found","message":"Session not found: telegram:2026-05-27-c6fb1431"}}
```
After a gateway restart a bridge's in-memory chat→session cache is empty, so `getSessionId` recovers the chat's most-recent persisted session via `listSessions` — here a **2026-05-27** session. The runner rejects reopening it with `404 Session not found`.

Crucially this 404 is **deliberate access control** (`agent-runner.ts` `openSession`/`ensureSessionLoaded`): reopen is refused when the resolved sender isn't a participant of that session. So a server-side `openSession` "upsert" is **not** an option — it would let anyone post into a session they don't belong to. The correct behavior is what `/new` does: start a fresh session.

## Fix (shared layer → all 6 channels)
- **SDK**: `isSessionNotFoundError` + `openSessionWithFreshFallback(sessionId, open, freshSessionId)`. Opens a session; on a stale-session 404, mints a fresh id (updating the bridge's per-chat cache) and reopens once. Only the open/reopen step is wrapped — once open, `postMessage` finds the session in memory and won't 404. Non-404 errors propagate unchanged.
- **Bridges** (telegram, discord, slack, whatsapp, signal, wechat): wrap the `ensureSession` call in `sendToAgent` with the helper. Each mints its own channel-formatted fresh id and updates its own cache.

Why the helper (not per-bridge copies): all six bridges share the exact same `getSessionId`(listSessions-recover) → `ensureSession` → `postMessage` seam, so one tested helper fixes them uniformly.

## Verification
- Typecheck + build clean for SDK, all 6 bridges, and the gateway.
- SDK unit tests cover the helper's 4 paths (success / stale-404 retry / non-404 rethrow / no-mint-on-success); 5 new tests pass.
- Matches the manual `/new` workaround that already unblocked the user in prod.
- (One pre-existing SDK test — `surfaces network failures` — fails on clean `main` too; unrelated, an outdated assertion regex.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session handling now automatically recovers from stale or unavailable chat sessions by creating a fresh session and continuing the conversation.
  * Message delivery is now more resilient across Telegram, Discord, Signal, Slack, WeChat, and WhatsApp.
* **Bug Fixes**
  * Reduced failed inbound and outbound messages caused by session re-open errors.
  * Replies and attachments now route to the recovered session so conversations stay on track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->