### PR TITLE
feat(channels): Lark / Feishu channel plugin (@openhermit/channel-lark)

### DIFF
--- a/apps/channels/lark/README.md
+++ b/apps/channels/lark/README.md
@@ -2,8 +2,12 @@
 
 OpenHermit channel plugin for **Lark / 飞书 (Feishu)**.
 
-Uses the platform's **WebSocket long-connection** event mode — no public URL,
-webhook, or tunnel required. The gateway only needs outbound internet access.
+Two event delivery modes:
+
+- **WebSocket long connection** (default) — no public URL, webhook, or tunnel
+  required; the gateway only needs outbound internet access.
+- **Webhook** — events POST to the gateway's public webhook route. Use when
+  you already run behind a public HTTPS URL and prefer push delivery.
 
 Supports both platforms: **飞书** (`open.feishu.cn`, China) and
 **Lark international** (`open.larksuite.com`) — pick via the `domain` config.
@@ -42,9 +46,16 @@ hermit channel install @openhermit/channel-lark
      (**without this the bot receives nothing in groups** — the most common
      misconfiguration)
    - `im:resource` — upload/download message images & files
-4. **Subscribe to events** (Event Subscriptions): choose **“Receive events
-   through a persistent connection (WebSocket)”** as the delivery mode, then
-   add the event `im.message.receive_v1`.
+4. **Subscribe to events** (Event Subscriptions), then add the event
+   `im.message.receive_v1`. Pick the delivery mode:
+   - **WebSocket** (default): choose **“Receive events through a persistent
+     connection”** in the Console.
+   - **Webhook**: choose **“Send events to a Request URL”**. The exact URL to
+     paste (`…/api/agents/<id>/channels/lark/webhook`) is printed in the
+     channel logs at start — it needs `OPENHERMIT_GATEWAY_PUBLIC_URL` set on
+     the gateway. Copy the Console's **Encrypt Key** / **Verification Token**
+     into the `LARK_ENCRYPT_KEY` / `LARK_VERIFICATION_TOKEN` secrets
+     (recommended; events are then decrypted and signature-checked).
 5. **Publish an app version** and approve it — permissions and events only
    take effect on a released version.
 6. In the OpenHermit admin UI, enable the **Lark / 飞书** channel on the
