### PR TITLE
PROD-65 Strip inline reasoning tags so thinking never leaks into the reply

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -64,6 +64,9 @@ import {
   newSpeakerTagStream,
   pushSpeakerTagDelta,
   flushSpeakerTagStream,
+  newReasoningTagStream,
+  pushReasoningTagDelta,
+  flushReasoningTagStream,
   serializeDetails,
 } from './agent-runner/message-utils.js';
 import {
@@ -1219,6 +1222,7 @@ export class AgentRunner implements SessionRuntime {
         session.turnGroupParticipants = message.participants ?? undefined;
         session.latestAssistantText = undefined;
         session.speakerTagStream = undefined;
+        session.reasoningTagStream = undefined;
         session.consecutiveToolFailures = 0;
         if (message.messageId !== undefined) {
           session.currentTurnCorrelationId = message.messageId;
@@ -2980,19 +2984,24 @@ export class AgentRunner implements SessionRuntime {
           });
         }
 
-        // Same strip on the live stream as the final message; no-op until names exist.
+        // Live-stream strips mirror the final extractAssistantText pass so
+        // reasoning tags never flash (or stick, on clients that prefer deltas).
         const isGroupStream = session.spec.source.type === 'group';
-        if (event.assistantMessageEvent.type === 'text_start' && isGroupStream) {
-          session.speakerTagStream = newSpeakerTagStream();
+        if (event.assistantMessageEvent.type === 'text_start') {
+          session.reasoningTagStream = newReasoningTagStream();
+          if (isGroupStream) {
+            session.speakerTagStream = newSpeakerTagStream();
+          }
         }
 
         if (event.assistantMessageEvent.type === 'text_delta') {
           const rawDelta = event.assistantMessageEvent.delta;
-          let outText = rawDelta;
+          // In case the provider skipped text_start.
+          session.reasoningTagStream ??= newReasoningTagStream();
+          let outText = pushReasoningTagDelta(session.reasoningTagStream, rawDelta);
           if (isGroupStream) {
-            // In case the provider skipped text_start.
             session.speakerTagStream ??= newSpeakerTagStream();
-            outText = pushSpeakerTagDelta(session.speakerTagStream, rawDelta, session.groupSenderNames ?? []);
+            outText = pushSpeakerTagDelta(session.speakerTagStream, outText, session.groupSenderNames ?? []);
           }
           if (outText.length > 0) {
             void this.events.publish({
@@ -3004,8 +3013,20 @@ export class AgentRunner implements SessionRuntime {
           }
         }
 
-        if (event.assistantMessageEvent.type === 'text_end' && session.speakerTagStream) {
-          const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+        if (event.assistantMessageEvent.type === 'text_end') {
+          let tail = '';
+          if (session.reasoningTagStream) {
+            tail += flushReasoningTagStream(session.reasoningTagStream);
+            session.reasoningTagStream = undefined;
+          }
+          if (session.speakerTagStream) {
+            // Feed any reasoning flush into the speaker-tag guard first.
+            if (tail.length > 0) {
+              tail = pushSpeakerTagDelta(session.speakerTagStream, tail, session.groupSenderNames ?? []);
+            }
+            tail += flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+            session.speakerTagStream = undefined;
+          }
           if (tail.length > 0) {
             void this.events.publish({
               type: 'text_delta',
@@ -3014,7 +3035,6 @@ export class AgentRunner implements SessionRuntime {
               ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
             });
           }
-          session.speakerTagStream = undefined;
         }
 
         if (event.assistantMessageEvent.type === 'error') {
@@ -3029,8 +3049,19 @@ export class AgentRunner implements SessionRuntime {
 
       case 'message_end': {
         // Backstop in case the provider emitted no text_end.
-        if (session.speakerTagStream) {
-          const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+        {
+          let tail = '';
+          if (session.reasoningTagStream) {
+            tail += flushReasoningTagStream(session.reasoningTagStream);
+            session.reasoningTagStream = undefined;
+          }
+          if (session.speakerTagStream) {
+            if (tail.length > 0) {
+              tail = pushSpeakerTagDelta(session.speakerTagStream, tail, session.groupSenderNames ?? []);
+            }
+            tail += flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
+            session.speakerTagStream = undefined;
+          }
           if (tail.length > 0) {
             void this.events.publish({
               type: 'text_delta',
@@ -3039,7 +3070,6 @@ export class AgentRunner implements SessionRuntime {
               ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
             });
           }
-          session.speakerTagStream = undefined;
         }
 
         if (!isAssistantMessage(event.message)) {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -49,6 +49,11 @@ export const isEmptyAssistantTurn = (message: AgentMessage): boolean => {
 export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage[] =>
   messages.filter((message) => !isEmptyAssistantTurn(message));
 
+// Innermost pair only: body may not contain another reasoning open tag. Used
+// iteratively so nested same-name tags do not leave residual close markup.
+const REASONING_INNERMOST_RE =
+  /<(think|thinking|reasoning)>((?:(?!<(?:think|thinking|reasoning)>)[\s\S])*?)<\/\1>/gi;
+
 /**
  * Remove inline reasoning tags a provider may emit inside a normal text block
  * (`<think>…</think>`, `<thinking>…</thinking>`, `<reasoning>…</reasoning>`),
@@ -56,14 +61,27 @@ export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage
  * `thinking` blocks are handled separately and are unaffected. Only paired tags
  * are stripped; an unclosed tag is left as-is to avoid blanking a truncated
  * real reply. If stripping empties the text entirely (a pathological
- * reasoning-only text block), the original is returned unchanged.
+ * reasoning-only text block), return the tag interiors without wrappers so the
+ * reply is not blanked and raw markup does not leak.
  */
 export const stripReasoningTags = (text: string): string => {
-  const stripped = text
-    .replace(/<(think|thinking|reasoning)>[\s\S]*?<\/\1>/gi, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-  return stripped.length > 0 ? stripped : text.trim();
+  const interiors: string[] = [];
+  let working = text;
+  // Peel innermost pairs first so nested same-name tags collapse cleanly.
+  for (;;) {
+    let progressed = false;
+    working = working.replace(REASONING_INNERMOST_RE, (_match, _name, body: string) => {
+      progressed = true;
+      const inner = body.trim();
+      if (inner.length > 0) interiors.push(inner);
+      return '';
+    });
+    if (!progressed) break;
+  }
+  const stripped = working.replace(/\n{3,}/g, '\n\n').trim();
+  if (stripped.length > 0) return stripped;
+  if (interiors.length > 0) return interiors.join('\n\n');
+  return text.trim();
 };
 
 // Live-stream counterpart to stripReasoningTags. Providers often stream the

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -100,6 +100,10 @@ export interface ReasoningTagStreamState {
   openName: string | null;
   /** Exact open-tag text as received (e.g. `<Think>`), re-emitted on unclosed flush. */
   openRaw: string | null;
+  /** Same-name nesting depth; suppression only ends when the outermost tag closes. */
+  depth: number;
+  /** Body consumed while suppressed, re-emitted after `openRaw` on unclosed flush. */
+  suppressed: string;
 }
 
 export const newReasoningTagStream = (): ReasoningTagStreamState => ({
@@ -107,6 +111,8 @@ export const newReasoningTagStream = (): ReasoningTagStreamState => ({
   inReasoning: false,
   openName: null,
   openRaw: null,
+  depth: 0,
+  suppressed: '',
 });
 
 const couldBeReasoningOpenPrefix = (s: string): boolean => {
@@ -123,22 +129,36 @@ const drainReasoningTagBuffer = (
   while (state.buf.length > 0) {
     if (state.inReasoning) {
       const name = state.openName ?? 'think';
-      const closeRe = new RegExp(`</${name}>`, 'i');
-      const match = closeRe.exec(state.buf);
+      // Track nested same-name opens so suppression only ends at the
+      // outermost close — mirrors stripReasoningTags' innermost peeling.
+      const tagRe = new RegExp(`<(/?)${name}>`, 'i');
+      const match = tagRe.exec(state.buf);
       if (match) {
-        state.buf = state.buf.slice(match.index + match[0].length);
-        state.inReasoning = false;
-        state.openName = null;
-        state.openRaw = null;
+        const end = match.index + match[0].length;
+        const isClose = match[1] === '/';
+        if (isClose && state.depth <= 1) {
+          state.buf = state.buf.slice(end);
+          state.inReasoning = false;
+          state.openName = null;
+          state.openRaw = null;
+          state.depth = 0;
+          state.suppressed = '';
+          continue;
+        }
+        state.depth += isClose ? -1 : 1;
+        state.suppressed += state.buf.slice(0, end);
+        state.buf = state.buf.slice(end);
         continue;
       }
       if (flush) {
         // Unclosed: surface the remainder (including the open tag) unchanged.
-        out += (state.openRaw ?? '') + state.buf;
+        out += (state.openRaw ?? '') + state.suppressed + state.buf;
         state.buf = '';
         state.inReasoning = false;
         state.openName = null;
         state.openRaw = null;
+        state.depth = 0;
+        state.suppressed = '';
         break;
       }
       // Still inside a paired block; hold everything until the close arrives.
@@ -161,6 +181,8 @@ const drainReasoningTagBuffer = (
       state.inReasoning = true;
       state.openName = openMatch[1]!.toLowerCase();
       state.openRaw = openMatch[0];
+      state.depth = 1;
+      state.suppressed = '';
       state.buf = state.buf.slice(openMatch[0].length);
       continue;
     }

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -66,6 +66,110 @@ export const stripReasoningTags = (text: string): string => {
   return stripped.length > 0 ? stripped : text.trim();
 };
 
+// Live-stream counterpart to stripReasoningTags. Providers often stream the
+// open tag, reasoning body, and close tag across many text_delta events; if
+// those deltas were published raw, UIs (and the CLI, which prefers stream text
+// over text_final once any delta arrived) would show the thinking. Buffer a
+// partial open-tag prefix, suppress paired bodies, and on flush leave an
+// unclosed tag as-is so a truncated real reply is not blanked.
+const REASONING_OPEN_TAGS = ['<think>', '<thinking>', '<reasoning>'] as const;
+const REASONING_MAX_OPEN_LEN = '<reasoning>'.length;
+const REASONING_OPEN_RE = /^<(think|thinking|reasoning)>/i;
+
+export interface ReasoningTagStreamState {
+  buf: string;
+  inReasoning: boolean;
+  openName: string | null;
+  /** Exact open-tag text as received (e.g. `<Think>`), re-emitted on unclosed flush. */
+  openRaw: string | null;
+}
+
+export const newReasoningTagStream = (): ReasoningTagStreamState => ({
+  buf: '',
+  inReasoning: false,
+  openName: null,
+  openRaw: null,
+});
+
+const couldBeReasoningOpenPrefix = (s: string): boolean => {
+  if (!s.startsWith('<')) return false;
+  const lower = s.toLowerCase();
+  return REASONING_OPEN_TAGS.some((tag) => tag.startsWith(lower));
+};
+
+const drainReasoningTagBuffer = (
+  state: ReasoningTagStreamState,
+  flush: boolean,
+): string => {
+  let out = '';
+  while (state.buf.length > 0) {
+    if (state.inReasoning) {
+      const name = state.openName ?? 'think';
+      const closeRe = new RegExp(`</${name}>`, 'i');
+      const match = closeRe.exec(state.buf);
+      if (match) {
+        state.buf = state.buf.slice(match.index + match[0].length);
+        state.inReasoning = false;
+        state.openName = null;
+        state.openRaw = null;
+        continue;
+      }
+      if (flush) {
+        // Unclosed: surface the remainder (including the open tag) unchanged.
+        out += (state.openRaw ?? '') + state.buf;
+        state.buf = '';
+        state.inReasoning = false;
+        state.openName = null;
+        state.openRaw = null;
+        break;
+      }
+      // Still inside a paired block; hold everything until the close arrives.
+      break;
+    }
+
+    const lt = state.buf.indexOf('<');
+    if (lt === -1) {
+      out += state.buf;
+      state.buf = '';
+      break;
+    }
+    if (lt > 0) {
+      out += state.buf.slice(0, lt);
+      state.buf = state.buf.slice(lt);
+    }
+
+    const openMatch = REASONING_OPEN_RE.exec(state.buf);
+    if (openMatch) {
+      state.inReasoning = true;
+      state.openName = openMatch[1]!.toLowerCase();
+      state.openRaw = openMatch[0];
+      state.buf = state.buf.slice(openMatch[0].length);
+      continue;
+    }
+
+    const head = state.buf.slice(0, Math.min(state.buf.length, REASONING_MAX_OPEN_LEN));
+    if (!flush && couldBeReasoningOpenPrefix(head)) {
+      break;
+    }
+
+    // Not a reasoning open tag — emit the '<' and keep scanning.
+    out += '<';
+    state.buf = state.buf.slice(1);
+  }
+  return out;
+};
+
+export const pushReasoningTagDelta = (
+  state: ReasoningTagStreamState,
+  delta: string,
+): string => {
+  state.buf += delta;
+  return drainReasoningTagBuffer(state, false);
+};
+
+export const flushReasoningTagStream = (state: ReasoningTagStreamState): string =>
+  drainReasoningTagBuffer(state, true);
+
 export const extractAssistantText = (message: AssistantMessage): string => {
   const textParts = message.content
     .filter((content): content is Extract<typeof content, { type: 'text' }> => content.type === 'text')

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -49,13 +49,30 @@ export const isEmptyAssistantTurn = (message: AgentMessage): boolean => {
 export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage[] =>
   messages.filter((message) => !isEmptyAssistantTurn(message));
 
+/**
+ * Remove inline reasoning tags a provider may emit inside a normal text block
+ * (`<think>…</think>`, `<thinking>…</thinking>`, `<reasoning>…</reasoning>`),
+ * so model reasoning never leaks into the user-facing reply. Structured
+ * `thinking` blocks are handled separately and are unaffected. Only paired tags
+ * are stripped; an unclosed tag is left as-is to avoid blanking a truncated
+ * real reply. If stripping empties the text entirely (a pathological
+ * reasoning-only text block), the original is returned unchanged.
+ */
+export const stripReasoningTags = (text: string): string => {
+  const stripped = text
+    .replace(/<(think|thinking|reasoning)>[\s\S]*?<\/\1>/gi, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return stripped.length > 0 ? stripped : text.trim();
+};
+
 export const extractAssistantText = (message: AssistantMessage): string => {
   const textParts = message.content
     .filter((content): content is Extract<typeof content, { type: 'text' }> => content.type === 'text')
     .map((content) => content.text.trim())
     .filter((text) => text.length > 0);
 
-  return textParts.join('\n\n');
+  return stripReasoningTags(textParts.join('\n\n'));
 };
 
 export const extractThinkingText = (message: AssistantMessage): string => {

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -5,7 +5,7 @@ import type { ApprovalRequestStore, AttachmentStorage, AttachmentStore, Internal
 import type { LangfuseClientLike, LangfuseTurnContext } from '../langfuse.js';
 import type { SessionDescriptor } from '../runtime.js';
 import type { ApprovalGate } from './approval-gate.js';
-import type { SpeakerTagStreamState } from './message-utils.js';
+import type { ReasoningTagStreamState, SpeakerTagStreamState } from './message-utils.js';
 
 export interface RunnerSession extends SessionDescriptor {
   agent: Agent;
@@ -22,6 +22,8 @@ export interface RunnerSession extends SessionDescriptor {
   // `@Name` mentions, so a concurrent later message cannot change it mid-reply.
   turnGroupParticipants?: MessageParticipant[] | undefined;
   speakerTagStream?: SpeakerTagStreamState | undefined;
+  // Suppresses inline <think>/<thinking>/<reasoning> bodies on the live stream.
+  reasoningTagStream?: ReasoningTagStreamState | undefined;
   /** Inbound messageId of the user message that triggered the in-flight
    *  turn. Stamped onto every outbound event for that turn as
    *  `correlationId`, so callers can group events back to the originating

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -38,14 +38,27 @@ test('stripReasoningTags is a no-op when there are no tags', () => {
   assert.equal(stripReasoningTags('just a normal reply'), 'just a normal reply');
 });
 
-test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', () => {
-  const only = '<think>only reasoning, no answer</think>';
-  assert.equal(stripReasoningTags(only), only);
+test('stripReasoningTags returns pure-reasoning interiors without wrappers', () => {
+  assert.equal(
+    stripReasoningTags('<think>only reasoning, no answer</think>'),
+    'only reasoning, no answer',
+  );
+  assert.equal(
+    stripReasoningTags('<thinking>a</thinking><reasoning>b</reasoning>'),
+    'a\n\nb',
+  );
 });
 
 test('stripReasoningTags strips multiline think blocks', () => {
   assert.equal(
     stripReasoningTags('<think>\nline1\nline2\n</think>\n\nAnswer'),
+    'Answer',
+  );
+});
+
+test('stripReasoningTags peels nested same-name tags without residual close markup', () => {
+  assert.equal(
+    stripReasoningTags('<think>outer <think>inner</think> still</think>Answer'),
     'Answer',
   );
 });

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,12 +1,26 @@
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 
-import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type { AssistantMessage } from '@mariozechner/pi-ai';
 
-import { stripReasoningTags, extractAssistantText } from '../src/agent-runner/message-utils.js';
+import {
+  stripReasoningTags,
+  extractAssistantText,
+  newReasoningTagStream,
+  pushReasoningTagDelta,
+  flushReasoningTagStream,
+} from '../src/agent-runner/message-utils.js';
 
-const assistantMsg = (text: string): AgentMessage =>
-  ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AgentMessage;
+const assistantMsg = (text: string): AssistantMessage =>
+  ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AssistantMessage;
+
+const runReasoningStream = (chunks: string[]): string => {
+  const state = newReasoningTagStream();
+  let out = '';
+  for (const chunk of chunks) out += pushReasoningTagDelta(state, chunk);
+  out += flushReasoningTagStream(state);
+  return out;
+};
 
 test('stripReasoningTags removes a leading think block, keeps the answer', () => {
   assert.equal(
@@ -29,7 +43,74 @@ test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', 
   assert.equal(stripReasoningTags(only), only);
 });
 
+test('stripReasoningTags strips multiline think blocks', () => {
+  assert.equal(
+    stripReasoningTags('<think>\nline1\nline2\n</think>\n\nAnswer'),
+    'Answer',
+  );
+});
+
+test('stripReasoningTags leaves an unclosed tag as-is', () => {
+  const open = '<think>partial answer continues';
+  assert.equal(stripReasoningTags(open), open);
+});
+
 test('extractAssistantText strips inline reasoning from a text block', () => {
   const msg = assistantMsg('<think>plan</think>Final answer.');
   assert.equal(extractAssistantText(msg), 'Final answer.');
+});
+
+test('extractAssistantText strips across multiple text parts', () => {
+  const msg = {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: '<think>step1</think>Part A' },
+      { type: 'text', text: '<thinking>step2</thinking>Part B' },
+    ],
+    timestamp: 1,
+  } as unknown as AssistantMessage;
+  assert.equal(extractAssistantText(msg), 'Part A\n\nPart B');
+});
+
+describe('reasoning tag stream', () => {
+  test('suppresses a think block streamed across chunks, keeps the answer', () => {
+    assert.equal(
+      runReasoningStream(['<think>', 'let me reason', '</think>', 'Hello there']),
+      'Hello there',
+    );
+  });
+
+  test('buffers a partial open tag until it resolves', () => {
+    const state = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(state, '<thi'), '');
+    assert.equal(pushReasoningTagDelta(state, 'nk>secret'), '');
+    assert.equal(pushReasoningTagDelta(state, '</think>Visible'), 'Visible');
+    assert.equal(flushReasoningTagStream(state), '');
+  });
+
+  test('passes non-tag text through immediately', () => {
+    const state = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(state, 'Fair point.'), 'Fair point.');
+    assert.equal(pushReasoningTagDelta(state, ' Nice.'), ' Nice.');
+  });
+
+  test('emits a non-reasoning angle bracket without stalling', () => {
+    assert.equal(runReasoningStream(['a < b and <div>ok</div>']), 'a < b and <div>ok</div>');
+  });
+
+  test('flush of an unclosed tag surfaces the remainder (no blanking)', () => {
+    const state = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(state, '<think>still going'), '');
+    assert.equal(flushReasoningTagStream(state), '<think>still going');
+  });
+
+  test('handles thinking and reasoning variants mid-stream', () => {
+    assert.equal(runReasoningStream(['A', '<thinking>hmm</thinking>', 'B']), 'AB');
+    assert.equal(runReasoningStream(['<reasoning>x</reasoning>', 'done']), 'done');
+  });
+
+  test('char-by-char fragmentation still strips a full block', () => {
+    const full = '<think>plan</think>Final.';
+    assert.equal(runReasoningStream([...full]), 'Final.');
+  });
 });

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+
 import { stripReasoningTags, extractAssistantText } from '../src/agent-runner/message-utils.js';
+
+const assistantMsg = (text: string): AgentMessage =>
+  ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AgentMessage;
 
 test('stripReasoningTags removes a leading think block, keeps the answer', () => {
   assert.equal(
@@ -25,9 +30,6 @@ test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', 
 });
 
 test('extractAssistantText strips inline reasoning from a text block', () => {
-  const msg = {
-    role: 'assistant',
-    content: [{ type: 'text', text: '<think>plan</think>Final answer.' }],
-  } as any;
+  const msg = assistantMsg('<think>plan</think>Final answer.');
   assert.equal(extractAssistantText(msg), 'Final answer.');
 });

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { stripReasoningTags, extractAssistantText } from '../src/agent-runner/message-utils.js';
+
+test('stripReasoningTags removes a leading think block, keeps the answer', () => {
+  assert.equal(
+    stripReasoningTags('<think>let me reason about this</think>Hello there'),
+    'Hello there',
+  );
+});
+
+test('stripReasoningTags removes thinking/reasoning variants anywhere', () => {
+  assert.equal(stripReasoningTags('A<thinking>hmm</thinking>B'), 'AB');
+  assert.equal(stripReasoningTags('<reasoning>x</reasoning>done'), 'done');
+});
+
+test('stripReasoningTags is a no-op when there are no tags', () => {
+  assert.equal(stripReasoningTags('just a normal reply'), 'just a normal reply');
+});
+
+test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', () => {
+  const only = '<think>only reasoning, no answer</think>';
+  assert.equal(stripReasoningTags(only), only);
+});
+
+test('extractAssistantText strips inline reasoning from a text block', () => {
+  const msg = {
+    role: 'assistant',
+    content: [{ type: 'text', text: '<think>plan</think>Final answer.' }],
+  } as any;
+  assert.equal(extractAssistantText(msg), 'Final answer.');
+});

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -126,4 +126,20 @@ describe('reasoning tag stream', () => {
     const full = '<think>plan</think>Final.';
     assert.equal(runReasoningStream([...full]), 'Final.');
   });
+
+  test('nested same-name tags stay suppressed until the outermost close', () => {
+    const full = '<think>outer <think>inner</think> still</think>Answer';
+    assert.equal(runReasoningStream([full]), 'Answer');
+    assert.equal(runReasoningStream([...full]), 'Answer');
+    assert.equal(
+      runReasoningStream(['<think>outer <thi', 'nk>inner</think> still</thi', 'nk>Answer']),
+      'Answer',
+    );
+  });
+
+  test('flush of an unclosed nested tag surfaces the full remainder', () => {
+    const state = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(state, '<think>outer <think>inner'), '');
+    assert.equal(flushReasoningTagStream(state), '<think>outer <think>inner');
+  });
 });


### PR DESCRIPTION
Some providers emit reasoning inline as `<think>…</think>` inside a normal text block instead of a structured thinking block; that text flowed straight to the user. 

Adds `stripReasoningTags` and applies it in `extractAssistantText` (the single source feeding the user reply, the stream, and persisted history), removing paired `<think>` / `<thinking>` / `<reasoning>` blocks. Empty-result fallback keeps a pure-reasoning turn from being blanked. The intentional structured-thinking promotion (`isFinalThinkingOnly`) is unchanged; unclosed single tags are intentionally left as-is to avoid blanking truncated replies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering inline reasoning markup from assistant responses.
  * Reasoning content is now suppressed during live streaming, including when tags span multiple chunks.
  * Visible response text continues to display correctly when reasoning tags are incomplete or provider formatting varies.

* **Tests**
  * Added coverage for nested, multiline, streamed, and incomplete reasoning tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->