### PR TITLE
fix(agent): compaction hysteresis — compact below the trigger, not to it

### DIFF
--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -27,6 +27,14 @@ export const DEFAULT_CONTEXT_COMPACTION_MAX_TOKENS_CEILING = 160_000;
 // wire — which kills prompt caching and inflates per-turn latency.
 export const DEFAULT_CONTEXT_COMPACTION_MAX_MESSAGES = 80;
 
+/**
+ * Hysteresis ratio: when compaction triggers (at the token budget or the
+ * message-count cap), shrink down to this fraction of the threshold so the
+ * session has headroom before the next compaction. Without it, a compaction
+ * that lands exactly at the cap re-triggers on the very next message.
+ */
+export const COMPACTION_TARGET_RATIO = 0.75;
+
 // ── Token estimation ───────────────────────────────────────────────────
 
 export const estimateTextTokens = (text: string): number =>
@@ -573,11 +581,26 @@ export const compactContextIfNeeded = async (
     );
   };
 
+  // Hysteresis: compact DOWN TO a target below the trigger thresholds, not
+  // to the thresholds themselves. Compacting to exactly the cap leaves zero
+  // headroom — a couple of new messages re-trip the trigger, and (since the
+  // result is persisted back into the live state) the session pays another
+  // LLM summary + marker on nearly every generation. Targeting ~75% gives
+  // real headroom before the next genuine compaction.
+  const targetTokens = Math.floor(budget * COMPACTION_TARGET_RATIO);
+  // Floor at retainCountOption+1 so a small ratio can't compact below the
+  // configured recent-message retention — but never above the hard cap
+  // (recentMessageCount may legitimately exceed maxMessages in config).
+  const targetMessages = Math.min(
+    maxMessages,
+    Math.max(retainCountOption + 1, Math.floor(maxMessages * COMPACTION_TARGET_RATIO)),
+  );
+
   // First pass: find the retain count without LLM summary (text-extraction only).
   let compacted = buildCandidate(retainCount, undefined);
 
   while (
-    (effectiveTokens(compacted) > budget || compacted.length > maxMessages)
+    (effectiveTokens(compacted) > targetTokens || compacted.length > targetMessages)
     && retainCount > 1
   ) {
     retainCount -= 1;
@@ -585,13 +608,13 @@ export const compactContextIfNeeded = async (
   }
 
   // Expansion phase: grow retainCount as long as we stay under the
-  // token budget AND under the message-count cap. Without the count
+  // token target AND under the message-count target. Without the count
   // cap, count-only triggers (lots of tiny messages well below budget)
   // would expand right back to the full list and undo the compaction.
   while (retainCount < messages.length) {
     const expanded = buildCandidate(retainCount + 1, undefined);
 
-    if (effectiveTokens(expanded) > budget || expanded.length > maxMessages) {
+    if (effectiveTokens(expanded) > targetTokens || expanded.length > targetMessages) {
       break;
     }
 

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -958,3 +958,33 @@ test('TOOL_RESULT_MAX_CHARS_CAP caps inline tool result regardless of context wi
     `result kept ${resultText.length} chars, expected ≤ ~${TOOL_RESULT_MAX_CHARS_CAP}`);
   assert.ok(resultText.includes('[truncated:'));
 });
+
+test('compactContextIfNeeded compacts below the trigger with headroom (hysteresis)', async () => {
+  // Count-triggered compaction must land meaningfully BELOW maxMessages —
+  // landing exactly at the cap re-triggers (with another LLM summary call
+  // and marker) on the very next message once results are persisted.
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < 113; i += 1) {
+    messages.push(makeUserMessage(`note ${i}`));
+  }
+  const deps = createStubDeps({
+    options: {
+      contextCompactionMaxTokens: 1_000_000,
+      contextCompactionRecentMessageCount: 6,
+      contextCompactionMaxMessages: 80,
+    },
+  });
+
+  const result = await compactContextIfNeeded('s1', stubConfig, [], messages, deps);
+  // target = floor(80 * 0.75) = 60 (+1 leeway for the summary block)
+  assert.ok(
+    result.length <= 61,
+    `compacted to ${result.length} messages — expected ≤ 61 (75% of the 80 cap + summary block)`,
+  );
+  // Adding a handful of new messages must NOT re-trigger.
+  const afterGrowth = result.concat(
+    Array.from({ length: 5 }, (_, i) => makeUserMessage(`new ${i}`)),
+  );
+  const second = await compactContextIfNeeded('s1', stubConfig, [], afterGrowth, deps);
+  assert.equal(second.length, afterGrowth.length, 'no re-compaction within the headroom window');
+});


### PR DESCRIPTION
Follow-up to #228, found during its live verification on test.

## Symptom
With #228's write-back in place, a count-triggered compaction landed at **exactly** `maxMessages` (80). The next message put the session at 81+ → compaction re-triggered → another LLM summary call + `context_compaction` marker per generation — the same spam #228 set out to fix. Observed on test: 3 compactions across 2 turns (`113→80`, `82→80`, `84→80`).

## Fix
The shrink/expansion loops now target `COMPACTION_TARGET_RATIO` (**75%**) of the thresholds instead of the thresholds themselves — a compaction of an 80-cap session lands at ~60 messages, leaving real headroom before the next genuine compaction. Same for the token budget. Floored at `recentMessageCount + 1` (a small ratio must not undercut the configured retention), clamped to `maxMessages` (retention may exceed the cap in config — covered by an existing test).

## Tests
New regression test: count-triggered compaction lands ≤ 75% of cap and does **not** re-trigger after several new messages. Suite: **64/64 pass**; build clean.

Will re-run the live over-budget scenario on test after merge to confirm a single compaction across multiple turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)