@@ -59,7 +70,10 @@ Stored in the agent's channel row:
 {
   "app_id": "cli_a1b2c3d4…",
   "app_secret": "${{LARK_APP_SECRET}}",
-  "domain": "feishu"
+  "domain": "feishu",
+  "mode": "ws",
+  "encrypt_key": "${{LARK_ENCRYPT_KEY}}",
+  "verification_token": "${{LARK_VERIFICATION_TOKEN}}"
 }
 ```
 
@@ -68,6 +82,9 @@ Stored in the agent's channel row:
 | `app_id` | `cli_…` | Developer Console → Credentials & Basic Info |
 | `app_secret` | secret ref | via the `LARK_APP_SECRET` agent secret |
 | `domain` | `feishu` (default) \| `lark` | which platform your tenant lives on |
+| `mode` | `ws` (default) \| `webhook` | event delivery; webhook needs a public gateway URL |
+| `encrypt_key` | optional secret ref | webhook mode: decrypt + signature-check events |
+| `verification_token` | optional secret ref | webhook mode: challenge token check |
 
 ## Troubleshooting
 
@@ -83,4 +100,3 @@ Stored in the agent's channel row:
 - Interactive cards / rich-post outbound (replies are plain text)
 - Sender display names (needs `contact:user.base:readonly`; planned)
 - Inbound voice STT transcription (audio arrives as a file attachment)
-- Webhook event mode (WS long connection only)

--- a/apps/channels/lark/README.md
+++ b/apps/channels/lark/README.md
@@ -1,0 +1,86 @@
+# @openhermit/channel-lark
+
+OpenHermit channel plugin for **Lark / 飞书 (Feishu)**.
+
+Uses the platform's **WebSocket long-connection** event mode — no public URL,
+webhook, or tunnel required. The gateway only needs outbound internet access.
+
+Supports both platforms: **飞书** (`open.feishu.cn`, China) and
+**Lark international** (`open.larksuite.com`) — pick via the `domain` config.
+
+## Features
+
+- Text messages in both directions (long replies auto-chunked)
+- Inbound images / files / audio → session attachments (vision input for images)
+- Outbound agent attachments → native Lark image / file messages
+- Group chats with @mention gating (the agent replies only when @mentioned)
+- `/new` (or `@bot new` in groups) starts a fresh conversation
+- `session_send` reachability via `lark_chat_id` session metadata
+
+## Install
+
+```bash
+hermit channel install @openhermit/channel-lark
+# restart the gateway to load the plugin
+```
+
+## Lark app setup (one app per agent!)
+
+> ⚠️ Lark allows **one live WebSocket connection per app**. Two gateways (or
+> two agents) sharing an app_id will fight over the connection ("system
+> busy"). Create a separate app for each agent — same rule as one Telegram
+> bot token per agent.
+
+1. **Create a self-built app** in the [Developer Console](https://open.feishu.cn)
+   (or [open.larksuite.com](https://open.larksuite.com) for international
+   tenants). Note the **App ID** (`cli_…`) and **App Secret**.
+2. **Add the Bot capability** (App features → Bot).
+3. **Grant permissions** (Permissions & Scopes). Minimum set:
+   - `im:message` — send messages
+   - `im:message.p2p_msg` — receive DMs
+   - `im:message.group_at_msg` — receive group @mentions
+     (**without this the bot receives nothing in groups** — the most common
+     misconfiguration)
+   - `im:resource` — upload/download message images & files
+4. **Subscribe to events** (Event Subscriptions): choose **“Receive events
+   through a persistent connection (WebSocket)”** as the delivery mode, then
+   add the event `im.message.receive_v1`.
+5. **Publish an app version** and approve it — permissions and events only
+   take effect on a released version.
+6. In the OpenHermit admin UI, enable the **Lark / 飞书** channel on the
+   agent: paste the **App ID**, pick the **platform** (飞书 / Lark), and set
+   the **App Secret** secret (`LARK_APP_SECRET`).
+
+## Config
+
+Stored in the agent's channel row:
+
+```json
+{
+  "app_id": "cli_a1b2c3d4…",
+  "app_secret": "${{LARK_APP_SECRET}}",
+  "domain": "feishu"
+}
+```
+
+| Field | Values | Notes |
+| --- | --- | --- |
+| `app_id` | `cli_…` | Developer Console → Credentials & Basic Info |
+| `app_secret` | secret ref | via the `LARK_APP_SECRET` agent secret |
+| `domain` | `feishu` (default) \| `lark` | which platform your tenant lives on |
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| Bot silent in groups, DMs fine | `im:message.group_at_msg` permission missing, or the app version wasn't republished after adding it |
+| “system busy” / connection churn in logs | another process holds the app's WS connection — one app per agent |
+| `bot info failed` at startup | wrong App ID/Secret, Bot capability not added, or app not published |
+| Replies work but `session_send` can't reach the chat | the session predates this plugin — send one message in the chat to stamp `lark_chat_id` metadata |
+
+## Not yet supported
+
+- Interactive cards / rich-post outbound (replies are plain text)
+- Sender display names (needs `contact:user.base:readonly`; planned)
+- Inbound voice STT transcription (audio arrives as a file attachment)
+- Webhook event mode (WS long connection only)

--- a/apps/channels/lark/package.json
+++ b/apps/channels/lark/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@openhermit/channel-lark",
+  "version": "0.1.0",
+  "description": "OpenHermit channel plugin for Lark / Feishu (飞书). WebSocket long-connection event subscription — no public URL required. Text and media in both directions; group @mention gating; supports both open.feishu.cn and open.larksuite.com tenants.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HCF-STUDIOS/openhermit.git",
+    "directory": "apps/channels/lark"
+  },
+  "homepage": "https://github.com/HCF-STUDIOS/openhermit/tree/main/apps/channels/lark",
+  "bugs": "https://github.com/HCF-STUDIOS/openhermit/issues",
+  "keywords": [
+    "openhermit",
+    "channel",
+    "lark",
+    "feishu",
+    "飞书",
+    "chatbot"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc -p tsconfig.typecheck.json --pretty false",
+    "test": "node --import tsx --test test/*.test.ts",
+    "dev": "tsx src/index.ts",
+    "prepublishOnly": "npm run build",
+    "prepack": "node scripts/strip-dev-condition.mjs",
+    "postpack": "node scripts/restore-package-json.mjs"
+  },
+  "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.70.0",
+    "@openhermit/sdk": "^0.7.0"
+  },
+  "devDependencies": {
+    "@openhermit/protocol": "0.2.0",
+    "@openhermit/shared": "0.2.0",
+    "tsup": "^8.5.1"
+  }
+}

--- a/apps/channels/lark/scripts/restore-package-json.mjs
+++ b/apps/channels/lark/scripts/restore-package-json.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// postpack: restore package.json from the backup written by prepack.
+import { existsSync, renameSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+if (existsSync(backupPath)) {
+  renameSync(backupPath, pkgPath);
+  console.log('[channel-wechat] restored package.json after publish');
+}

--- a/apps/channels/lark/scripts/strip-dev-condition.mjs
+++ b/apps/channels/lark/scripts/strip-dev-condition.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// prepack: back up package.json and remove the `development` export
+// condition so the published tarball only exposes built artifacts.
+// Restored by scripts/restore-package-json.mjs in postpack.
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+const backupPath = `${pkgPath}.bak`;
+
+// Only create the backup if one doesn't already exist — otherwise a
+// repeated prepack run would overwrite the original with an already
+// stripped manifest, leaving postpack with nothing to restore.
+if (!existsSync(backupPath)) {
+  copyFileSync(pkgPath, backupPath);
+}
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const dot = pkg.exports?.['.'];
+if (dot && typeof dot === 'object' && 'development' in dot) {
+  delete dot.development;
+}
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log('[channel-wechat] stripped development export condition for publish');

--- a/apps/channels/lark/src/bot.ts
+++ b/apps/channels/lark/src/bot.ts
@@ -1,14 +1,28 @@
 /**
- * Lark bot. Receives events over the platform's WebSocket long connection
- * (no public URL required — the SDK maintains and reconnects the socket),
- * normalizes `im.message.receive_v1`, and forwards to the bridge.
+ * Lark bot. Two event delivery modes:
  *
- * Constraint worth knowing: Lark allows ONE live WS connection per app.
- * Running two gateways against the same app_id makes them fight (the
- * platform reports "system busy"), same failure family as Telegram's
- * getUpdates Conflict — use one Lark app per agent.
+ * - `ws` (default): the platform's WebSocket long connection — the SDK
+ *   maintains and reconnects the socket; no public URL required.
+ *   Constraint: Lark allows ONE live WS connection per app. Two gateways
+ *   sharing an app_id fight over it ("system busy") — same failure family
+ *   as Telegram's getUpdates Conflict. One Lark app per agent.
+ *
+ * - `webhook`: events arrive on the gateway's public webhook route
+ *   (`…/channels/lark/webhook`). Lark has no programmatic setWebhook —
+ *   the operator pastes the URL into the Developer Console. The handler
+ *   answers the url_verification challenge synchronously and dispatches
+ *   real events asynchronously (Lark retries on slow responses, so we
+ *   ack fast; `message_id` dedup absorbs redeliveries).
+ *
+ * Both modes share the same EventDispatcher and normalization path.
  */
-import { WSClient, EventDispatcher, Domain, LoggerLevel } from '@larksuiteoapi/node-sdk';
+import {
+  WSClient,
+  EventDispatcher,
+  Domain,
+  LoggerLevel,
+  generateChallenge,
+} from '@larksuiteoapi/node-sdk';
 
 import type { LarkApi } from './lark-api.js';
 import type { LarkBridge, LarkInboundMessage } from './bridge.js';
@@ -18,10 +32,28 @@ export interface LarkBotOptions {
   appId: string;
   appSecret: string;
   domainKey: 'feishu' | 'lark';
+  mode: 'ws' | 'webhook';
+  /** Webhook-mode Encrypt Key; enables event decryption + signature checks. */
+  encryptKey?: string;
+  /** Webhook-mode Verification Token. */
+  verificationToken?: string;
+  /** Public webhook URL, for operator guidance in the logs. */
+  webhookUrl?: string;
   api: LarkApi;
   bridge: LarkBridge;
   logger?: (message: string) => void;
   reportRuntimeError?: (error: string | null) => void;
+}
+
+export interface WebhookRequestLike {
+  headers: Record<string, string>;
+  rawBody: string;
+}
+
+export interface WebhookResponseLike {
+  status: number;
+  body?: string;
+  headers?: Record<string, string>;
 }
 
 /** The subset of the `im.message.receive_v1` event payload we consume. */
@@ -42,12 +74,33 @@ interface ReceiveEvent {
 
 export class LarkBot {
   private readonly log: (message: string) => void;
+  private readonly dispatcher: EventDispatcher;
   private ws: WSClient | undefined;
   private botOpenId: string | undefined;
   private readonly recentlyHandled = new Set<string>();
 
   constructor(private readonly options: LarkBotOptions) {
     this.log = options.logger ?? ((msg: string) => console.log(`[lark-bot] ${msg}`));
+    this.dispatcher = new EventDispatcher({
+      ...(options.encryptKey ? { encryptKey: options.encryptKey } : {}),
+      ...(options.verificationToken ? { verificationToken: options.verificationToken } : {}),
+      loggerLevel: LoggerLevel.error,
+    }).register({
+      'im.message.receive_v1': async (data: unknown) => {
+        try {
+          await this.handleReceive(data as ReceiveEvent);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log(`error handling message: ${msg}`);
+          const chatId = (data as ReceiveEvent).message?.chat_id;
+          if (chatId) {
+            await this.options.api
+              .sendText(chatId, 'Sorry, something went wrong. Please try again.')
+              .catch(() => undefined);
+          }
+        }
+      },
+    });
   }
 
   async start(): Promise<void> {
@@ -64,22 +117,14 @@ export class LarkBot {
       this.options.reportRuntimeError?.(`bot info failed: ${msg}`);
     }
 
-    const dispatcher = new EventDispatcher({}).register({
-      'im.message.receive_v1': async (data: unknown) => {
-        try {
-          await this.handleReceive(data as ReceiveEvent);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          this.log(`error handling message: ${msg}`);
-          const chatId = (data as ReceiveEvent).message?.chat_id;
-          if (chatId) {
-            await this.options.api
-              .sendText(chatId, 'Sorry, something went wrong. Please try again.')
-              .catch(() => undefined);
-          }
-        }
-      },
-    });
+    if (this.options.mode === 'webhook') {
+      this.log(
+        `webhook mode — configure this Request URL in the Developer Console: ${
+          this.options.webhookUrl ?? '(no public gateway URL configured!)'
+        }`,
+      );
+      return;
+    }
 
     this.ws = new WSClient({
       appId: this.options.appId,
@@ -88,7 +133,7 @@ export class LarkBot {
       loggerLevel: LoggerLevel.error,
     });
     // start() is non-blocking; the SDK owns reconnection with backoff.
-    this.ws.start({ eventDispatcher: dispatcher });
+    this.ws.start({ eventDispatcher: this.dispatcher });
     this.log('websocket long connection started');
   }
 
@@ -98,6 +143,56 @@ export class LarkBot {
     } catch { /* ignore */ }
     this.ws = undefined;
     this.log('bot stopped');
+  }
+
+  /**
+   * Webhook-mode entry, called by the gateway dispatcher. Answers the
+   * url_verification challenge synchronously; real events are verified +
+   * decrypted by the SDK dispatcher and handled asynchronously so Lark
+   * gets its ack well inside the retry window.
+   */
+  async handleWebhookRequest(req: WebhookRequestLike): Promise<WebhookResponseLike> {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(req.rawBody) as Record<string, unknown>;
+    } catch {
+      return { status: 400, body: 'invalid json' };
+    }
+
+    // URL verification handshake (plaintext or encrypted).
+    try {
+      const { isChallenge, challenge } = generateChallenge(body as { encrypt?: string }, {
+        encryptKey: this.options.encryptKey ?? '',
+      });
+      if (isChallenge) {
+        return {
+          status: 200,
+          body: JSON.stringify(challenge),
+          headers: { 'content-type': 'application/json' },
+        };
+      }
+    } catch (err) {
+      // Encrypted challenge but no/wrong encrypt key configured.
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log(`webhook challenge failed: ${msg}`);
+      return { status: 400, body: 'challenge failed' };
+    }
+
+    // Signature validation reads `data.headers` while JSON.stringify(data)
+    // must reproduce the original body — keep headers on the prototype
+    // (same trick as the SDK's own adapters).
+    const invokeData = Object.assign(
+      Object.create({ headers: req.headers }),
+      body,
+    ) as Record<string, unknown>;
+
+    // Dispatch asynchronously: the agent turn can take minutes, Lark
+    // redelivers on slow acks, and message_id dedup absorbs any repeats.
+    void this.dispatcher.invoke(invokeData).catch((err) => {
+      this.log(`webhook dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+
+    return { status: 200, body: '{"ok":true}', headers: { 'content-type': 'application/json' } };
   }
 
   private async handleReceive(event: ReceiveEvent): Promise<void> {

--- a/apps/channels/lark/src/bot.ts
+++ b/apps/channels/lark/src/bot.ts
@@ -1,0 +1,149 @@
+/**
+ * Lark bot. Receives events over the platform's WebSocket long connection
+ * (no public URL required — the SDK maintains and reconnects the socket),
+ * normalizes `im.message.receive_v1`, and forwards to the bridge.
+ *
+ * Constraint worth knowing: Lark allows ONE live WS connection per app.
+ * Running two gateways against the same app_id makes them fight (the
+ * platform reports "system busy"), same failure family as Telegram's
+ * getUpdates Conflict — use one Lark app per agent.
+ */
+import { WSClient, EventDispatcher, Domain, LoggerLevel } from '@larksuiteoapi/node-sdk';
+
+import type { LarkApi } from './lark-api.js';
+import type { LarkBridge, LarkInboundMessage } from './bridge.js';
+import { isBotMentioned, parseMessageContent, stripMentionPlaceholders, type LarkMention } from './parse.js';
+
+export interface LarkBotOptions {
+  appId: string;
+  appSecret: string;
+  domainKey: 'feishu' | 'lark';
+  api: LarkApi;
+  bridge: LarkBridge;
+  logger?: (message: string) => void;
+  reportRuntimeError?: (error: string | null) => void;
+}
+
+/** The subset of the `im.message.receive_v1` event payload we consume. */
+interface ReceiveEvent {
+  sender?: {
+    sender_id?: { open_id?: string };
+    sender_type?: string;
+  };
+  message?: {
+    message_id?: string;
+    chat_id?: string;
+    chat_type?: string;
+    message_type?: string;
+    content?: string;
+    mentions?: LarkMention[];
+  };
+}
+
+export class LarkBot {
+  private readonly log: (message: string) => void;
+  private ws: WSClient | undefined;
+  private botOpenId: string | undefined;
+  private readonly recentlyHandled = new Set<string>();
+
+  constructor(private readonly options: LarkBotOptions) {
+    this.log = options.logger ?? ((msg: string) => console.log(`[lark-bot] ${msg}`));
+  }
+
+  async start(): Promise<void> {
+    try {
+      const info = await this.options.api.getBotInfo();
+      this.botOpenId = info.openId;
+      this.log(`connected as ${info.appName ?? 'bot'} (${info.openId ?? 'unknown open_id'})`);
+      this.options.reportRuntimeError?.(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Bad credentials fail here — surface but keep starting so the
+      // channels list shows the error rather than a silent no-op.
+      this.log(`bot info failed (check app_id/app_secret + bot capability): ${msg}`);
+      this.options.reportRuntimeError?.(`bot info failed: ${msg}`);
+    }
+
+    const dispatcher = new EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: unknown) => {
+        try {
+          await this.handleReceive(data as ReceiveEvent);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.log(`error handling message: ${msg}`);
+          const chatId = (data as ReceiveEvent).message?.chat_id;
+          if (chatId) {
+            await this.options.api
+              .sendText(chatId, 'Sorry, something went wrong. Please try again.')
+              .catch(() => undefined);
+          }
+        }
+      },
+    });
+
+    this.ws = new WSClient({
+      appId: this.options.appId,
+      appSecret: this.options.appSecret,
+      domain: this.options.domainKey === 'lark' ? Domain.Lark : Domain.Feishu,
+      loggerLevel: LoggerLevel.error,
+    });
+    // start() is non-blocking; the SDK owns reconnection with backoff.
+    this.ws.start({ eventDispatcher: dispatcher });
+    this.log('websocket long connection started');
+  }
+
+  async stop(): Promise<void> {
+    try {
+      (this.ws as unknown as { close?: () => void })?.close?.();
+    } catch { /* ignore */ }
+    this.ws = undefined;
+    this.log('bot stopped');
+  }
+
+  private async handleReceive(event: ReceiveEvent): Promise<void> {
+    const message = event.message;
+    if (!message?.chat_id || !message.message_id) return;
+
+    // Only human senders; the bot's own outbound (and other apps) echo as
+    // sender_type 'app'.
+    if (event.sender?.sender_type && event.sender.sender_type !== 'user') return;
+
+    // Lark delivery is at-least-once — dedupe by message_id.
+    if (this.recentlyHandled.has(message.message_id)) return;
+    this.recentlyHandled.add(message.message_id);
+    setTimeout(() => this.recentlyHandled.delete(message.message_id!), 60_000);
+
+    const chatType: 'p2p' | 'group' = message.chat_type === 'group' ? 'group' : 'p2p';
+    const parsed = parseMessageContent(message.message_type ?? '', message.content ?? '');
+    if (parsed.unsupported && !parsed.imageKey && !parsed.fileKey) {
+      this.log(`skipping unsupported message_type=${message.message_type}`);
+      return;
+    }
+
+    const mentioned = isBotMentioned(chatType, message.mentions, this.botOpenId);
+    const text = stripMentionPlaceholders(parsed.text, message.mentions, this.botOpenId);
+
+    if (mentioned && (text === 'new' || text === '/new')) {
+      await this.options.bridge.handleNewSession(message.chat_id);
+      return;
+    }
+
+    const senderOpenId = event.sender?.sender_id?.open_id;
+
+    const inbound: LarkInboundMessage = {
+      chatId: message.chat_id,
+      chatType,
+      messageId: message.message_id,
+      senderOpenId,
+      // Resolving display names needs contact:user scopes — v2 concern.
+      senderName: undefined,
+      text,
+      mentioned,
+      ...(parsed.imageKey ? { imageKey: parsed.imageKey } : {}),
+      ...(parsed.fileKey ? { fileKey: parsed.fileKey } : {}),
+      ...(parsed.fileName ? { fileName: parsed.fileName } : {}),
+    };
+
+    await this.options.bridge.handleMessage(inbound);
+  }
+}

