### PR TITLE
fix(agent): don't user-policy-filter internal toolsets (introspection memory writes broken fleet-wide)

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2130,7 +2130,19 @@ export class AgentRunner implements SessionRuntime {
     const notifyOwner = this.makeNotifyOwnerApproval();
     const eventBroker = this.events;
 
-    const filteredTools = tools
+    // Explicitly-provided toolsets (`input.tools`) are internal runtime turns
+    // — introspection and compaction — whose tools are curated by the caller
+    // and run with no user principal. Do NOT apply user-policy filtering to
+    // them: the principal has no role, so role-granted tools (memory_add/
+    // memory_update: owner|user) and internal-only tools (working_memory_update:
+    // defaultGrants []) all evaluate to deny and get silently dropped — the
+    // model, whose prompt instructs it to call them, then gets "Tool X not
+    // found" (observed fleet-wide: 44k+ failed introspection memory writes).
+    // Introspection is documented as exempt from approval wrapping for the
+    // same reason.
+    const filteredTools = input.tools
+      ? tools
+      : tools
       .filter((t: any) => {
         const toolMatches = resolveToolMatches(policyRows, t.name, t.policy);
         const toolDecision = evaluateAccess(principal, toolMatches);


### PR DESCRIPTION
## Symptom
Introspection turns fail their memory writes with `Tool memory_add not found` / `Tool memory_update not found` — while `memory_get` / `memory_recall` work in the same run. Session `working_memory` is empty nearly everywhere.

## Fleet impact (prod, since 06-20)
- **44,556** "Tool not found" failures on introspection memory writes
- `workingMemoryUpdated` succeeded in only **54 of 166k** introspection runs
- (the `memoriesAdded: 26,970` introspection counter counts *attempted* `tool_call`s, not successes)

## Root cause
`createConfiguredAgent` filters **all** tools through the user-principal policy check (`buildPrincipal` + `evaluateAccess`) — including the explicitly-curated `input.tools` passed by **internal runtime turns** (introspection, compaction), which run with **no user principal**:

- `memory_add`/`memory_update`/`memory_delete` declare `defaultGrants: [role:owner, role:user]` → no-role principal → **deny → dropped from the list**
- `working_memory_update`/`session_description_update` declare `defaultGrants: []` (internal-only by design) → **always dropped**

Meanwhile the introspection prompt explicitly instructs: *"use memory_recall … then memory_add or memory_update"* → the model calls tools that aren't in its list → pi-agent-core returns "Tool X not found". Silent regression since `44e1868` (ToolPolicy on every tool, 2026-05-05). Agents with permissive DB policy rows escape it, which is why a minority of writes still succeeded.

## Fix
Skip principal/policy filtering when `input.tools` is explicitly provided. Internal callers own their toolset — introspection is already documented as exempt from approval wrapping for exactly this reason. Only two call sites use this path: introspection (curated internal tools) and compaction (`tools: []`). User-facing toolsets are built via `createBuiltInToolsets` and remain fully filtered.

## Verification
- `src` typechecks + builds clean.
- policy tests: 54/56 pass — the 2 failures are **pre-existing on clean `main`** (verified by stash), unrelated to this change (it doesn't touch `policy.ts`).
- Deploying to test to verify a live introspection run persists memory/working-memory (will confirm before prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified internal handling of runtime-provided tools during agent setup.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->