### PR TITLE
Rolling context window behind a default-off flag

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2793,38 +2793,50 @@ export class AgentRunner implements SessionRuntime {
       ? applyRollingWindow(truncatedMessages, config.context?.rolling_window_messages ?? 40)
       : truncatedMessages;
 
-    // Only offer LLM compaction when we have a dedicated API key.
-    // When streamFn is provided (tests, proxied setups), the shared stream
-    // should not be consumed by an internal compaction turn.
-    const canRunLlmCompaction =
-      !this.options.streamFn && Boolean(this.resolveApiKey(config.model.provider));
+    // When the rolling window is active it already bounds the per-turn context,
+    // so we must NOT run compaction on the truncated view: compaction can
+    // compute AND PERSIST a summary derived from only the last-N messages,
+    // corrupting the stored summary with a partial history. Skip it entirely
+    // and send the windowed messages directly. Older turns stay fetchable via
+    // `fetch_full_history`. With the flag off this branch is not taken and the
+    // compaction path below is byte-identical to before.
+    let finalMessages: AgentMessage[];
+    if (rolling) {
+      finalMessages = [...contextBlocks, ...windowedMessages];
+    } else {
+      // Only offer LLM compaction when we have a dedicated API key.
+      // When streamFn is provided (tests, proxied setups), the shared stream
+      // should not be consumed by an internal compaction turn.
+      const canRunLlmCompaction =
+        !this.options.streamFn && Boolean(this.resolveApiKey(config.model.provider));
 
-    // System prompt + tool catalog also live in every request payload.
-    // Surface them to compaction so its budget check sees the real wire
-    // size, not just the messages portion. Read from the active session's
-    // agent state when available — that's the same `systemPrompt` /
-    // `tools` snapshot the LLM call will use.
-    const agentState = this.sessions.get(sessionId)?.agent.state;
-    const overheadTokens = estimateFixedOverheadTokens({
-      systemPrompt: agentState?.systemPrompt,
-      tools: agentState?.tools,
-    });
+      // System prompt + tool catalog also live in every request payload.
+      // Surface them to compaction so its budget check sees the real wire
+      // size, not just the messages portion. Read from the active session's
+      // agent state when available — that's the same `systemPrompt` /
+      // `tools` snapshot the LLM call will use.
+      const agentState = this.sessions.get(sessionId)?.agent.state;
+      const overheadTokens = estimateFixedOverheadTokens({
+        systemPrompt: agentState?.systemPrompt,
+        tools: agentState?.tools,
+      });
 
-    const finalMessages = await compactContextIfNeeded(sessionId, config, contextBlocks, windowedMessages, {
-      store: this.store,
-      scope: this.scope,
-      options: {
-        contextCompactionMaxTokens: this.options.contextCompactionMaxTokens,
-        contextCompactionRecentMessageCount: this.options.contextCompactionRecentMessageCount,
-        contextCompactionSummaryMaxChars: this.options.contextCompactionSummaryMaxChars,
-        contextCompactionMaxMessages: this.options.contextCompactionMaxMessages,
-        fixedOverheadTokens: overheadTokens,
-      },
-      createCompactionAgent: canRunLlmCompaction
-        ? (sid) => this.createCompactionAgent(sid, config)
-        : undefined,
-      logRuntime: (msg) => this.logRuntime(msg),
-    });
+      finalMessages = await compactContextIfNeeded(sessionId, config, contextBlocks, windowedMessages, {
+        store: this.store,
+        scope: this.scope,
+        options: {
+          contextCompactionMaxTokens: this.options.contextCompactionMaxTokens,
+          contextCompactionRecentMessageCount: this.options.contextCompactionRecentMessageCount,
+          contextCompactionSummaryMaxChars: this.options.contextCompactionSummaryMaxChars,
+          contextCompactionMaxMessages: this.options.contextCompactionMaxMessages,
+          fixedOverheadTokens: overheadTokens,
+        },
+        createCompactionAgent: canRunLlmCompaction
+          ? (sid) => this.createCompactionAgent(sid, config)
+          : undefined,
+        logRuntime: (msg) => this.logRuntime(msg),
+      });
+    }
 
     // Persist a compaction back into the session's live state. The hook's
     // return value only feeds THIS request — without a write-back the

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -88,6 +88,7 @@ import {
   withApproval,
 } from './tools.js';
 import {
+  applyRollingWindow,
   compactContextIfNeeded,
   estimateAgentMessagesTokens,
   estimateFixedOverheadTokens,
@@ -2780,6 +2781,18 @@ export class AgentRunner implements SessionRuntime {
     const model = resolveModel(config);
     const truncatedMessages = truncateToolResults(cleanedMessages, model.contextWindow);
 
+    // Opt-in rolling context window (default-off). When enabled, cap the
+    // per-turn context handed to the model to the last N messages (tool-pair
+    // safe). This is REQUEST-ONLY: `windowedMessages` feeds this generation
+    // only and is never written back into live `state.messages`, so with the
+    // flag absent the behaviour below is byte-identical to today (same
+    // reference flows through). Older turns stay fetchable via
+    // `fetch_full_history`.
+    const rolling = config.context?.rolling_window_enabled === true;
+    const windowedMessages = rolling
+      ? applyRollingWindow(truncatedMessages, config.context?.rolling_window_messages ?? 40)
+      : truncatedMessages;
+
     // Only offer LLM compaction when we have a dedicated API key.
     // When streamFn is provided (tests, proxied setups), the shared stream
     // should not be consumed by an internal compaction turn.
@@ -2797,7 +2810,7 @@ export class AgentRunner implements SessionRuntime {
       tools: agentState?.tools,
     });
 
-    const finalMessages = await compactContextIfNeeded(sessionId, config, contextBlocks, truncatedMessages, {
+    const finalMessages = await compactContextIfNeeded(sessionId, config, contextBlocks, windowedMessages, {
       store: this.store,
       scope: this.scope,
       options: {
@@ -2829,8 +2842,12 @@ export class AgentRunner implements SessionRuntime {
     //   freshly prepended on every generation and would otherwise stack up.
     // - Mutate in place to preserve the array reference pi-ai holds, so the
     //   in-flight generation's appends land on the compacted list.
-    const didCompact = finalMessages.length !== contextBlocks.length + truncatedMessages.length;
-    if (isMainSessionAgent && didCompact) {
+    const didCompact = finalMessages.length !== contextBlocks.length + windowedMessages.length;
+    // The rolling window is request-only: when it is active we never persist
+    // the truncated view back into live state (that would drop older turns
+    // the agent can still pull via `fetch_full_history`). With the flag off
+    // this guard is a no-op and the write-back path is unchanged.
+    if (isMainSessionAgent && didCompact && !rolling) {
       const liveState = this.sessions.get(sessionId)?.agent.state.messages;
       if (liveState) {
         const core = finalMessages.slice(contextBlocks.length);

--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -223,6 +223,26 @@ export const getCompactionRetainedStartIndex = (
   return startIndex;
 };
 
+/**
+ * Rolling context window (request-only). Returns the last `maxMessages`
+ * messages, but if that raw cut point would start inside a
+ * toolCall→toolResult pair, the boundary is pulled back to keep the pair
+ * intact (reusing `getCompactionRetainedStartIndex`). Returns the input
+ * unchanged when `maxMessages <= 0` or the list already fits. Pure — never
+ * mutates its input and does no I/O.
+ */
+export const applyRollingWindow = (
+  messages: AgentMessage[],
+  maxMessages: number,
+): AgentMessage[] => {
+  if (maxMessages <= 0 || messages.length <= maxMessages) {
+    return messages;
+  }
+
+  const startIndex = getCompactionRetainedStartIndex(messages, maxMessages);
+  return messages.slice(startIndex);
+};
+
 export const summarizeMessageForCompaction = (message: AgentMessage): string | undefined => {
   if (!message || typeof message !== 'object' || !('role' in message)) {
     return undefined;

--- a/apps/agent/src/core/security.ts
+++ b/apps/agent/src/core/security.ts
@@ -146,6 +146,13 @@ const VoiceConfigSchema = z.object({
   tts: TtsConfigSchema.optional(),
 });
 
+// Opt-in rolling context window (default-off). Absent `context` is fine;
+// only exact true enables the window. See AgentRuntimeConfig.context.
+const ContextConfigSchema = z.object({
+  rolling_window_enabled: z.boolean().optional(),
+  rolling_window_messages: z.number().int().positive().optional(),
+});
+
 const AgentRuntimeConfigSchema = z.object({
   workspace_root: z.string(),
   model: ModelConfigSchema,
@@ -154,6 +161,7 @@ const AgentRuntimeConfigSchema = z.object({
   web: WebConfigSchema.optional(),
   channels: ChannelsConfigSchema.optional(),
   voice: VoiceConfigSchema.optional(),
+  context: ContextConfigSchema.optional(),
 });
 
 function validateConfig(config: unknown, filePath: string): asserts config is AgentRuntimeConfig {

--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -141,6 +141,19 @@ export interface AgentRuntimeConfig {
    * `@openhermit/voice`).
    */
   voice?: import('@openhermit/voice').VoiceConfig;
+  /**
+   * Opt-in rolling context window. Default-off: when
+   * `rolling_window_enabled` is not exactly `true`, per-turn context
+   * assembly is byte-identical to today. When enabled, the messages handed
+   * to the model for a generation are truncated to the last N (plus
+   * system/context blocks); older turns remain fetchable via
+   * `fetch_full_history`. Request-only — never written back into live state.
+   */
+  context?: {
+    rolling_window_enabled?: boolean;
+    /** Number of trailing messages to keep when the window is on. Default 40. */
+    rolling_window_messages?: number;
+  };
 }
 
 export type AgentConfig = AgentRuntimeConfig;

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -67,7 +67,7 @@ export const createBuiltInToolsets = (
   if (context.sessionStore) {
     toolsets.push(createSessionToolset(context));
   }
-  if (context.messageStore && context.sessionId) {
+  if (context.messageStore && context.storeScope && context.sessionId) {
     toolsets.push(createHistoryToolset(context));
   }
   if (context.scheduleStore) {

--- a/apps/agent/src/tools.ts
+++ b/apps/agent/src/tools.ts
@@ -12,6 +12,7 @@ import type {
 import { createInstructionToolset } from './tools/instruction.js';
 import { createWebToolset } from './tools/web.js';
 import { createSessionToolset } from './tools/session.js';
+import { createHistoryToolset } from './tools/history.js';
 import { createIdentityToolset, createUserToolset } from './tools/user.js';
 import { createExecToolset } from './tools/sandbox-exec.js';
 import { createFileToolset } from './tools/file.js';
@@ -65,6 +66,9 @@ export const createBuiltInToolsets = (
   }
   if (context.sessionStore) {
     toolsets.push(createSessionToolset(context));
+  }
+  if (context.messageStore && context.sessionId) {
+    toolsets.push(createHistoryToolset(context));
   }
   if (context.scheduleStore) {
     toolsets.push(createScheduleToolset(context));

--- a/apps/agent/src/tools/history.ts
+++ b/apps/agent/src/tools/history.ts
@@ -11,8 +11,14 @@ import {
 // ── Parameters ──────────────────────────────────────────────────────
 
 const HistoryFetchParams = Type.Object({
-  limit: Type.Optional(Type.Number({ description: 'Maximum number of older messages to return (default 50).' })),
-  offset: Type.Optional(Type.Number({ description: 'Number of messages to skip from the end (0 = most recent). Use with limit to page backwards through this conversation.' })),
+  limit: Type.Optional(Type.Number({ description: 'Maximum number of messages to return (default 50).' })),
+  offset: Type.Optional(Type.Number({
+    description:
+      'Number of messages to skip from the end before returning (same pagination model as session_read). '
+      + 'Default 0 returns the most recent messages, which usually already sit in the live window. '
+      + 'To reach turns that scrolled out of the rolling window, set offset ≈ rolling_window_messages '
+      + '(default 40 when that config is set), then page further back by increasing offset.',
+  })),
 });
 
 type HistoryFetchArgs = Static<typeof HistoryFetchParams>;
@@ -24,8 +30,11 @@ export const createHistoryFetchTool = (context: ToolContext): PolicyAwareTool<ty
   name: 'fetch_full_history',
   label: 'Fetch Full History',
   description:
-    'Fetch older messages from THIS conversation that may have scrolled out of the live context window. '
-    + 'Returns user and assistant messages, most recent first. Page backwards with `limit`/`offset`. '
+    'Fetch messages from THIS conversation via the store (same offset/limit model as session_read). '
+    + 'Returns user and assistant messages, most recent first. '
+    + 'offset 0 (default) returns the most recent messages, which are usually already in the live context. '
+    + 'To fetch older messages that scrolled out of a rolling window, set offset ≈ rolling_window_messages '
+    + '(default 40) and page further with higher offsets. '
     + 'Use this when you need context from earlier in the conversation that is no longer visible.',
   parameters: HistoryFetchParams,
   execute: async (_toolCallId, args: HistoryFetchArgs) => {
@@ -63,7 +72,7 @@ export const createHistoryFetchTool = (context: ToolContext): PolicyAwareTool<ty
 const HISTORY_DESCRIPTION = `\
 ### Conversation History
 
-When a rolling context window is active, only the most recent messages are kept live. Use \`fetch_full_history\` to pull older messages from this conversation on demand — nothing is lost.`;
+When a rolling context window is active, only the most recent messages are kept live. Use \`fetch_full_history\` to pull older messages from this conversation on demand — nothing is lost. Default offset 0 returns the most recent store tail (often already in context); set offset ≈ \`rolling_window_messages\` (default 40) to reach scrolled-out turns.`;
 
 export const createHistoryToolset = (context: ToolContext): Toolset => ({
   id: 'history',

--- a/apps/agent/src/tools/history.ts
+++ b/apps/agent/src/tools/history.ts
@@ -46,7 +46,7 @@ export const createHistoryFetchTool = (context: ToolContext): PolicyAwareTool<ty
     }
 
     const formatted = messages.map((m) => {
-      const tag = m.role === 'user' ? '[USER]' : m.role === 'assistant' ? '[ASSISTANT]' : `[${m.role.toUpperCase()}]`;
+      const tag = `[${m.role.toUpperCase()}]`;
       const preview = m.content.length > 500 ? `${m.content.slice(0, 500)}…` : m.content;
       return `${m.ts} ${tag} ${preview}`;
     }).join('\n\n');

--- a/apps/agent/src/tools/history.ts
+++ b/apps/agent/src/tools/history.ts
@@ -1,0 +1,72 @@
+import { Type, type Static } from '@mariozechner/pi-ai';
+import { ValidationError } from '@openhermit/shared';
+
+import {
+  type PolicyAwareTool,
+  type Toolset,
+  type ToolContext,
+  asTextContent,
+} from './shared.js';
+
+// ── Parameters ──────────────────────────────────────────────────────
+
+const HistoryFetchParams = Type.Object({
+  limit: Type.Optional(Type.Number({ description: 'Maximum number of older messages to return (default 50).' })),
+  offset: Type.Optional(Type.Number({ description: 'Number of messages to skip from the end (0 = most recent). Use with limit to page backwards through this conversation.' })),
+});
+
+type HistoryFetchArgs = Static<typeof HistoryFetchParams>;
+
+// ── Tool ────────────────────────────────────────────────────────────
+
+export const createHistoryFetchTool = (context: ToolContext): PolicyAwareTool<typeof HistoryFetchParams> => ({
+  policy: { defaultGrants: [{ type: 'any' }] },
+  name: 'fetch_full_history',
+  label: 'Fetch Full History',
+  description:
+    'Fetch older messages from THIS conversation that may have scrolled out of the live context window. '
+    + 'Returns user and assistant messages, most recent first. Page backwards with `limit`/`offset`. '
+    + 'Use this when you need context from earlier in the conversation that is no longer visible.',
+  parameters: HistoryFetchParams,
+  execute: async (_toolCallId, args: HistoryFetchArgs) => {
+    if (!context.messageStore || !context.storeScope || !context.sessionId) {
+      throw new ValidationError('fetch_full_history is unavailable: no message store or session is configured.');
+    }
+
+    const sessionId = context.sessionId;
+    const limit = args.limit ?? 50;
+    const offset = args.offset ?? 0;
+    const messages = await context.messageStore.listRecentMessages(context.storeScope, sessionId, limit, offset);
+
+    if (messages.length === 0) {
+      return {
+        content: asTextContent(`No older messages found${offset > 0 ? ` (offset ${offset})` : ''}.\n`),
+        details: { sessionId, count: 0, offset },
+      };
+    }
+
+    const formatted = messages.map((m) => {
+      const tag = m.role === 'user' ? '[USER]' : m.role === 'assistant' ? '[ASSISTANT]' : `[${m.role.toUpperCase()}]`;
+      const preview = m.content.length > 500 ? `${m.content.slice(0, 500)}…` : m.content;
+      return `${m.ts} ${tag} ${preview}`;
+    }).join('\n\n');
+
+    return {
+      content: asTextContent(`${messages.length} older messages${offset > 0 ? ` (offset ${offset})` : ''}:\n\n${formatted}\n`),
+      details: { sessionId, count: messages.length, offset },
+    };
+  },
+});
+
+// ── Toolset ────────────────────────────────────────────────────────
+
+const HISTORY_DESCRIPTION = `\
+### Conversation History
+
+When a rolling context window is active, only the most recent messages are kept live. Use \`fetch_full_history\` to pull older messages from this conversation on demand — nothing is lost.`;
+
+export const createHistoryToolset = (context: ToolContext): Toolset => ({
+  id: 'history',
+  description: HISTORY_DESCRIPTION,
+  tools: [createHistoryFetchTool(context)],
+});

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -11,6 +11,7 @@ import {
   estimateAgentMessagesTokens,
   estimateFixedOverheadTokens,
   getCompactionRetainedStartIndex,
+  applyRollingWindow,
   summarizeMessageForCompaction,
   buildContextCompactionBlock,
   compactContextIfNeeded,
@@ -987,4 +988,58 @@ test('compactContextIfNeeded compacts below the trigger with headroom (hysteresi
   );
   const second = await compactContextIfNeeded('s1', stubConfig, [], afterGrowth, deps);
   assert.equal(second.length, afterGrowth.length, 'no re-compaction within the headroom window');
+});
+
+// ── applyRollingWindow ──────────────────────────────────────────────────
+
+test('applyRollingWindow returns all messages when count <= maxMessages', () => {
+  const messages = [
+    makeUserMessage('a'),
+    makeAssistantMessage('b'),
+    makeUserMessage('c'),
+  ];
+  const result = applyRollingWindow(messages, 5);
+  assert.equal(result.length, 3);
+  assert.deepEqual(result, messages);
+});
+
+test('applyRollingWindow returns the last N when no tool pair straddles the boundary', () => {
+  const messages = [
+    makeUserMessage('u0'),
+    makeUserMessage('u1'),
+    makeUserMessage('u2'),
+    makeUserMessage('u3'),
+    makeUserMessage('u4'),
+    makeUserMessage('u5'),
+  ];
+  const result = applyRollingWindow(messages, 3);
+  assert.equal(result.length, 3);
+  assert.deepEqual(result, messages.slice(3));
+});
+
+test('applyRollingWindow never orphans a toolResult at the boundary', () => {
+  const messages = [
+    makeUserMessage('u0'),
+    makeToolCallMessage('search'),
+    makeToolResultMessage('search', 'result'),
+    makeUserMessage('u3'),
+    makeAssistantMessage('a4'),
+    makeUserMessage('u5'),
+  ];
+  // N=4 → raw cut at index 2, which is a bare toolResult preceded by the
+  // assistant toolCall; boundary must move back to include the toolCall.
+  const result = applyRollingWindow(messages, 4);
+  assert.notEqual(result[0].role, 'toolResult');
+  assert.equal(result[0].role, 'assistant');
+  assert.deepEqual(result, messages.slice(1));
+});
+
+test('applyRollingWindow returns input unchanged for maxMessages <= 0', () => {
+  const messages = [
+    makeUserMessage('a'),
+    makeUserMessage('b'),
+    makeUserMessage('c'),
+  ];
+  assert.equal(applyRollingWindow(messages, 0), messages);
+  assert.equal(applyRollingWindow(messages, -5), messages);
 });

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -1029,8 +1029,8 @@ test('applyRollingWindow never orphans a toolResult at the boundary', () => {
   // N=4 → raw cut at index 2, which is a bare toolResult preceded by the
   // assistant toolCall; boundary must move back to include the toolCall.
   const result = applyRollingWindow(messages, 4);
-  assert.notEqual(result[0].role, 'toolResult');
-  assert.equal(result[0].role, 'assistant');
+  assert.notEqual(result[0]!.role, 'toolResult');
+  assert.equal(result[0]!.role, 'assistant');
   assert.deepEqual(result, messages.slice(1));
 });
 

--- a/apps/agent/test/history-tool.test.ts
+++ b/apps/agent/test/history-tool.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { MessageRow, StoreScope } from '@openhermit/store';
+
+import { createHistoryToolset } from '../src/tools/history.js';
+import type { ToolContext } from '../src/tools/shared.js';
+
+const scope: StoreScope = { agentId: 'agent-1' };
+
+const makeContext = (
+  calls: Array<{ scope: StoreScope; sessionId: string; limit: number; offset: number | undefined }>,
+  rows: MessageRow[],
+): ToolContext => ({
+  security: {} as ToolContext['security'],
+  storeScope: scope,
+  sessionId: 'session-1',
+  messageStore: {
+    listRecentMessages: async (
+      s: StoreScope,
+      sessionId: string,
+      limit: number,
+      offset?: number,
+    ) => {
+      calls.push({ scope: s, sessionId, limit, offset });
+      return rows;
+    },
+  } as unknown as ToolContext['messageStore'],
+});
+
+test('createHistoryToolset exposes a fetch_full_history tool', () => {
+  const toolset = createHistoryToolset(makeContext([], []));
+  assert.equal(toolset.id, 'history');
+  const tool = toolset.tools.find((t) => t.name === 'fetch_full_history');
+  assert.ok(tool, 'fetch_full_history tool is registered');
+});
+
+test('fetch_full_history passes limit/offset through to listRecentMessages', async () => {
+  const calls: Array<{ scope: StoreScope; sessionId: string; limit: number; offset: number | undefined }> = [];
+  const rows: MessageRow[] = [
+    { role: 'user', content: 'first older message', ts: '2026-07-01T00:00:00.000Z' },
+    { role: 'assistant', content: 'second older message', ts: '2026-07-01T00:00:01.000Z' },
+  ];
+  const toolset = createHistoryToolset(makeContext(calls, rows));
+  const tool = toolset.tools.find((t) => t.name === 'fetch_full_history')!;
+
+  const result = await tool.execute('call-1', { limit: 50, offset: 0 });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { scope, sessionId: 'session-1', limit: 50, offset: 0 });
+
+  const text = result.content.map((c) => (c.type === 'text' ? c.text : '')).join('');
+  assert.ok(text.includes('first older message'));
+  assert.ok(text.includes('second older message'));
+});
+
+test('fetch_full_history defaults to limit 50 offset 0', async () => {
+  const calls: Array<{ scope: StoreScope; sessionId: string; limit: number; offset: number | undefined }> = [];
+  const toolset = createHistoryToolset(makeContext(calls, []));
+  const tool = toolset.tools.find((t) => t.name === 'fetch_full_history')!;
+
+  await tool.execute('call-2', {});
+
+  assert.equal(calls[0]!.limit, 50);
+  assert.equal(calls[0]!.offset, 0);
+});


### PR DESCRIPTION
Closes PROD-70 (first slice).

Adds an opt-in, default-off rolling context window for the twin agent plus a fetch_full_history tool so nothing is lost when older turns drop out of the window.

- Config: `context.rolling_window_enabled` / `rolling_window_messages` on AgentRuntimeConfig (absent => off; not in buildDefaultAgentConfig).
- `applyRollingWindow` pure helper in context-compaction.ts, reusing the existing tool-pair-safe boundary so a toolResult is never orphaned.
- Gated in transformContext, request-only: a separate windowedMessages array is used and the live-state write-back is disabled when the window is on. Flag OFF is byte-identical to today.
- `fetch_full_history` tool (tools/history.ts) reads older messages from the store on demand, registered guarded by messageStore + sessionId.

71 tests pass; zero new typecheck errors. The parallel small-model summariser and any live-state write-back are deferred to a follow-up slice.