--- a/apps/channels/lark/src/bridge.ts
+++ b/apps/channels/lark/src/bridge.ts
@@ -1,0 +1,356 @@
+/**
+ * Bridge between Lark/Feishu messages and the OpenHermit agent API.
+ * Mirrors the Slack bridge: per-chat session cache with DB recovery,
+ * stale-session fallback, SSE turn wait, attachment delivery.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { AgentLocalClient, parseSseFrames } from '@openhermit/sdk';
+import type { ChannelOutbound, ChannelOutboundResult, OutboundSession } from '@openhermit/protocol';
+import { stripSilenceTokens, openSessionWithFreshFallback } from '@openhermit/shared';
+
+import type { LarkApi } from './lark-api.js';
+import { chunkText } from './parse.js';
+
+/** Gateway-enforced attachment cap (25 MiB). Skip oversized media early. */
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
+
+interface TurnResult {
+  text: string | undefined;
+  error: string | undefined;
+}
+
+/** Normalized inbound message handed over by the bot layer. */
+export interface LarkInboundMessage {
+  chatId: string;
+  chatType: 'p2p' | 'group';
+  messageId: string;
+  senderOpenId: string | undefined;
+  senderName: string | undefined;
+  text: string;
+  mentioned: boolean;
+  imageKey?: string;
+  fileKey?: string;
+  fileName?: string;
+}
+
+export class LarkBridge implements ChannelOutbound {
+  readonly channel = 'lark';
+
+  private readonly client: AgentLocalClient;
+  private readonly clientToken: string;
+  private readonly log: (message: string) => void;
+  private readonly lastEventIds = new Map<string, number>();
+  private readonly chatSessions = new Map<string, string>();
+  /** Serialize turns per chat so one SSE watcher runs at a time. */
+  private readonly chatLocks = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly lark: LarkApi,
+    clientOptions: { baseUrl: string; token: string },
+    logger?: (message: string) => void,
+  ) {
+    this.client = new AgentLocalClient(clientOptions);
+    this.clientToken = clientOptions.token;
+    this.log = logger ?? ((msg: string) => console.log(`[lark-bridge] ${msg}`));
+  }
+
+  // ── ChannelOutbound ────────────────────────────────────────────────
+
+  async send(params: { sessionId: string; to: string; text: string }): Promise<ChannelOutboundResult> {
+    try {
+      let lastId: string | undefined;
+      for (const chunk of chunkText(params.text)) {
+        lastId = await this.lark.sendText(params.to, chunk);
+      }
+      const result: ChannelOutboundResult = { success: true };
+      if (lastId) result.messageId = lastId;
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`failed to send message to ${params.to}: ${message}`);
+      return { success: false, error: message };
+    }
+  }
+
+  /** Recipient for `session_send`: the Lark chat id from session metadata. */
+  resolveRecipient(session: OutboundSession): string | undefined {
+    const v = session.metadata?.lark_chat_id;
+    return typeof v === 'string' && v ? v : undefined;
+  }
+
+  // ── Sessions ───────────────────────────────────────────────────────
+
+  private static generateSessionId(): string {
+    return `lark:${new Date().toISOString().slice(0, 10)}-${randomUUID().slice(0, 8)}`;
+  }
+
+  private async getSessionId(chatId: string): Promise<string> {
+    const cached = this.chatSessions.get(chatId);
+    if (cached) return cached;
+
+    try {
+      const sessions = await this.client.listSessions({
+        channel: 'lark',
+        metadata: { lark_chat_id: chatId },
+        limit: 1,
+      });
+      if (sessions.length > 0) {
+        const sessionId = sessions[0]!.sessionId;
+        this.chatSessions.set(chatId, sessionId);
+        return sessionId;
+      }
+    } catch {
+      // Server unavailable — fall through to generate a new session.
+    }
+
+    const sessionId = LarkBridge.generateSessionId();
+    this.chatSessions.set(chatId, sessionId);
+    return sessionId;
+  }
+
+  async handleNewSession(chatId: string): Promise<void> {
+    const fresh = LarkBridge.generateSessionId();
+    this.chatSessions.set(chatId, fresh);
+    await this.lark.sendText(chatId, 'New conversation started.');
+  }
+
+  private async ensureSession(sessionId: string, msg: LarkInboundMessage): Promise<void> {
+    const metadata: Record<string, string> = {
+      lark_chat_id: msg.chatId,
+      lark_chat_type: msg.chatType,
+    };
+    if (msg.chatType === 'p2p') {
+      if (msg.senderOpenId) metadata.lark_user_id = msg.senderOpenId;
+      if (msg.senderName) metadata.lark_user_name = msg.senderName;
+    }
+
+    await this.client.openSession({
+      sessionId,
+      source: {
+        kind: 'channel',
+        interactive: true,
+        platform: 'lark',
+        type: msg.chatType === 'p2p' ? 'direct' : 'group',
+      },
+      metadata,
+    });
+  }
+
+  // ── Inbound ────────────────────────────────────────────────────────
+
+  async handleMessage(msg: LarkInboundMessage): Promise<void> {
+    const previous = this.chatLocks.get(msg.chatId) ?? Promise.resolve();
+    const turn = previous.then(() => this.handleMessageInner(msg));
+    this.chatLocks.set(msg.chatId, turn.catch(() => undefined));
+    await turn;
+  }
+
+  private async handleMessageInner(msg: LarkInboundMessage): Promise<void> {
+    let sessionId = await this.getSessionId(msg.chatId);
+
+    // A recovered session id may no longer be reopenable (stale/migrated,
+    // or a different resolved identity) — fall back to a fresh session.
+    sessionId = await openSessionWithFreshFallback(
+      sessionId,
+      (id) => this.ensureSession(id, msg),
+      () => {
+        const fresh = LarkBridge.generateSessionId();
+        this.chatSessions.set(msg.chatId, fresh);
+        return fresh;
+      },
+    );
+
+    const attachments = await this.resolveInboundMedia(sessionId, msg);
+    if (!msg.text && attachments.length === 0) return;
+
+    const postResult = await this.client.postMessage(sessionId, {
+      text: msg.text,
+      mentioned: msg.mentioned,
+      ...(attachments.length > 0 ? { attachments } : {}),
+      ...(msg.senderOpenId
+        ? {
+            sender: {
+              channel: 'lark',
+              channelUserId: msg.senderOpenId,
+              ...(msg.senderName ? { displayName: msg.senderName } : {}),
+            },
+          }
+        : {}),
+    });
+
+    if (!(postResult as { triggered?: boolean }).triggered) return;
+
+    const result = await this.waitForAgentResponse(sessionId, msg.chatId);
+
+    if (result.error && !result.text) {
+      await this.lark.sendText(msg.chatId, `Error: ${result.error}`);
+    } else if (result.text) {
+      await this.send({ sessionId, to: msg.chatId, text: result.text });
+    }
+  }
+
+  /** Download inbound image/file and re-upload as a session attachment. */
+  private async resolveInboundMedia(
+    sessionId: string,
+    msg: LarkInboundMessage,
+  ): Promise<{ type: 'file'; id: string }[]> {
+    const key = msg.imageKey ?? msg.fileKey;
+    if (!key) return [];
+    try {
+      const bytes = await this.lark.downloadResource(
+        msg.messageId,
+        key,
+        msg.imageKey ? 'image' : 'file',
+      );
+      if (bytes.byteLength > MAX_MEDIA_BYTES) {
+        this.log(`skipping oversized inbound media (${bytes.byteLength} bytes)`);
+        return [];
+      }
+      const filename = msg.fileName ?? (msg.imageKey ? 'image.png' : 'attachment');
+      const blob = new Blob([bytes as unknown as BlobPart]);
+      const uploaded = await this.client.uploadAttachment(sessionId, blob, filename);
+      return uploaded.id ? [{ type: 'file', id: uploaded.id }] : [];
+    } catch (err) {
+      this.log(`inbound media failed: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  // ── Turn wait (SSE) ────────────────────────────────────────────────
+
+  private async waitForAgentResponse(sessionId: string, chatId: string): Promise<TurnResult> {
+    const eventsUrl = this.client.buildEventsUrl(sessionId);
+    const lastEventId = this.lastEventIds.get(sessionId) ?? 0;
+
+    const response = await fetch(eventsUrl, {
+      headers: { authorization: `Bearer ${this.clientToken}` },
+    });
+    if (!response.ok || !response.body) {
+      return { text: undefined, error: `Failed to open event stream (${response.status})` };
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let nextLastEventId = lastEventId;
+    let sequenceResetChecked = false;
+    let accumulatedText = '';
+    let finalText: string | undefined;
+    let error: string | undefined;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const parsed = parseSseFrames(buffer);
+        buffer = parsed.remainder;
+        let sawAgentEnd = false;
+
+        for (const frame of parsed.frames) {
+          if (frame.id !== undefined && frame.id <= nextLastEventId) continue;
+          if (frame.id !== undefined) nextLastEventId = frame.id;
+
+          if (frame.event === 'ready') {
+            if (!sequenceResetChecked) {
+              sequenceResetChecked = true;
+              try {
+                const data = frame.data.length > 0
+                  ? (JSON.parse(frame.data) as { nextEventId?: number })
+                  : {};
+                if (typeof data.nextEventId === 'number' && data.nextEventId <= nextLastEventId) {
+                  nextLastEventId = 0;
+                }
+              } catch { /* ignore */ }
+            }
+            continue;
+          }
+          if (frame.event === 'ping') continue;
+
+          const payload = frame.data.length > 0
+            ? (JSON.parse(frame.data) as Record<string, unknown>)
+            : {};
+
+          if (frame.event === 'text_delta') {
+            accumulatedText += String(payload.text ?? '');
+            continue;
+          }
+          if (frame.event === 'text_final') {
+            finalText = String(payload.text ?? '').trim();
+            continue;
+          }
+          if (frame.event === 'error') {
+            error = String(payload.message ?? 'Unknown error');
+            continue;
+          }
+          if (frame.event === 'attachment') {
+            try {
+              await this.deliverAttachment(chatId, payload);
+            } catch (err) {
+              this.log(
+                `attachment delivery failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+            continue;
+          }
+          if (frame.event === 'agent_end') {
+            sawAgentEnd = true;
+            continue;
+          }
+        }
+
+        if (sawAgentEnd) break;
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+
+    this.lastEventIds.set(sessionId, nextLastEventId);
+
+    const rawResponseText = finalText ?? (accumulatedText.trim() || undefined);
+    const stripped = rawResponseText !== undefined ? stripSilenceTokens(rawResponseText) : undefined;
+    if (stripped?.isSilent) return { text: undefined, error: undefined };
+    const responseText = stripped?.hadToken ? stripped.text : rawResponseText;
+
+    return { text: responseText, error };
+  }
+
+  /**
+   * Deliver an outbound `attachment` SSE event to the chat. Bytes are
+   * pulled lazily from the agent-local API; images go out as native Lark
+   * image messages, everything else as a file.
+   */
+  private async deliverAttachment(chatId: string, payload: Record<string, unknown>): Promise<void> {
+    const sessionId = String(payload.sessionId ?? '');
+    const attachmentId = String(payload.attachmentId ?? '');
+    if (!sessionId || !attachmentId) {
+      this.log('attachment event missing sessionId/attachmentId');
+      return;
+    }
+    const caption =
+      typeof payload.caption === 'string' && payload.caption.length > 0
+        ? payload.caption
+        : undefined;
+    const hintedKind = String(payload.kind ?? '');
+    const hintedName =
+      typeof payload.name === 'string' && payload.name.length > 0 ? payload.name : undefined;
+
+    const { bytes, mimeType, kind: resolvedKind, filename } =
+      await this.client.downloadAttachmentBytes(sessionId, attachmentId);
+    const kind = hintedKind || resolvedKind || '';
+    const name = hintedName ?? filename ?? 'attachment';
+
+    if (kind === 'image' || mimeType?.startsWith('image/')) {
+      const imageKey = await this.lark.uploadImage(bytes);
+      if (!imageKey) throw new Error('lark image upload returned no image_key');
+      await this.lark.sendImage(chatId, imageKey);
+    } else {
+      const fileKey = await this.lark.uploadFile(bytes, name);
+      if (!fileKey) throw new Error('lark file upload returned no file_key');
+      await this.lark.sendFile(chatId, fileKey);
+    }
+    if (caption) await this.lark.sendText(chatId, caption);
+  }
+}

