### PR TITLE
fix(agent): track caller channel identity per message, not per session

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1125,6 +1125,14 @@ export class AgentRunner implements SessionRuntime {
     let messageUserId = session.resolvedUserId;
     if (message.sender) {
       const now = new Date().toISOString();
+      // Track the raw channel identity of THIS message's sender. The toolset
+      // is rebuilt every turn (refreshAgentConfiguration) from these fields,
+      // so caller-scoped tools (e.g. identity_link_*) must reflect who sent
+      // the current message — not whoever opened the session. Matters in
+      // group sessions where a later, different sender joins, and for external
+      // channels (e.g. amiko) whose per-session id can't be derived.
+      if (message.sender.channel) session.resolvedChannel = message.sender.channel;
+      if (message.sender.channelUserId) session.resolvedChannelUserId = message.sender.channelUserId;
       const resolved = await this.resolveMessageSender(message.sender, now);
       if (resolved.userId) {
         messageUserId = resolved.userId;


### PR DESCRIPTION
## Symptom
On amiko-openhermit, confirming identity with an agent failed:
```
identity_link_confirm requires a known caller channel.
```

## Root cause
`refreshAgentConfiguration` rebuilds the toolset **every turn** from `session.resolved*`. The per-message sender block (agent-runner.ts) already updates `resolvedUserId` / `resolvedUserRole` from `message.sender` — so **user- and role-scoped tools already follow the actual message sender** (correct for the group case: a higher-role member who joins after a lower-role opener).

But that block never updated **`resolvedChannel` / `resolvedChannelUserId`**. So the caller's *channel identity* stayed pinned to the session opener — and for external channels like **amiko**, whose per-session channel-user id can't be derived (`deriveChannelUserId` only handles telegram/cli), it was simply `undefined`. Hence `currentChannelUserId` was empty and `identity_link_*` threw.

This also means, pre-fix, a group message from a *different* sender would be attributed (channel-identity-wise) to whoever opened the session — the exact correctness bug raised in review.

## Fix
Propagate the sender's raw channel identity per message, right where userId/role are already updated:
```js
if (message.sender.channel) session.resolvedChannel = message.sender.channel;
if (message.sender.channelUserId) session.resolvedChannelUserId = message.sender.channelUserId;
```
So `currentChannel` / `currentChannelUserId` reflect the sender of the triggering message, per turn.

**No channel-side change needed** — amiko (and every bridge, via `senderFor`) already sends `sender.{channel, channelUserId}` on each `postMessage`; core just wasn't propagating it. Supersedes the earlier idea of binding at session-open / adding an amiko branch to `deriveChannelUserId`.

## Verification
- `src` builds clean (`tsc -b`). The change is 2 lines, adjacent to the already-proven per-message `resolvedUserId`/`resolvedUserRole` update.
- (Runner integration tests require a live `DATABASE_URL`; the pre-existing test-file typecheck errors — 71 on clean `main` — are unrelated.)
- Live check after deploy: `identity_link_confirm` succeeds on amiko; a second group sender flips `currentChannelUserId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling so the app now keeps the current sender’s channel context in sync for each new message.
  * Fixed cases where group or external-channel conversations could incorrectly reuse the session opener’s identity instead of the active sender’s.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->