### PR TITLE
chore(cli): bump to 0.10.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhermit",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "OpenHermit — multi-agent platform CLI & server",
   "type": "module",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,7 +249,7 @@
     },
     "apps/cli": {
       "name": "openhermit",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",


### PR DESCRIPTION
Version bump for npm release. 39 commits since 0.9.3 — notable:

**Features**: session_list enrichment + filters/pagination (#215) · universal session_send recipient resolution (#207) · external-channel outbound (#211) · MiniMax-M3 under openrouter (#213) · model sort (#214)

**Fixes**: resume context persistence (#226) · introspection memory writes (#227) · compaction boundary/write-back/hysteresis (#228/#229) · stale-session recovery all channels (#222/#223) · per-message channel identity (#224) · canSend re-sync (#217) · skill-mount isolation (#219) · boot order (#220) · fleetStats + cost clamp (#209/#216)

The published CLI is a self-contained tsup bundle, so all workspace fixes ship with it. Publish steps after merge: rebuild admin/web UI assets, `npm publish` from `apps/cli` (runs `prepublishOnly` = bundle + copy:assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)