--- a/apps/channels/lark/src/config.ts
+++ b/apps/channels/lark/src/config.ts
@@ -1,0 +1,33 @@
+/** Runtime config persisted in the agent's `agent_channels` row. */
+export interface LarkRuntimeConfig {
+  enabled?: boolean;
+  /** App ID from the Lark/Feishu Developer Console (e.g. `cli_a1b2c3…`). */
+  app_id: string;
+  /** App Secret — normally referenced as `${{LARK_APP_SECRET}}`. */
+  app_secret: string;
+  /**
+   * Which platform the tenant lives on. `feishu` → open.feishu.cn (China),
+   * `lark` → open.larksuite.com (international). Defaults to `feishu`.
+   */
+  domain?: 'feishu' | 'lark';
+}
+
+export const parseLarkConfig = (input: unknown): LarkRuntimeConfig => {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('lark config must be an object');
+  }
+  const raw = input as Record<string, unknown>;
+  const appId = typeof raw.app_id === 'string' ? raw.app_id.trim() : '';
+  const appSecret = typeof raw.app_secret === 'string' ? raw.app_secret.trim() : '';
+  if (!appId) throw new Error('lark config requires app_id');
+  if (!appSecret || appSecret.startsWith('${{')) {
+    throw new Error('lark config requires app_secret (set the LARK_APP_SECRET secret)');
+  }
+  const domain = raw.domain === 'lark' ? 'lark' : 'feishu';
+  return {
+    ...(typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : {}),
+    app_id: appId,
+    app_secret: appSecret,
+    domain,
+  };
+};

