### PR TITLE
fix(agent): persist restored history on resume (context lost after first post-resume generation)

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2707,6 +2707,21 @@ export class AgentRunner implements SessionRuntime {
         supportsImageInput,
       });
       session.resumed = false;
+
+      // Seed the live agent state with the restored history so it PERSISTS
+      // for subsequent generations. Without this the restore is one-shot:
+      // it feeds only the first post-resume generation, then `state.messages`
+      // (which pi-ai keeps appending to from empty) holds just the messages
+      // accumulated since resume — so from the 2nd generation onward (e.g. a
+      // tool-loop turn, or the next user message) the session loses ALL prior
+      // context. Mutate in place to preserve the array reference pi-ai holds.
+      // `restoredMessages` already ends with the current user turn (persisted
+      // by postMessage before agent.prompt), matching pi-ai's single seeded
+      // message, so this replaces rather than duplicates it.
+      if (restoredMessages.length > 0) {
+        session.agent.state.messages.length = 0;
+        session.agent.state.messages.push(...restoredMessages);
+      }
     }
 
     if (sessionWorking.trim()) {


### PR DESCRIPTION
## Symptom
Agent "forgets" what was just discussed after an idle gap. Reproduced on agent Will (`amiko:cml7j6ez…`): user set an image spec, and later — after a ~10.5h idle gap — said "generate one," and the agent asked "what content?" despite having been told.

## Root cause (verified via session_events + Langfuse)
`transformContext` (per-generation hook, agent-runner.ts:2351) restores the full history from the DB **only when `session.resumed && messages.length <= 1`**, then clears `session.resumed` — and it **never writes the restored history into `session.agent.state.messages`**.

So the restore is **one-shot**: it feeds only the *first* generation after resume. pi-ai keeps appending to `state.messages` from empty, so:
- **1st generation after resume**: full history (Langfuse: 119k chars, image spec present). ✅
- **2nd generation onward** (tool-loop turn, or next user message): only messages accumulated since resume (Langfuse: ~5 messages, spec gone). ❌

**Not compaction:** no `context_compaction` event and no `openhermit.compaction` trace ran, and the context (~30k tokens) was far under the 128k budget. The earlier compaction hypothesis was wrong — the context simply wasn't retained past the first generation.

## Fix
After restoring, seed the live agent state with the restored history (mutating the array in place to preserve pi-ai's reference), so it persists across subsequent generations and turns. `restoredMessages` already ends with the current user turn, matching pi-ai's single seeded message, so it replaces rather than duplicates.

## Impact
Affects **every resumed session** (i.e. any agent after idle eviction) — the first reply works, then context collapses. This is a broad correctness fix.

## Verification plan
Deploy to test first; exercise a resumed session with a tool-loop turn + a follow-up message and confirm via Langfuse that later generations retain the full history. (No unit test added yet — the runner harness needs a live DB; will verify on test before prod.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)