### PR TITLE
fix(channels): move session-recovery helper to @openhermit/shared (fixes 'no manifest registered')

### DIFF
--- a/apps/channels/discord/src/bridge.ts
+++ b/apps/channels/discord/src/bridge.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import type { DiscordApi, DiscordMessageEvent } from './discord-api.js';
 import { formatAgentResponse, markdownToDiscord } from './formatting.js';

--- a/apps/channels/signal/src/bridge.ts
+++ b/apps/channels/signal/src/bridge.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
   OutboundSession,
 } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import type { SendOptions, SignalApi, SignalIncomingMessage } from './signal-api.js';
 import { formatAgentResponse } from './formatting.js';

--- a/apps/channels/slack/src/bridge.ts
+++ b/apps/channels/slack/src/bridge.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import type { SlackApi, SlackMessageEvent } from './slack-api.js';
 import { formatAgentResponse, markdownToSlackMrkdwn } from './formatting.js';

--- a/apps/channels/telegram/src/bridge.ts
+++ b/apps/channels/telegram/src/bridge.ts
@@ -5,9 +5,9 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type { ChannelMessageAction, ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import type { TelegramApi, TelegramCallbackQuery, TelegramMessage, TelegramMessageEntity, TelegramUser } from './telegram-api.js';
 import {

--- a/apps/channels/wechat/src/bridge.ts
+++ b/apps/channels/wechat/src/bridge.ts
@@ -8,14 +8,14 @@
  */
 import { randomUUID } from 'node:crypto';
 
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
   OutboundSession,
 } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import { sendMessage } from './ilink/api.js';
 import {

--- a/apps/channels/whatsapp/src/bridge.ts
+++ b/apps/channels/whatsapp/src/bridge.ts
@@ -1,11 +1,11 @@
-import { AgentLocalClient, parseSseFrames, openSessionWithFreshFallback } from '@openhermit/sdk';
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
 import type {
   ChannelMessageAction,
   ChannelOutbound,
   ChannelOutboundResult,
   OutboundSession,
 } from '@openhermit/protocol';
-import { stripSilenceTokens } from '@openhermit/shared';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
 
 import { formatAgentResponse } from './formatting.js';
 import {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -59,52 +59,6 @@ export interface AgentLocalClientOptions {
   fetch?: FetchLike;
 }
 
-/**
- * True when an agent-local API error means the target session can't be
- * (re)opened for the current caller — either it no longer exists, or the
- * resolved sender isn't a participant. Channel bridges hit this when
- * `getSessionId` recovers a persisted session id from a previous
- * deployment / migration (or one belonging to a different identity): the
- * runner rejects the reopen with `404 Session not found`.
- */
-export const isSessionNotFoundError = (err: unknown): boolean => {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg.includes('404') && msg.includes('Session not found');
-};
-
-/**
- * Open a channel session, falling back to a fresh one when the recovered id
- * can't be reopened (`404 Session not found`). Channel bridges recover a
- * chat's most-recent session via `listSessions`, but that session may be
- * stale (previous deployment) or belong to a different resolved identity —
- * reopening it then 404s and, historically, surfaced to the user as
- * "something went wrong". This retries once against a fresh session so the
- * message still gets through.
- *
- * `open(id)` must open/create the session (i.e. call `openSession`).
- * `freshSessionId()` must mint a new id AND update the bridge's per-chat
- * cache so subsequent messages reuse it. Returns the id actually opened.
- *
- * Only the open/reopen step needs wrapping: once a session is open in the
- * runner, the follow-up `postMessage` finds it in memory and won't 404.
- * Errors other than a stale-session 404 propagate unchanged.
- */
-export const openSessionWithFreshFallback = async (
-  sessionId: string,
-  open: (id: string) => Promise<unknown>,
-  freshSessionId: () => string,
-): Promise<string> => {
-  try {
-    await open(sessionId);
-    return sessionId;
-  } catch (err) {
-    if (!isSessionNotFoundError(err)) throw err;
-    const fresh = freshSessionId();
-    await open(fresh);
-    return fresh;
-  }
-};
-
 export class AgentLocalClient {
   private readonly fetchImpl: FetchLike;
 

--- a/packages/sdk/test/index.test.ts
+++ b/packages/sdk/test/index.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { AgentLocalClient, GatewayClient, isSessionNotFoundError, openSessionWithFreshFallback } from '../src/index.js';
+import { AgentLocalClient, GatewayClient } from '../src/index.js';
 
 test('AgentLocalClient surfaces network failures with a helpful local-agent message', async () => {
   const client = new AgentLocalClient({
@@ -234,58 +234,4 @@ test('synthesizeAudio decodes base64 response back into Uint8Array', async () =>
 
   assert.deepEqual(Array.from(result.bytes), [9, 8, 7]);
   assert.equal(result.mimeType, 'audio/ogg');
-});
-
-test('isSessionNotFoundError detects a stale-session 404 from the agent API', () => {
-  const err = new Error(
-    'Agent local API request failed (404): {"error":{"code":"not_found","message":"Session not found: telegram:2026-05-27-c6fb1431"}}',
-  );
-  assert.equal(isSessionNotFoundError(err), true);
-});
-
-test('isSessionNotFoundError ignores unrelated errors', () => {
-  assert.equal(isSessionNotFoundError(new Error('Agent local API request failed (500): boom')), false);
-  assert.equal(isSessionNotFoundError(new Error('404: Not Found')), false);
-  assert.equal(isSessionNotFoundError(new Error('Session not found')), false);
-  assert.equal(isSessionNotFoundError('random string'), false);
-});
-
-test('openSessionWithFreshFallback returns the original id when open succeeds', async () => {
-  const opened: string[] = [];
-  const id = await openSessionWithFreshFallback(
-    'telegram:orig',
-    async (sid) => { opened.push(sid); },
-    () => { throw new Error('should not mint a fresh id'); },
-  );
-  assert.equal(id, 'telegram:orig');
-  assert.deepEqual(opened, ['telegram:orig']);
-});
-
-test('openSessionWithFreshFallback mints a fresh session on a stale-session 404', async () => {
-  const opened: string[] = [];
-  const id = await openSessionWithFreshFallback(
-    'telegram:stale',
-    async (sid) => {
-      opened.push(sid);
-      if (sid === 'telegram:stale') {
-        throw new Error('Agent local API request failed (404): Session not found: telegram:stale');
-      }
-    },
-    () => 'telegram:fresh',
-  );
-  assert.equal(id, 'telegram:fresh');
-  assert.deepEqual(opened, ['telegram:stale', 'telegram:fresh']);
-});
-
-test('openSessionWithFreshFallback rethrows non-404 errors without retrying', async () => {
-  let calls = 0;
-  await assert.rejects(
-    openSessionWithFreshFallback(
-      'telegram:x',
-      async () => { calls += 1; throw new Error('Agent local API request failed (500): boom'); },
-      () => 'telegram:fresh',
-    ),
-    /500/,
-  );
-  assert.equal(calls, 1);
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -115,3 +115,8 @@ export const requireEnv = (name: string): string => {
 
   return value;
 };
+
+export {
+  isSessionNotFoundError,
+  openSessionWithFreshFallback,
+} from './session-recovery.js';

--- a/packages/shared/src/session-recovery.ts
+++ b/packages/shared/src/session-recovery.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared session-recovery helpers for channel bridges.
+ *
+ * Lives in @openhermit/shared (not @openhermit/sdk) on purpose: channel
+ * packages pin `@openhermit/shared` to an exact workspace version, so it is
+ * always resolved to the workspace copy — whereas `@openhermit/sdk` is a
+ * caret range that npm may satisfy with a nested published copy, which would
+ * not carry newly-added exports.
+ */
+
+/**
+ * True when an agent-local API error means the target session can't be
+ * (re)opened for the current caller — either it no longer exists, or the
+ * resolved sender isn't a participant. Channel bridges hit this when
+ * `getSessionId` recovers a persisted session id from a previous
+ * deployment / migration (or one belonging to a different identity): the
+ * runner rejects the reopen with `404 Session not found`.
+ */
+export const isSessionNotFoundError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('404') && msg.includes('Session not found');
+};
+
+/**
+ * Open a channel session, falling back to a fresh one when the recovered id
+ * can't be reopened (`404 Session not found`). Channel bridges recover a
+ * chat's most-recent session via `listSessions`, but that session may be
+ * stale (previous deployment) or belong to a different resolved identity —
+ * reopening it then 404s and, historically, surfaced to the user as
+ * "something went wrong". This retries once against a fresh session so the
+ * message still gets through.
+ *
+ * `open(id)` must open/create the session (i.e. call `openSession`).
+ * `freshSessionId()` must mint a new id AND update the bridge's per-chat
+ * cache so subsequent messages reuse it. Returns the id actually opened.
+ *
+ * Only the open/reopen step needs wrapping: once a session is open in the
+ * runner, the follow-up `postMessage` finds it in memory and won't 404.
+ * Errors other than a stale-session 404 propagate unchanged.
+ */
+export const openSessionWithFreshFallback = async (
+  sessionId: string,
+  open: (id: string) => Promise<unknown>,
+  freshSessionId: () => string,
+): Promise<string> => {
+  try {
+    await open(sessionId);
+    return sessionId;
+  } catch (err) {
+    if (!isSessionNotFoundError(err)) throw err;
+    const fresh = freshSessionId();
+    await open(fresh);
+    return fresh;
+  }
+};

--- a/packages/shared/test/session-recovery.test.ts
+++ b/packages/shared/test/session-recovery.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSessionNotFoundError, openSessionWithFreshFallback } from '../src/index.js';
+
+test('isSessionNotFoundError detects a stale-session 404 from the agent API', () => {
+  const err = new Error(
+    'Agent local API request failed (404): {"error":{"code":"not_found","message":"Session not found: telegram:2026-05-27-c6fb1431"}}',
+  );
+  assert.equal(isSessionNotFoundError(err), true);
+});
+
+test('isSessionNotFoundError ignores unrelated errors', () => {
+  assert.equal(isSessionNotFoundError(new Error('Agent local API request failed (500): boom')), false);
+  assert.equal(isSessionNotFoundError(new Error('404: Not Found')), false);
+  assert.equal(isSessionNotFoundError(new Error('Session not found')), false);
+  assert.equal(isSessionNotFoundError('random string'), false);
+});
+
+test('openSessionWithFreshFallback returns the original id when open succeeds', async () => {
+  const opened: string[] = [];
+  const id = await openSessionWithFreshFallback(
+    'telegram:orig',
+    async (sid) => { opened.push(sid); },
+    () => { throw new Error('should not mint a fresh id'); },
+  );
+  assert.equal(id, 'telegram:orig');
+  assert.deepEqual(opened, ['telegram:orig']);
+});
+
+test('openSessionWithFreshFallback mints a fresh session on a stale-session 404', async () => {
+  const opened: string[] = [];
+  const id = await openSessionWithFreshFallback(
+    'telegram:stale',
+    async (sid) => {
+      opened.push(sid);
+      if (sid === 'telegram:stale') {
+        throw new Error('Agent local API request failed (404): Session not found: telegram:stale');
+      }
+    },
+    () => 'telegram:fresh',
+  );
+  assert.equal(id, 'telegram:fresh');
+  assert.deepEqual(opened, ['telegram:stale', 'telegram:fresh']);
+});
+
+test('openSessionWithFreshFallback rethrows non-404 errors without retrying', async () => {
+  let calls = 0;
+  await assert.rejects(
+    openSessionWithFreshFallback(
+      'telegram:x',
+      async () => { calls += 1; throw new Error('Agent local API request failed (500): boom'); },
+      () => 'telegram:fresh',
+    ),
+    /500/,
+  );
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
## Symptom
On amiko-openhermit (and reproduced on test), the channel-manage page showed **"no manifest registered for channel"** for telegram/slack/discord/wechat — those channels failed to load and couldn't start.

## Root cause
The stale-session recovery helper added in #222 lives in `@openhermit/sdk`. Channel packages depend on the SDK via `"^0.6.0"`, but the workspace SDK is `0.7.0` — which `^0.6.0` does **not** satisfy. So npm installs a **nested published `0.6.x`** copy under each channel:
```
apps/channels/telegram/node_modules/@openhermit/sdk   (0.6.1, published — no new export)
node_modules/@openhermit/sdk → packages/sdk           (0.7.0, has export — unused by channel)
```
The channels resolve the nested `0.6.1` (which has `AgentLocalClient` etc. but not `openSessionWithFreshFallback`) → the whole manifest module throws on import → "no manifest registered". whatsapp escaped it (pins `^0.7.0`).

Bumping the dep didn't fix it reliably: **npm won't prune an already-installed nested copy**, and amiko's deploy reuses a persistent volume (`git reset --hard` + `npm install`, no clean install), so the stale `0.6.1` lingers.

## Fix
Move the helper to `@openhermit/shared`, which channels pin to an **exact** workspace version (`"0.2.0"`). Exact match means npm **always** links the workspace copy — no nested copies are ever created — so a newly-added export is reliably visible regardless of hoisting/prune behavior.

- `@openhermit/shared`: add `isSessionNotFoundError` + `openSessionWithFreshFallback` (+ unit tests). Reverted the same from `@openhermit/sdk`.
- All six bridges import the helper from `@openhermit/shared`.

## Verification
- Typecheck + build clean for shared, sdk, all six channels.
- shared tests 14/14 (5 new).
- **All six channels load successfully even while a stale nested `@openhermit/sdk` 0.6.1 is still present** — confirming the fix doesn't depend on npm pruning.
- No package.json / lockfile changes (dep bumps reverted; helper location is the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery when a connection reports a stale or missing session, helping channel bridges retry more reliably instead of failing immediately.
  * Applied the same behavior across multiple messaging channels for more consistent reconnect handling.

* **Tests**
  * Added coverage for session recovery and retry behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->