--- a/apps/channels/lark/src/config.ts
+++ b/apps/channels/lark/src/config.ts
@@ -10,7 +10,30 @@ export interface LarkRuntimeConfig {
    * `lark` → open.larksuite.com (international). Defaults to `feishu`.
    */
   domain?: 'feishu' | 'lark';
+  /**
+   * Event delivery mode. `ws` (default) holds the platform's WebSocket
+   * long connection — no public URL needed. `webhook` receives events on
+   * the gateway's public webhook route; paste that URL into the Developer
+   * Console (Lark has no programmatic setWebhook).
+   */
+  mode?: 'ws' | 'webhook';
+  /** Webhook-mode Encrypt Key (Console → Events). Optional but recommended. */
+  encrypt_key?: string;
+  /** Webhook-mode Verification Token (Console → Events). Optional. */
+  verification_token?: string;
 }
+
+/**
+ * Optional secrets resolve to their raw `${{…}}` placeholder when the
+ * operator never set them; treat that as unset (same convention as the
+ * Debox optional API secret).
+ */
+const optionalSecret = (v: unknown): string | undefined => {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  if (!t || t.startsWith('${{')) return undefined;
+  return t;
+};
 
 export const parseLarkConfig = (input: unknown): LarkRuntimeConfig => {
   if (typeof input !== 'object' || input === null) {
@@ -24,10 +47,16 @@ export const parseLarkConfig = (input: unknown): LarkRuntimeConfig => {
     throw new Error('lark config requires app_secret (set the LARK_APP_SECRET secret)');
   }
   const domain = raw.domain === 'lark' ? 'lark' : 'feishu';
+  const mode = raw.mode === 'webhook' ? 'webhook' : 'ws';
+  const encryptKey = optionalSecret(raw.encrypt_key);
+  const verificationToken = optionalSecret(raw.verification_token);
   return {
     ...(typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : {}),
     app_id: appId,
     app_secret: appSecret,
     domain,
+    mode,
+    ...(encryptKey ? { encrypt_key: encryptKey } : {}),
+    ...(verificationToken ? { verification_token: verificationToken } : {}),
   };
 };

--- a/apps/channels/lark/src/index.ts
+++ b/apps/channels/lark/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public entry point for `@openhermit/channel-lark`.
+ *
+ * The default export is the `ChannelManifest`, consumed by the gateway's
+ * plugin loader. Named exports are provided for ad-hoc tooling and tests.
+ */
+export { LarkBridge } from './bridge.js';
+export type { LarkInboundMessage } from './bridge.js';
+export { LarkBot } from './bot.js';
+export { LarkApi } from './lark-api.js';
+export { parseLarkConfig } from './config.js';
+export type { LarkRuntimeConfig } from './config.js';
+export {
+  parseMessageContent,
+  isBotMentioned,
+  stripMentionPlaceholders,
+  chunkText,
+} from './parse.js';
+export type { LarkMention, ParsedContent } from './parse.js';
+export type { ChannelOutbound, ChannelOutboundResult } from '@openhermit/protocol';
+
+export { default } from './manifest.js';

--- a/apps/channels/lark/src/index.ts
+++ b/apps/channels/lark/src/index.ts
@@ -7,6 +7,7 @@
 export { LarkBridge } from './bridge.js';
 export type { LarkInboundMessage } from './bridge.js';
 export { LarkBot } from './bot.js';
+export type { WebhookRequestLike, WebhookResponseLike } from './bot.js';
 export { LarkApi } from './lark-api.js';
 export { parseLarkConfig } from './config.js';
 export type { LarkRuntimeConfig } from './config.js';

--- a/apps/channels/lark/src/lark-api.ts
+++ b/apps/channels/lark/src/lark-api.ts
@@ -1,0 +1,131 @@
+/**
+ * Thin wrapper around the official `@larksuiteoapi/node-sdk` REST client.
+ * The SDK manages `tenant_access_token` acquisition/refresh internally.
+ */
+import { Client, Domain, LoggerLevel } from '@larksuiteoapi/node-sdk';
+
+export interface LarkBotInfo {
+  openId: string | undefined;
+  appName: string | undefined;
+}
+
+export class LarkApi {
+  readonly client: Client;
+
+  constructor(
+    private readonly appId: string,
+    private readonly appSecret: string,
+    private readonly domainKey: 'feishu' | 'lark',
+    private readonly log: (message: string) => void = () => {},
+  ) {
+    this.client = new Client({
+      appId,
+      appSecret,
+      domain: domainKey === 'lark' ? Domain.Lark : Domain.Feishu,
+      loggerLevel: LoggerLevel.error,
+    });
+  }
+
+  get domain(): 'feishu' | 'lark' {
+    return this.domainKey;
+  }
+
+  /** GET /open-apis/bot/v3/info — the bot's own open_id (for @mention gating). */
+  async getBotInfo(): Promise<LarkBotInfo> {
+    const res = await this.client.request<{
+      bot?: { open_id?: string; app_name?: string };
+    }>({ method: 'GET', url: '/open-apis/bot/v3/info' });
+    const bot = (res as { bot?: { open_id?: string; app_name?: string } }).bot;
+    return { openId: bot?.open_id, appName: bot?.app_name };
+  }
+
+  /** Send a plain text message to a chat. Returns the message_id. */
+  async sendText(chatId: string, text: string): Promise<string | undefined> {
+    const res = await this.client.im.v1.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        msg_type: 'text',
+        content: JSON.stringify({ text }),
+      },
+    });
+    return res.data?.message_id;
+  }
+
+  /** Send a previously uploaded image by key. */
+  async sendImage(chatId: string, imageKey: string): Promise<string | undefined> {
+    const res = await this.client.im.v1.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        msg_type: 'image',
+        content: JSON.stringify({ image_key: imageKey }),
+      },
+    });
+    return res.data?.message_id;
+  }
+
+  /** Send a previously uploaded file by key. */
+  async sendFile(chatId: string, fileKey: string): Promise<string | undefined> {
+    const res = await this.client.im.v1.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        msg_type: 'file',
+        content: JSON.stringify({ file_key: fileKey }),
+      },
+    });
+    return res.data?.message_id;
+  }
+
+  /** Upload image bytes for messaging. Returns the image_key. */
+  async uploadImage(bytes: Uint8Array): Promise<string | undefined> {
+    const res = await this.client.im.v1.image.create({
+      data: {
+        image_type: 'message',
+        image: Buffer.from(bytes),
+      },
+    });
+    return res?.image_key;
+  }
+
+  /** Upload file bytes for messaging. Returns the file_key. */
+  async uploadFile(bytes: Uint8Array, fileName: string): Promise<string | undefined> {
+    const res = await this.client.im.v1.file.create({
+      data: {
+        file_type: 'stream',
+        file_name: fileName,
+        file: Buffer.from(bytes),
+      },
+    });
+    return res?.file_key;
+  }
+
+  /**
+   * Download an inbound message resource (image or file) as bytes.
+   * `type` must be `image` for image messages and `file` otherwise.
+   */
+  async downloadResource(
+    messageId: string,
+    key: string,
+    type: 'image' | 'file',
+  ): Promise<Uint8Array> {
+    const res = await this.client.im.v1.messageResource.get({
+      path: { message_id: messageId, file_key: key },
+      params: { type },
+    });
+    // The SDK wraps binary endpoints in a readable-stream helper.
+    const streamHolder = res as unknown as {
+      getReadableStream?: () => NodeJS.ReadableStream;
+    };
+    if (typeof streamHolder.getReadableStream !== 'function') {
+      throw new Error('lark resource download: SDK response has no readable stream');
+    }
+    const stream = streamHolder.getReadableStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    }
+    return Buffer.concat(chunks);
+  }
+}

