### PR TITLE
Default agent model to gemini-3.5-flash

### DIFF
--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -155,7 +155,7 @@ export const buildDefaultAgentConfig = (workspaceRoot: string): AgentRuntimeConf
   workspace_root: workspaceRoot,
   model: {
     provider: 'openrouter',
-    model: 'google/gemini-3-flash-preview',
+    model: 'google/gemini-3.5-flash',
     max_tokens: 8192,
   },
   exec: {

--- a/apps/web/ui/src/components/BasicPanel.tsx
+++ b/apps/web/ui/src/components/BasicPanel.tsx
@@ -274,7 +274,7 @@ export function BasicPanel() {
               type="text"
               value={model}
               onChange={(e) => setModel(e.target.value)}
-              placeholder={modelsForProvider[0]?.id ?? 'e.g. google/gemini-3-flash-preview'}
+              placeholder={modelsForProvider[0]?.id ?? 'e.g. google/gemini-3.5-flash'}
               autoComplete="off"
             />
             {modelsForProvider.length > 0 && (

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,7 +180,7 @@ and its per-agent secrets. All `config` subcommands require
 hermit config show --agent main
 hermit config get model.model --agent main
 hermit config set model.provider openrouter --agent main
-hermit config set model.model google/gemini-3-flash-preview --agent main
+hermit config set model.model google/gemini-3.5-flash --agent main
 ```
 
 ### `hermit config secrets`
@@ -419,7 +419,7 @@ hermit logs --json | jq 'select(.level=="error")'
 | Create an agent | `hermit agents create main` (active by default; hydrates on first request) |
 | Talk to it | `hermit chat --agent main` |
 | Set a model API key | `hermit config secrets set OPENROUTER_API_KEY ... --agent main` |
-| Switch model | `hermit config set model.model google/gemini-3-flash-preview --agent main` |
+| Switch model | `hermit config set model.model google/gemini-3.5-flash --agent main` |
 | Add a rule everywhere | `hermit instructions append rules "..." --all` |
 | Enable a skill on every agent | `hermit skills enable my-skill --all` |
 | Schedule a weekly task | `hermit schedules create --type cron --cron '0 17 * * FRI' --prompt "..." --agent main` |

--- a/skills/openhermit-admin/SKILL.md
+++ b/skills/openhermit-admin/SKILL.md
@@ -74,7 +74,7 @@ Model:
 {
   "model": {
     "provider": "openrouter",
-    "model": "google/gemini-3-flash-preview",
+    "model": "google/gemini-3.5-flash",
     "max_tokens": 8192
   }
 }


### PR DESCRIPTION
Switch the openhermit agent default and docs examples from google/gemini-3-flash-preview to google/gemini-3.5-flash (https://openrouter.ai/google/gemini-3.5-flash).

Pairs with amiko-platform default update on PR #1188 (openrouter/google/gemini-3.5-flash).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the default Gemini model to `google/gemini-3.5-flash`.
  * Updated the custom model input placeholder to reflect the new model.

* **Documentation**
  * Updated CLI and administration examples to use `google/gemini-3.5-flash`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->