--- a/apps/channels/lark/src/manifest.ts
+++ b/apps/channels/lark/src/manifest.ts
@@ -1,0 +1,87 @@
+/**
+ * Channel plugin manifest for Lark / Feishu (飞书). Consumed by the
+ * gateway's ChannelManifestRegistry; see `docs/channel-plugin-design.md`.
+ *
+ * Uses the platform's WebSocket long-connection event mode — no public
+ * URL, webhook, or tunnel required. One Lark app per agent (the platform
+ * allows a single live WS connection per app).
+ */
+import type { ChannelManifest } from '@openhermit/protocol';
+
+import { parseLarkConfig, type LarkRuntimeConfig } from './config.js';
+import { LarkApi } from './lark-api.js';
+import { LarkBridge } from './bridge.js';
+import { LarkBot } from './bot.js';
+
+const manifest: ChannelManifest = {
+  manifestVersion: 1,
+  key: 'lark',
+  namespace: 'lark',
+  displayName: 'Lark / 飞书',
+  secretKeys: [
+    {
+      key: 'LARK_APP_SECRET',
+      label: 'App Secret',
+      placeholder: 'Developer Console → Credentials & Basic Info',
+    },
+  ],
+  configFields: [
+    {
+      kind: 'text',
+      key: 'app_id',
+      label: 'App ID',
+      placeholder: 'cli_a1b2c3d4…',
+      help: 'From the Lark/Feishu Developer Console. Create a self-built app with the Bot capability; one app per agent.',
+    },
+    {
+      kind: 'select',
+      key: 'domain',
+      label: 'Platform',
+      options: [
+        { value: 'feishu', label: '飞书 (open.feishu.cn)' },
+        { value: 'lark', label: 'Lark international (open.larksuite.com)' },
+      ],
+      defaultValue: 'feishu',
+    },
+  ],
+  defaultConfig: {
+    app_id: '',
+    app_secret: '${{LARK_APP_SECRET}}',
+    domain: 'feishu',
+  },
+  parseConfig: parseLarkConfig,
+  start: async (rawConfig, context) => {
+    const config = rawConfig as LarkRuntimeConfig;
+    const log = (msg: string): void => context.logger('lark', msg);
+
+    const domainKey = config.domain === 'lark' ? 'lark' : 'feishu';
+    const api = new LarkApi(config.app_id, config.app_secret, domainKey, log);
+    const bridge = new LarkBridge(
+      api,
+      {
+        baseUrl: context.agentBaseUrl,
+        token: context.agentTokens['lark'] ?? '',
+      },
+      log,
+    );
+
+    const bot = new LarkBot({
+      appId: config.app_id,
+      appSecret: config.app_secret,
+      domainKey,
+      api,
+      bridge,
+      logger: log,
+      reportRuntimeError: context.reportRuntimeError,
+    });
+    await bot.start();
+
+    return {
+      name: 'lark',
+      outbound: bridge,
+      stop: () => bot.stop(),
+    };
+  },
+};
+
+export default manifest;

--- a/apps/channels/lark/src/manifest.ts
+++ b/apps/channels/lark/src/manifest.ts
@@ -2,9 +2,13 @@
  * Channel plugin manifest for Lark / Feishu (飞书). Consumed by the
  * gateway's ChannelManifestRegistry; see `docs/channel-plugin-design.md`.
  *
- * Uses the platform's WebSocket long-connection event mode — no public
- * URL, webhook, or tunnel required. One Lark app per agent (the platform
- * allows a single live WS connection per app).
+ * Two event modes:
+ * - `ws` (default): WebSocket long connection — no public URL, webhook,
+ *   or tunnel required. One Lark app per agent (the platform allows a
+ *   single live WS connection per app).
+ * - `webhook`: gateway-hosted webhook. Lark has no programmatic
+ *   setWebhook — the operator pastes the gateway URL into the Developer
+ *   Console (it is logged at channel start).
  */
 import type { ChannelManifest } from '@openhermit/protocol';
 
@@ -23,6 +27,18 @@ const manifest: ChannelManifest = {
       key: 'LARK_APP_SECRET',
       label: 'App Secret',
       placeholder: 'Developer Console → Credentials & Basic Info',
+    },
+    {
+      key: 'LARK_ENCRYPT_KEY',
+      label: 'Encrypt Key (webhook mode)',
+      placeholder: 'Console → Events → Encrypt Key (optional)',
+      optional: true,
+    },
+    {
+      key: 'LARK_VERIFICATION_TOKEN',
+      label: 'Verification Token (webhook mode)',
+      placeholder: 'Console → Events → Verification Token (optional)',
+      optional: true,
     },
   ],
   configFields: [
@@ -43,11 +59,25 @@ const manifest: ChannelManifest = {
       ],
       defaultValue: 'feishu',
     },
+    {
+      kind: 'select',
+      key: 'mode',
+      label: 'Event delivery',
+      options: [
+        { value: 'ws', label: 'WebSocket long connection (recommended — no public URL)' },
+        { value: 'webhook', label: 'Webhook (paste the gateway URL into the Console)' },
+      ],
+      defaultValue: 'ws',
+      help: 'Webhook mode needs a public gateway URL; the exact Request URL to paste is printed in the channel logs at start.',
+    },
   ],
   defaultConfig: {
     app_id: '',
     app_secret: '${{LARK_APP_SECRET}}',
     domain: 'feishu',
+    mode: 'ws',
+    encrypt_key: '${{LARK_ENCRYPT_KEY}}',
+    verification_token: '${{LARK_VERIFICATION_TOKEN}}',
   },
   parseConfig: parseLarkConfig,
   start: async (rawConfig, context) => {
@@ -55,6 +85,7 @@ const manifest: ChannelManifest = {
     const log = (msg: string): void => context.logger('lark', msg);
 
     const domainKey = config.domain === 'lark' ? 'lark' : 'feishu';
+    const mode = config.mode === 'webhook' ? 'webhook' : 'ws';
     const api = new LarkApi(config.app_id, config.app_secret, domainKey, log);
     const bridge = new LarkBridge(
       api,
@@ -65,10 +96,24 @@ const manifest: ChannelManifest = {
       log,
     );
 
+    let webhookUrl: string | undefined;
+    if (mode === 'webhook') {
+      if (context.publicAgentBaseUrl === context.agentBaseUrl) {
+        throw new Error(
+          'Lark webhook mode needs a public URL. Set OPENHERMIT_GATEWAY_PUBLIC_URL on the gateway, or use mode "ws".',
+        );
+      }
+      webhookUrl = `${context.publicAgentBaseUrl}/channels/lark/webhook`;
+    }
+
     const bot = new LarkBot({
       appId: config.app_id,
       appSecret: config.app_secret,
       domainKey,
+      mode,
+      ...(config.encrypt_key ? { encryptKey: config.encrypt_key } : {}),
+      ...(config.verification_token ? { verificationToken: config.verification_token } : {}),
+      ...(webhookUrl ? { webhookUrl } : {}),
       api,
       bridge,
       logger: log,
@@ -80,6 +125,9 @@ const manifest: ChannelManifest = {
       name: 'lark',
       outbound: bridge,
       stop: () => bot.stop(),
+      ...(mode === 'webhook'
+        ? { handleWebhook: (req: Parameters<LarkBot['handleWebhookRequest']>[0]) => bot.handleWebhookRequest(req) }
+        : {}),
     };
   },
 };

--- a/apps/channels/lark/src/parse.ts
+++ b/apps/channels/lark/src/parse.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure parsing helpers for inbound Lark/Feishu `im.message.receive_v1`
+ * events. Kept side-effect-free so they can be unit-tested without the
+ * SDK or a live connection.
+ */
+
+/** One entry of the event's `mentions` array. */
+export interface LarkMention {
+  /** Placeholder key as it appears in the text content, e.g. `@_user_1`. */
+  key: string;
+  id?: { open_id?: string; union_id?: string; user_id?: string };
+  name?: string;
+}
+
+/** Normalized inbound content: text plus optional media reference. */
+export interface ParsedContent {
+  text: string;
+  /** Set for `image` messages. */
+  imageKey?: string;
+  /** Set for `file` / `media` / `audio` messages. */
+  fileKey?: string;
+  fileName?: string;
+  /** True when the message type carries nothing we can forward. */
+  unsupported?: boolean;
+}
+
+/**
+ * Parse the JSON-string `content` of an inbound message by `message_type`.
+ * Lark double-encodes: `content` is itself a JSON document.
+ */
+export const parseMessageContent = (messageType: string, content: string): ParsedContent => {
+  let body: Record<string, unknown> = {};
+  try {
+    body = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return { text: '', unsupported: true };
+  }
+
+  switch (messageType) {
+    case 'text':
+      return { text: typeof body.text === 'string' ? body.text : '' };
+
+    case 'post': {
+      // Rich text: { title?, content: [[{tag, text|href|user_id, ...}, ...], ...] }
+      const lines: string[] = [];
+      const title = typeof body.title === 'string' ? body.title.trim() : '';
+      if (title) lines.push(title);
+      const rows = Array.isArray(body.content) ? body.content : [];
+      for (const row of rows) {
+        if (!Array.isArray(row)) continue;
+        const parts: string[] = [];
+        for (const node of row) {
+          if (!node || typeof node !== 'object') continue;
+          const n = node as Record<string, unknown>;
+          // Order matters: `a` and `at` nodes also carry a `text` field.
+          if (n.tag === 'a' && typeof n.href === 'string') parts.push(String(n.href));
+          else if (n.tag === 'at') parts.push(typeof n.user_name === 'string' ? `@${n.user_name}` : '');
+          else if (typeof n.text === 'string') parts.push(n.text);
+        }
+        const line = parts.join('');
+        if (line.trim()) lines.push(line);
+      }
+      return { text: lines.join('\n') };
+    }
+
+    case 'image':
+      return {
+        text: '',
+        ...(typeof body.image_key === 'string' ? { imageKey: body.image_key } : {}),
+      };
+
+    case 'file':
+    case 'media':
+    case 'audio':
+      return {
+        text: '',
+        ...(typeof body.file_key === 'string' ? { fileKey: body.file_key } : {}),
+        ...(typeof body.file_name === 'string' ? { fileName: body.file_name } : {}),
+      };
+
+    default:
+      // sticker, share_chat, interactive, …
+      return { text: '', unsupported: true };
+  }
+};
+
+/**
+ * Whether the bot is addressed. DMs always count; group messages count only
+ * when the bot itself appears in `mentions` (requires the
+ * `im:message.group_at_msg` event permission — without it Lark never
+ * delivers group messages at all).
+ */
+export const isBotMentioned = (
+  chatType: string,
+  mentions: LarkMention[] | undefined,
+  botOpenId: string | undefined,
+): boolean => {
+  if (chatType !== 'group') return true;
+  if (!botOpenId || !Array.isArray(mentions)) return false;
+  return mentions.some((m) => m.id?.open_id === botOpenId);
+};
+
+/**
+ * Replace mention placeholders (`@_user_1` …) in the text: the bot's own
+ * mention is stripped; other users' become `@Name` so the agent still sees
+ * who was addressed.
+ */
+export const stripMentionPlaceholders = (
+  text: string,
+  mentions: LarkMention[] | undefined,
+  botOpenId: string | undefined,
+): string => {
+  if (!Array.isArray(mentions) || mentions.length === 0) return text.trim();
+  let out = text;
+  for (const m of mentions) {
+    if (!m.key) continue;
+    const replacement = m.id?.open_id === botOpenId ? '' : `@${m.name ?? 'user'}`;
+    out = out.split(m.key).join(replacement);
+  }
+  return out.replace(/\s{2,}/g, ' ').trim();
+};
+
+/** Lark text messages cap out well above this; chunk conservatively. */
+export const TEXT_CHUNK_CHARS = 4000;
+
+/** Split a long reply into send-sized chunks, preferring newline boundaries. */
+export const chunkText = (text: string, max = TEXT_CHUNK_CHARS): string[] => {
+  const t = text.trim();
+  if (t.length <= max) return t ? [t] : [];
+  const chunks: string[] = [];
+  let rest = t;
+  while (rest.length > max) {
+    let cut = rest.lastIndexOf('\n', max);
+    if (cut < max * 0.5) cut = max;
+    chunks.push(rest.slice(0, cut).trimEnd());
+    rest = rest.slice(cut).trimStart();
+  }
+  if (rest) chunks.push(rest);
+  return chunks;
+};

--- a/apps/channels/lark/test/parse.test.ts
+++ b/apps/channels/lark/test/parse.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  parseMessageContent,
+  isBotMentioned,
+  stripMentionPlaceholders,
+  chunkText,
+  type LarkMention,
+} from '../src/parse.js';
+
+describe('parseMessageContent', () => {
+  test('text message: unwraps the double-encoded content', () => {
+    const p = parseMessageContent('text', JSON.stringify({ text: 'hello world' }));
+    assert.equal(p.text, 'hello world');
+    assert.equal(p.unsupported, undefined);
+  });
+
+  test('post message: flattens title + rich-text runs into lines', () => {
+    const content = JSON.stringify({
+      title: 'Weekly report',
+      content: [
+        [{ tag: 'text', text: 'First ' }, { tag: 'a', text: 'link', href: 'https://x.dev' }],
+        [{ tag: 'at', user_id: 'ou_1', user_name: 'Alice' }, { tag: 'text', text: ' please review' }],
+      ],
+    });
+    const p = parseMessageContent('post', content);
+    assert.equal(p.text, 'Weekly report\nFirst https://x.dev\n@Alice please review');
+  });
+
+  test('image message: extracts image_key', () => {
+    const p = parseMessageContent('image', JSON.stringify({ image_key: 'img_v3_abc' }));
+    assert.equal(p.imageKey, 'img_v3_abc');
+    assert.equal(p.text, '');
+  });
+
+  test('file message: extracts file_key and file_name', () => {
+    const p = parseMessageContent('file', JSON.stringify({ file_key: 'file_v3_x', file_name: 'report.pdf' }));
+    assert.equal(p.fileKey, 'file_v3_x');
+    assert.equal(p.fileName, 'report.pdf');
+  });
+
+  test('audio message: extracts file_key (delivered as a file attachment)', () => {
+    const p = parseMessageContent('audio', JSON.stringify({ file_key: 'file_v3_a' }));
+    assert.equal(p.fileKey, 'file_v3_a');
+  });
+
+  test('sticker: flagged unsupported', () => {
+    const p = parseMessageContent('sticker', JSON.stringify({ file_key: 'sticker_x' }));
+    assert.equal(p.unsupported, true);
+  });
+
+  test('malformed content JSON: flagged unsupported, does not throw', () => {
+    const p = parseMessageContent('text', 'not-json');
+    assert.equal(p.unsupported, true);
+  });
+});
+
+describe('isBotMentioned', () => {
+  const mentions: LarkMention[] = [
+    { key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Hermit' },
+    { key: '@_user_2', id: { open_id: 'ou_alice' }, name: 'Alice' },
+  ];
+
+  test('p2p always counts as mentioned', () => {
+    assert.equal(isBotMentioned('p2p', undefined, 'ou_bot'), true);
+  });
+
+  test('group with bot in mentions', () => {
+    assert.equal(isBotMentioned('group', mentions, 'ou_bot'), true);
+  });
+
+  test('group without bot in mentions', () => {
+    assert.equal(isBotMentioned('group', [mentions[1]!], 'ou_bot'), false);
+  });
+
+  test('group with no mentions at all', () => {
+    assert.equal(isBotMentioned('group', undefined, 'ou_bot'), false);
+  });
+
+  test('unknown bot open_id never matches', () => {
+    assert.equal(isBotMentioned('group', mentions, undefined), false);
+  });
+});
+
+describe('stripMentionPlaceholders', () => {
+  const mentions: LarkMention[] = [
+    { key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Hermit' },
+    { key: '@_user_2', id: { open_id: 'ou_alice' }, name: 'Alice' },
+  ];
+
+  test('removes the bot mention, keeps other users as @Name', () => {
+    const out = stripMentionPlaceholders('@_user_1 ping @_user_2 about the doc', mentions, 'ou_bot');
+    assert.equal(out, 'ping @Alice about the doc');
+  });
+
+  test('no mentions: trims and passes through', () => {
+    assert.equal(stripMentionPlaceholders('  hello  ', undefined, 'ou_bot'), 'hello');
+  });
+
+  test('mention without a name falls back to @user', () => {
+    const out = stripMentionPlaceholders('@_user_9 hi', [{ key: '@_user_9', id: { open_id: 'ou_z' } }], 'ou_bot');
+    assert.equal(out, '@user hi');
+  });
+});
+
+describe('chunkText', () => {
+  test('short text is one chunk', () => {
+    assert.deepEqual(chunkText('hi'), ['hi']);
+  });
+
+  test('empty text yields no chunks', () => {
+    assert.deepEqual(chunkText('   '), []);
+  });
+
+  test('long text splits on newline boundaries under the cap', () => {
+    const para = 'x'.repeat(1500);
+    const text = [para, para, para].join('\n');
+    const chunks = chunkText(text, 2000);
+    assert.equal(chunks.length, 3);
+    for (const c of chunks) assert.ok(c.length <= 2000);
+    assert.equal(chunks.join(''), para + para + para);
+  });
+
+  test('unbroken text hard-splits at the cap', () => {
+    const chunks = chunkText('y'.repeat(4500), 2000);
+    assert.equal(chunks.length, 3);
+    assert.equal(chunks.join('').length, 4500);
+  });
+});

--- a/apps/channels/lark/test/webhook.test.ts
+++ b/apps/channels/lark/test/webhook.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { LarkBot } from '../src/bot.js';
+import { parseLarkConfig } from '../src/config.js';
+import type { LarkInboundMessage } from '../src/bridge.js';
+
+/** Build a bot in webhook mode with recording fakes; no network. */
+const makeBot = () => {
+  const sentTexts: Array<{ chatId: string; text: string }> = [];
+  const handled: LarkInboundMessage[] = [];
+  const api = {
+    getBotInfo: async () => ({ openId: 'ou_bot', appName: 'TestBot' }),
+    sendText: async (chatId: string, text: string) => {
+      sentTexts.push({ chatId, text });
+      return 'om_1';
+    },
+  };
+  const bridge = {
+    handleMessage: async (msg: LarkInboundMessage) => {
+      handled.push(msg);
+    },
+    handleNewSession: async () => {},
+  };
+  const bot = new LarkBot({
+    appId: 'cli_x',
+    appSecret: 'secret',
+    domainKey: 'feishu',
+    mode: 'webhook',
+    api: api as never,
+    bridge: bridge as never,
+    logger: () => {},
+  });
+  return { bot, handled, sentTexts };
+};
+
+const receiveBody = (messageId: string, text: string) => ({
+  schema: '2.0',
+  header: {
+    event_id: `evt_${messageId}`,
+    event_type: 'im.message.receive_v1',
+    create_time: '1700000000000',
+    token: '',
+    app_id: 'cli_x',
+    tenant_key: 't',
+  },
+  event: {
+    sender: { sender_id: { open_id: 'ou_alice' }, sender_type: 'user' },
+    message: {
+      message_id: messageId,
+      chat_id: 'oc_chat1',
+      chat_type: 'p2p',
+      message_type: 'text',
+      content: JSON.stringify({ text }),
+    },
+  },
+});
+
+describe('LarkBot.handleWebhookRequest', () => {
+  test('answers the plaintext url_verification challenge synchronously', async () => {
+    const { bot } = makeBot();
+    const res = await bot.handleWebhookRequest({
+      headers: {},
+      rawBody: JSON.stringify({ type: 'url_verification', challenge: 'abc123', token: 't' }),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(res.body ?? '{}'), { challenge: 'abc123' });
+  });
+
+  test('rejects invalid JSON with 400', async () => {
+    const { bot } = makeBot();
+    const res = await bot.handleWebhookRequest({ headers: {}, rawBody: 'not-json' });
+    assert.equal(res.status, 400);
+  });
+
+  test('rejects an encrypted challenge when no encrypt key is configured', async () => {
+    const { bot } = makeBot();
+    const res = await bot.handleWebhookRequest({
+      headers: {},
+      rawBody: JSON.stringify({ encrypt: 'AAAA' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  test('acks a message event immediately and dispatches it async to the bridge', async () => {
+    const { bot, handled } = makeBot();
+    const res = await bot.handleWebhookRequest({
+      headers: {},
+      rawBody: JSON.stringify(receiveBody('om_msg1', 'hello over webhook')),
+    });
+    assert.equal(res.status, 200);
+    // The dispatch is intentionally async — drain the microtask queue.
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(handled.length, 1);
+    assert.equal(handled[0]!.text, 'hello over webhook');
+    assert.equal(handled[0]!.chatId, 'oc_chat1');
+    assert.equal(handled[0]!.mentioned, true); // p2p
+  });
+
+  test('dedupes redelivered events by message_id', async () => {
+    const { bot, handled } = makeBot();
+    const body = JSON.stringify(receiveBody('om_dup', 'once please'));
+    await bot.handleWebhookRequest({ headers: {}, rawBody: body });
+    await bot.handleWebhookRequest({ headers: {}, rawBody: body });
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(handled.length, 1);
+  });
+});
+
+describe('parseLarkConfig modes', () => {
+  const base = { app_id: 'cli_x', app_secret: 's3cret' };
+
+  test('defaults to ws mode', () => {
+    assert.equal(parseLarkConfig(base).mode, 'ws');
+  });
+
+  test('accepts webhook mode with optional secrets', () => {
+    const cfg = parseLarkConfig({
+      ...base,
+      mode: 'webhook',
+      encrypt_key: 'ek',
+      verification_token: 'vt',
+    });
+    assert.equal(cfg.mode, 'webhook');
+    assert.equal(cfg.encrypt_key, 'ek');
+    assert.equal(cfg.verification_token, 'vt');
+  });
+
+  test('unresolved ${{…}} placeholders on optional secrets read as unset', () => {
+    const cfg = parseLarkConfig({
+      ...base,
+      mode: 'webhook',
+      encrypt_key: '${{LARK_ENCRYPT_KEY}}',
+      verification_token: '${{LARK_VERIFICATION_TOKEN}}',
+    });
+    assert.equal(cfg.encrypt_key, undefined);
+    assert.equal(cfg.verification_token, undefined);
+  });
+
+  test('missing app_secret placeholder still rejects', () => {
+    assert.throws(() => parseLarkConfig({ app_id: 'cli_x', app_secret: '${{LARK_APP_SECRET}}' }));
+  });
+});

--- a/apps/channels/lark/tsconfig.build.json
+++ b/apps/channels/lark/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "outDir": "dist",
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../../../packages/protocol/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/lark/tsconfig.json
+++ b/apps/channels/lark/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../../../packages/sdk" }
+  ],
+  "include": [
+    "src"
+  ]
+}

--- a/apps/channels/lark/tsconfig.typecheck.json
+++ b/apps/channels/lark/tsconfig.typecheck.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "noEmit": true,
+    "composite": false,
+    "incremental": false
+  },
+  "include": [
+    "src",
+    "../../../packages/protocol/src",
+    "../../../packages/sdk/src",
+    "../../../packages/shared/src"
+  ]
+}

--- a/apps/channels/lark/tsup.config.ts
+++ b/apps/channels/lark/tsup.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tsup';
+
+// Workspace packages that are `private: true` and therefore unreachable
+// for an external `npm install`. Bundle them into the published artifact
+// so consumers don't need to resolve them at runtime or compile time.
+const internalPackages = [
+  '@openhermit/protocol',
+  '@openhermit/shared',
+];
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  platform: 'node',
+  outDir: 'dist',
+  clean: true,
+  splitting: false,
+  tsconfig: 'tsconfig.build.json',
+  dts: { resolve: true },
+  sourcemap: true,
+  noExternal: internalPackages,
+  esbuildOptions(options) {
+    options.conditions = ['development'];
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,23 @@
         "node": ">=20"
       }
     },
+    "apps/channels/lark": {
+      "name": "@openhermit/channel-lark",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@larksuiteoapi/node-sdk": "^1.70.0",
+        "@openhermit/sdk": "^0.7.0"
+      },
+      "devDependencies": {
+        "@openhermit/protocol": "0.2.0",
+        "@openhermit/shared": "0.2.0",
+        "tsup": "^8.5.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/channels/signal": {
       "name": "@openhermit/channel-signal",
       "version": "0.3.0",
@@ -3713,6 +3730,32 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.70.0.tgz",
+      "integrity": "sha512-CzVfMbh2MO+cVWQgQGeYN9KkFdX6mofYYTsIjImU0hQqlxaXKzHcUEwG6mrpsmU2LWqYYtIGwCSIZjYQRjD6kw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@larksuiteoapi/node-sdk/node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@mariozechner/pi-agent-core": {
       "version": "0.70.6",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.6.tgz",
@@ -4130,6 +4173,10 @@
     },
     "node_modules/@openhermit/channel-discord": {
       "resolved": "apps/channels/discord",
+      "link": true
+    },
+    "node_modules/@openhermit/channel-lark": {
+      "resolved": "apps/channels/lark",
       "link": true
     },
     "node_modules/@openhermit/channel-signal": {
@@ -10016,6 +10063,12 @@
       "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
       "license": "MIT"
     },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -10051,6 +10104,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {


### PR DESCRIPTION
New external channel plugin for **Lark / 飞书**, per the shipped plugin contract (`docs/channel-plugin-design.md`). Design research: WS long-connection is the right integration mode (no public URL needed; SDK-managed reconnects).

## What's in v1
- **WebSocket long-connection events** via official `@larksuiteoapi/node-sdk` (`im.message.receive_v1`); works behind NAT, both 飞书 (`open.feishu.cn`) and Lark international (`open.larksuite.com`) via a `domain` select.
- **Text both ways** (long replies chunked); **inbound image/file/audio → session attachments** (vision input for images); **outbound agent attachments → native Lark image/file messages**.
- **Groups**: @mention gating; mention placeholders rewritten (`@_user_N` → stripped for the bot, `@Name` for others). `/new` resets the conversation.
- **session_send** reachability: `lark_chat_id` metadata + `resolveRecipient` (#207 contract).
- **Robustness**: `openSessionWithFreshFallback` from shared (#222/#223), `message_id` dedup (at-least-once delivery), per-chat turn serialization, `reportRuntimeError` on auth failures.

## Structure
- Runtime mirrors **slack** (closest analog: socket-mode event stream). Publishing mirrors **wechat**: tsup `noExternal` bundles `protocol`/`shared` into the artifact (the #223 lesson — no nested-dep trap), `@openhermit/sdk` stays an npm dep (`^0.7.0`), dev-condition strip on pack.
- Manifest declares `secretKeys` (`LARK_APP_SECRET`) + `configFields` (`app_id` text, `domain` select) → admin UI renders a structured form; `parseConfig` validates before start.

## Known constraints (documented in README)
- **One Lark app per agent** — the platform allows a single live WS connection per app (violations = "system busy" churn; same family as Telegram getUpdates Conflict).
- The #1 user misconfiguration is pinned in README + troubleshooting: `im:message.group_at_msg` is a **separate permission**; without it groups are silent.

## Verification
- 19/19 unit tests (content parsing text/post/image/file/audio, mention gating, placeholder rewrite, chunking)
- typecheck + tsup build clean; other channel packages unaffected (telegram typecheck re-run OK)
- manifest verified loadable through the plugin-loader import path (`key/namespace/manifestVersion/configFields/secretKeys` all present)
- `npm pack --dry-run`: 5 files, 31 kB
- Live smoke against a real Lark app: pending — needs an app_id/secret; plan is to install on test (`hermit channel install`) with a dev 飞书 app before publishing to npm

## Not in v1 (README "Not yet supported")
Interactive cards/rich-post outbound, sender display names (needs contact scope), inbound voice STT, webhook event mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Lark/Feishu channel plugin for WebSocket-based chat integration.
  * Supports text messages, image/file attachments, group mention handling, and starting a new conversation with `/new`.
  * Added outbound attachment delivery, including images and files, plus message streaming back into chat.

* **Bug Fixes**
  * Improved handling of duplicate and malformed incoming messages.
  * Added better fallback behavior when message delivery or processing fails.

* **Documentation**
  * Added setup, configuration, troubleshooting, and limitation guidance for the Lark/Feishu plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->