### PR TITLE
PROD-66: two-step agent reply pass (flag-gated experiment)

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2380,6 +2380,7 @@ export class AgentRunner implements SessionRuntime {
     await this.options.security.load();
     const config = await this.options.security.readConfig();
     this.ensureProviderApiKey(config.model.provider);
+    session.twoStepActive = config.experiments?.two_step?.enabled === true;
 
     const isOwnerInteractive = session.spec.source.interactive && session.resolvedUserRole === 'owner';
     const approvalCallback = isOwnerInteractive

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3336,6 +3336,12 @@ export class AgentRunner implements SessionRuntime {
         const turnCorrelationId = session.currentTurnCorrelationId;
         delete session.currentTurnCorrelationId;
         void (async () => {
+          if (session.twoStepActive && finalText && finalText.trim() !== '<NO_REPLY>') {
+            const draft = finalText;
+            const rewrite = await this.generateStyledReply(session, draft);
+            finalText = this.acceptRewrite(draft, rewrite) ? (rewrite as string) : draft;
+          }
+
           // For channel-bound sessions, run the channel.message.out@v1
           // transform so plugins can scrub/rewrite outbound text (e.g.
           // PII unmasking, brand-voice enforcement) before adapters

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3111,12 +3111,12 @@ export class AgentRunner implements SessionRuntime {
         // agent loop won't dispatch anything (no toolCall blocks), so without this rescue
         // the turn would persist with empty content and the channel adapter would never see
         // a text_final event, producing a phantom "interrupted reply".
-        const isFinalThinkingOnly =
-          !session.twoStepActive
-          && !hasText
+        const isThinkingOnly =
+          !hasText
           && hasThinking
           && (assistantMessage.stopReason !== 'toolUse' || toolCallCount === 0);
-        const effectiveText = isFinalThinkingOnly ? thinkingText : (assistantText || '');
+        const isFinalThinkingOnly = !session.twoStepActive && isThinkingOnly;
+        const effectiveText = isThinkingOnly ? thinkingText : (assistantText || '');
         const effectiveThinking = isFinalThinkingOnly ? undefined : (hasThinking ? thinkingText : undefined);
 
         if (!hasText && !hasThinking) {

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2927,13 +2927,26 @@ export class AgentRunner implements SessionRuntime {
       return null;
     }
 
+    const replySessionId = `${session.spec.sessionId}:reply`;
+    const langfuseTurnContext: LangfuseTurnContext | undefined = this.options.langfuse
+      ? {
+          currentTrace: this.options.langfuse.trace({
+            name: 'openhermit.two_step_reply',
+            sessionId: replySessionId,
+          }),
+        }
+      : undefined;
+    const startedAt = Date.now();
+
     const timeoutMs = twoStep.reply_timeout_ms ?? 8000;
     let agent: Agent | undefined;
     const timer = setTimeout(() => agent?.abort(), timeoutMs);
+    let replyText: string | null = null;
+    let replyTokens: number | undefined;
     try {
       agent = await this.createConfiguredAgent({
         config: replyConfig,
-        agentSessionId: `${session.spec.sessionId}:reply`,
+        agentSessionId: replySessionId,
         contextSessionId: session.spec.sessionId,
         tools: [],
         extraSystemPrompt: [
@@ -2941,16 +2954,35 @@ export class AgentRunner implements SessionRuntime {
           'Rewrite it as your final user-facing reply in your own voice and tone.',
           'Preserve all facts, links, and code verbatim. Output only the reply.',
         ].join('\n'),
+        ...(langfuseTurnContext ? { langfuseTurnContext } : {}),
       });
       await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
       await agent.waitForIdle();
       const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
       const rewrite = lastAssistant ? extractAssistantText(lastAssistant).trim() : '';
-      return rewrite ? rewrite : null;
+      replyText = rewrite ? rewrite : null;
+      replyTokens = lastAssistant?.usage?.totalTokens;
+      return replyText;
     } catch {
       return null;
     } finally {
       clearTimeout(timer);
+      if (this.options.langfuse && langfuseTurnContext?.currentTrace) {
+        langfuseTurnContext.currentTrace.update({
+          metadata: {
+            twoStep: true,
+            draftText,
+            replyText,
+            ...(replyTokens !== undefined ? { replyTokens } : {}),
+            rewriteLatencyMs: Date.now() - startedAt,
+          },
+        });
+        try {
+          await this.options.langfuse.flushAsync?.();
+        } catch {
+          // Best-effort telemetry should never affect request execution.
+        }
+      }
     }
   }
 

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2940,7 +2940,8 @@ export class AgentRunner implements SessionRuntime {
 
     const timeoutMs = twoStep.reply_timeout_ms ?? 8000;
     let agent: Agent | undefined;
-    const timer = setTimeout(() => agent?.abort(), timeoutMs);
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; agent?.abort(); }, timeoutMs);
     let replyText: string | null = null;
     let replyTokens: number | undefined;
     try {
@@ -2956,6 +2957,9 @@ export class AgentRunner implements SessionRuntime {
         ].join('\n'),
         ...(langfuseTurnContext ? { langfuseTurnContext } : {}),
       });
+      // The timeout may have fired during construction, before `agent` existed
+      // for the timer to abort; honor it now.
+      if (timedOut) agent.abort();
       await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
       await agent.waitForIdle();
       const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
@@ -3459,6 +3463,15 @@ export class AgentRunner implements SessionRuntime {
             type: 'agent_end',
             sessionId: session.spec.sessionId,
           });
+
+          // For two-step turns finalText is only settled here (after the reply
+          // pass overwrote the draft), so trace inside the pass to record the
+          // reply the user actually received, not the draft.
+          if (isTwoStepTurn && this.options.langfuse && session.langfuseTurnContext) {
+            await endTurnTrace(this.options.langfuse, session.langfuseTurnContext, {
+              ...(finalText ? { text: finalText } : {}),
+            });
+          }
         })();
 
         if (isTwoStepTurn) {
@@ -3472,7 +3485,7 @@ export class AgentRunner implements SessionRuntime {
           void replyPass;
         }
 
-        if (this.options.langfuse && session.langfuseTurnContext) {
+        if (!isTwoStepTurn && this.options.langfuse && session.langfuseTurnContext) {
           void endTurnTrace(this.options.langfuse, session.langfuseTurnContext, {
             ...(finalText ? { text: finalText } : {}),
           });

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3223,19 +3223,24 @@ export class AgentRunner implements SessionRuntime {
           if (u.cacheWrite) agentTokensTotal.inc({ agent_id: this.scope.agentId, direction: 'cache_write' }, u.cacheWrite);
         }
 
-        void this.queueSideEffect(session, async () => {
-          await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
-            ts,
-            role: 'assistant',
-            content: cleanedText,
-            ...(effectiveThinking ? { thinking: effectiveThinking } : {}),
-            ...(effectiveThinking && thinkingSignature ? { thinkingSignature } : {}),
-            provider: assistantMessage.provider,
-            model: assistantMessage.model,
-            usage: assistantMessage.usage,
-            stopReason: assistantMessage.stopReason,
+        // Two-step: the draft's user-facing row is folded into the reply's
+        // `thinking` field at agent_end instead, so it isn't persisted here
+        // (avoids a duplicate assistant row per turn).
+        if (!session.twoStepActive) {
+          void this.queueSideEffect(session, async () => {
+            await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
+              ts,
+              role: 'assistant',
+              content: cleanedText,
+              ...(effectiveThinking ? { thinking: effectiveThinking } : {}),
+              ...(effectiveThinking && thinkingSignature ? { thinkingSignature } : {}),
+              provider: assistantMessage.provider,
+              model: assistantMessage.model,
+              usage: assistantMessage.usage,
+              stopReason: assistantMessage.stopReason,
+            });
           });
-        });
+        }
         break;
       }
 
@@ -3299,6 +3304,11 @@ export class AgentRunner implements SessionRuntime {
       case 'agent_end': {
         const ts = new Date().toISOString();
         let finalText = session.latestAssistantText;
+        const draftText = finalText;
+        // Capture two-step-ness synchronously: twoStepActive is re-stamped
+        // per turn, and the reply pass below is un-awaited relative to the
+        // rest of this handler.
+        const isTwoStepTurn = session.twoStepActive;
         // Capture the roster synchronously: the emit below runs in a detached,
         // un-awaited async IIFE, so the next queued turn could overwrite
         // session.turnGroupParticipants before extractMentionRefs runs.
@@ -3336,10 +3346,9 @@ export class AgentRunner implements SessionRuntime {
         const turnCorrelationId = session.currentTurnCorrelationId;
         delete session.currentTurnCorrelationId;
         void (async () => {
-          if (session.twoStepActive && finalText && finalText.trim() !== '<NO_REPLY>') {
-            const draft = finalText;
-            const rewrite = await this.generateStyledReply(session, draft);
-            finalText = this.acceptRewrite(draft, rewrite) ? (rewrite as string) : draft;
+          if (isTwoStepTurn && finalText && finalText.trim() !== '<NO_REPLY>') {
+            const rewrite = await this.generateStyledReply(session, draftText!);
+            finalText = this.acceptRewrite(draftText!, rewrite) ? (rewrite as string) : draftText;
           }
 
           // For channel-bound sessions, run the channel.message.out@v1
@@ -3372,6 +3381,19 @@ export class AgentRunner implements SessionRuntime {
               text: finalText,
               ...(finalMentions.length ? { mentions: finalMentions } : {}),
               ...(turnCorrelationId !== undefined ? { correlationId: turnCorrelationId } : {}),
+            });
+          }
+
+          // Single-entry persistence: the draft's assistant row is suppressed
+          // at message_end (see the `!isTwoStepTurn` gate there) so the reply
+          // pass never produces a duplicate assistant row -- one entry per
+          // two-step turn, content = reply, thinking = draft.
+          if (isTwoStepTurn && finalText) {
+            await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
+              ts,
+              role: 'assistant',
+              content: finalText,
+              thinking: draftText,
             });
           }
 

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -55,10 +55,11 @@ import {
   extractToolResultDetails,
   extractToolResultText,
   hasCodeFenceParity,
+  hasVisibleReply,
+  preservesLinks,
   isAssistantMessage,
   isEmptyAssistantTurn,
   stripEmptyAssistantTurns,
-  stripReasoningTags,
   stripLeadingSpeakerTag,
   transcodeGroupMentions,
   extractMentionRefs,
@@ -2941,32 +2942,41 @@ export class AgentRunner implements SessionRuntime {
     const timeoutMs = twoStep.reply_timeout_ms ?? 8000;
     let agent: Agent | undefined;
     let timedOut = false;
-    const timer = setTimeout(() => { timedOut = true; agent?.abort(); }, timeoutMs);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // A true deadline over the WHOLE pass: agent construction can hang and the
+    // prompt/waitForIdle can overrun, so race everything against the timeout.
+    // When the deadline wins we return null (draft fallback) and abort the
+    // in-flight agent; any output that lands after timedOut is also rejected.
+    const deadline = new Promise<null>((resolve) => {
+      timer = setTimeout(() => { timedOut = true; agent?.abort(); resolve(null); }, timeoutMs);
+    });
     let replyText: string | null = null;
     let replyTokens: number | undefined;
     try {
-      agent = await this.createConfiguredAgent({
-        config: replyConfig,
-        agentSessionId: replySessionId,
-        contextSessionId: session.spec.sessionId,
-        tools: [],
-        extraSystemPrompt: [
-          'Below is a DRAFT answer produced by your reasoning pass.',
-          'Rewrite it as your final user-facing reply in your own voice and tone.',
-          'Preserve all facts, links, and code verbatim. Output only the reply.',
-        ].join('\n'),
-        ...(langfuseTurnContext ? { langfuseTurnContext } : {}),
-      });
-      // The timeout may have fired during construction, before `agent` existed
-      // for the timer to abort; honor it now.
-      if (timedOut) agent.abort();
-      await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
-      await agent.waitForIdle();
-      const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
-      const rewrite = lastAssistant ? extractAssistantText(lastAssistant).trim() : '';
-      replyText = rewrite ? rewrite : null;
-      replyTokens = lastAssistant?.usage?.totalTokens;
-      return replyText;
+      const work = (async (): Promise<string | null> => {
+        agent = await this.createConfiguredAgent({
+          config: replyConfig,
+          agentSessionId: replySessionId,
+          contextSessionId: session.spec.sessionId,
+          tools: [],
+          extraSystemPrompt: [
+            'Below is a DRAFT answer produced by your reasoning pass.',
+            'Rewrite it as your final user-facing reply in your own voice and tone.',
+            'Preserve all facts, links, and code verbatim. Output only the reply.',
+          ].join('\n'),
+          ...(langfuseTurnContext ? { langfuseTurnContext } : {}),
+        });
+        if (timedOut) return null;
+        await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
+        await agent.waitForIdle();
+        if (timedOut) return null;
+        const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
+        const rewrite = lastAssistant ? extractAssistantText(lastAssistant).trim() : '';
+        replyText = rewrite ? rewrite : null;
+        replyTokens = lastAssistant?.usage?.totalTokens;
+        return replyText;
+      })();
+      return await Promise.race([work, deadline]);
     } catch {
       return null;
     } finally {
@@ -2997,8 +3007,11 @@ export class AgentRunner implements SessionRuntime {
    */
   private acceptRewrite(draft: string, rewrite: string | null): boolean {
     if (draft.trim() === '<NO_REPLY>') return false;
-    if (!rewrite || stripReasoningTags(rewrite).trim() === '') return false;
-    return hasCodeFenceParity(draft, rewrite);
+    // Reject empty and reasoning-only rewrites: stripReasoningTags falls back
+    // to the original text when stripping empties it, so a `<think>…</think>`
+    // rewrite would otherwise be published as the reply.
+    if (!rewrite || !hasVisibleReply(rewrite)) return false;
+    return hasCodeFenceParity(draft, rewrite) && preservesLinks(draft, rewrite);
   }
 
   private buildReplyInput(lastUserMessageText: string | undefined, draftText: string): AgentMessage {
@@ -3450,8 +3463,12 @@ export class AgentRunner implements SessionRuntime {
               ts,
               role: 'assistant',
               content: finalText,
+              // `thinking` is the draft reply TEXT, not signed provider
+              // reasoning, so the draft's thinkingSignature is deliberately
+              // dropped: buildResumptionMessages would otherwise replay the
+              // draft as signed reasoning and signature-validating providers
+              // would reject the next turn.
               thinking: draftText,
-              ...(draftAssistantMeta?.thinkingSignature ? { thinkingSignature: draftAssistantMeta.thinkingSignature } : {}),
               provider: draftAssistantMeta?.provider ?? 'anthropic',
               model: draftAssistantMeta?.model ?? 'unknown',
               usage: draftAssistantMeta?.usage,

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -54,9 +54,11 @@ import {
   prepareAttachmentContent,
   extractToolResultDetails,
   extractToolResultText,
+  hasCodeFenceParity,
   isAssistantMessage,
   isEmptyAssistantTurn,
   stripEmptyAssistantTurns,
+  stripReasoningTags,
   stripLeadingSpeakerTag,
   transcodeGroupMentions,
   extractMentionRefs,
@@ -2943,6 +2945,17 @@ export class AgentRunner implements SessionRuntime {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  /**
+   * Fidelity guard: reject the rewrite (keep the draft) when it's empty, when
+   * it dropped code fences the draft had, or when the draft itself was
+   * `<NO_REPLY>` (the pass is skipped entirely in that case).
+   */
+  private acceptRewrite(draft: string, rewrite: string | null): boolean {
+    if (draft.trim() === '<NO_REPLY>') return false;
+    if (!rewrite || stripReasoningTags(rewrite).trim() === '') return false;
+    return hasCodeFenceParity(draft, rewrite);
   }
 
   private buildReplyInput(lastUserMessageText: string | undefined, draftText: string): AgentMessage {

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2997,7 +2997,7 @@ export class AgentRunner implements SessionRuntime {
           }
           if (outText.length > 0) {
             void this.events.publish({
-              type: 'text_delta',
+              type: session.twoStepActive ? 'thinking_delta' : 'text_delta',
               sessionId: session.spec.sessionId,
               text: outText,
               ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
@@ -3009,7 +3009,7 @@ export class AgentRunner implements SessionRuntime {
           const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
           if (tail.length > 0) {
             void this.events.publish({
-              type: 'text_delta',
+              type: session.twoStepActive ? 'thinking_delta' : 'text_delta',
               sessionId: session.spec.sessionId,
               text: tail,
               ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),
@@ -3112,7 +3112,8 @@ export class AgentRunner implements SessionRuntime {
         // the turn would persist with empty content and the channel adapter would never see
         // a text_final event, producing a phantom "interrupted reply".
         const isFinalThinkingOnly =
-          !hasText
+          !session.twoStepActive
+          && !hasText
           && hasThinking
           && (assistantMessage.stopReason !== 'toolUse' || toolCallCount === 0);
         const effectiveText = isFinalThinkingOnly ? thinkingText : (assistantText || '');

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3225,8 +3225,18 @@ export class AgentRunner implements SessionRuntime {
 
         // Two-step: the draft's user-facing row is folded into the reply's
         // `thinking` field at agent_end instead, so it isn't persisted here
-        // (avoids a duplicate assistant row per turn).
-        if (!session.twoStepActive) {
+        // (avoids a duplicate assistant row per turn). Stash the draft's
+        // provider/model/usage/stopReason so agent_end can reuse them on
+        // that single row.
+        if (session.twoStepActive) {
+          session.latestAssistantMeta = {
+            provider: assistantMessage.provider,
+            model: assistantMessage.model,
+            usage: assistantMessage.usage,
+            stopReason: assistantMessage.stopReason,
+            ...(thinkingSignature ? { thinkingSignature } : {}),
+          };
+        } else {
           void this.queueSideEffect(session, async () => {
             await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
               ts,
@@ -3309,6 +3319,10 @@ export class AgentRunner implements SessionRuntime {
         // per turn, and the reply pass below is un-awaited relative to the
         // rest of this handler.
         const isTwoStepTurn = session.twoStepActive;
+        // Snapshot the draft's provider/model/usage/stopReason captured at
+        // message_end, so the single persisted row below matches the shape
+        // of every other assistant appendLogEntry call.
+        const draftAssistantMeta = session.latestAssistantMeta;
         // Capture the roster synchronously: the emit below runs in a detached,
         // un-awaited async IIFE, so the next queued turn could overwrite
         // session.turnGroupParticipants before extractMentionRefs runs.
@@ -3394,6 +3408,11 @@ export class AgentRunner implements SessionRuntime {
               role: 'assistant',
               content: finalText,
               thinking: draftText,
+              ...(draftAssistantMeta?.thinkingSignature ? { thinkingSignature: draftAssistantMeta.thinkingSignature } : {}),
+              provider: draftAssistantMeta?.provider ?? 'anthropic',
+              model: draftAssistantMeta?.model ?? 'unknown',
+              usage: draftAssistantMeta?.usage,
+              stopReason: draftAssistantMeta?.stopReason ?? 'stop',
             });
           }
 
@@ -3410,6 +3429,7 @@ export class AgentRunner implements SessionRuntime {
         }
 
         session.latestAssistantText = undefined;
+        delete session.latestAssistantMeta;
         void this.queueSideEffect(session, async () => {
           await this.store.messages.appendLogEntry(this.scope,session.spec.sessionId, {
             ts,

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2910,7 +2910,11 @@ export class AgentRunner implements SessionRuntime {
    * lose the answer — returns null on throw / timeout / empty output / missing
    * provider key, and the caller falls back to publishing the draft.
    */
-  private async generateStyledReply(session: RunnerSession, draftText: string): Promise<string | null> {
+  private async generateStyledReply(
+    session: RunnerSession,
+    draftText: string,
+    lastUserMessageText: string | undefined,
+  ): Promise<string | null> {
     const config = await this.options.security.readConfig();
     const twoStep = config.experiments?.two_step;
     if (!twoStep?.enabled) return null;
@@ -2967,7 +2971,7 @@ export class AgentRunner implements SessionRuntime {
           ...(langfuseTurnContext ? { langfuseTurnContext } : {}),
         });
         if (timedOut) return null;
-        await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
+        await agent.prompt(this.buildReplyInput(lastUserMessageText, draftText));
         await agent.waitForIdle();
         if (timedOut) return null;
         const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
@@ -3417,7 +3421,10 @@ export class AgentRunner implements SessionRuntime {
         delete session.currentTurnCorrelationId;
         const replyPass = (async () => {
           if (isTwoStepTurn && finalText && finalText.trim() !== '<NO_REPLY>') {
-            const rewrite = await this.generateStyledReply(session, draftText!);
+            // Use the user-text snapshot captured before this pass was queued;
+            // a later postMessage can overwrite session.lastUserMessageText
+            // before the queued reply pass builds its prompt.
+            const rewrite = await this.generateStyledReply(session, draftText!, lastUserMessageText);
             finalText = this.acceptRewrite(draftText!, rewrite) ? (rewrite as string) : draftText;
           }
 
@@ -3457,12 +3464,15 @@ export class AgentRunner implements SessionRuntime {
           // Single-entry persistence: the draft's assistant row is suppressed
           // at message_end (see the `!isTwoStepTurn` gate there) so the reply
           // pass never produces a duplicate assistant row -- one entry per
-          // two-step turn, content = reply, thinking = draft.
-          if (isTwoStepTurn && finalText) {
+          // two-step turn, content = reply, thinking = draft. Fall back to the
+          // draft as content when channel.message.out@v1 stripped finalText to
+          // empty, so the turn never loses its assistant history row.
+          const persistedContent = finalText || draftText;
+          if (isTwoStepTurn && persistedContent && persistedContent.trim() !== '<NO_REPLY>') {
             await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
               ts,
               role: 'assistant',
-              content: finalText,
+              content: persistedContent,
               // `thinking` is the draft reply TEXT, not signed provider
               // reasoning, so the draft's thinkingSignature is deliberately
               // dropped: buildResumptionMessages would otherwise replay the

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -2894,6 +2894,65 @@ export class AgentRunner implements SessionRuntime {
     });
   }
 
+  /**
+   * Reply pass (PROD-66): rewrites the tool loop's draft answer in the twin's
+   * voice, gated behind `config.experiments.two_step`. Never lets a failure
+   * lose the answer — returns null on throw / timeout / empty output / missing
+   * provider key, and the caller falls back to publishing the draft.
+   */
+  private async generateStyledReply(session: RunnerSession, draftText: string): Promise<string | null> {
+    const config = await this.options.security.readConfig();
+    const twoStep = config.experiments?.two_step;
+    if (!twoStep?.enabled) return null;
+
+    // Reply pass never thinks: thinking blocks on some providers (e.g.
+    // MiniMax-M3 via anthropic-messages) 400 on a no-tools no-history turn.
+    const replyConfig: AgentConfig = {
+      ...config,
+      model: { ...(twoStep.reply_model ?? config.model), thinking: 'off' },
+    };
+
+    try {
+      this.ensureProviderApiKey(replyConfig.model.provider);
+    } catch {
+      return null;
+    }
+
+    const timeoutMs = twoStep.reply_timeout_ms ?? 8000;
+    let agent: Agent | undefined;
+    const timer = setTimeout(() => agent?.abort(), timeoutMs);
+    try {
+      agent = await this.createConfiguredAgent({
+        config: replyConfig,
+        agentSessionId: `${session.spec.sessionId}:reply`,
+        contextSessionId: session.spec.sessionId,
+        tools: [],
+        extraSystemPrompt: [
+          'Below is a DRAFT answer produced by your reasoning pass.',
+          'Rewrite it as your final user-facing reply in your own voice and tone.',
+          'Preserve all facts, links, and code verbatim. Output only the reply.',
+        ].join('\n'),
+      });
+      await agent.prompt(this.buildReplyInput(session.lastUserMessageText, draftText));
+      await agent.waitForIdle();
+      const lastAssistant = [...agent.state.messages].reverse().find(isAssistantMessage);
+      const rewrite = lastAssistant ? extractAssistantText(lastAssistant).trim() : '';
+      return rewrite ? rewrite : null;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private buildReplyInput(lastUserMessageText: string | undefined, draftText: string): AgentMessage {
+    const parts = [
+      ...(lastUserMessageText ? [`User: ${lastUserMessageText}`] : []),
+      `Draft: ${draftText}`,
+    ];
+    return { role: 'user', content: [{ type: 'text', text: parts.join('\n\n') }], timestamp: Date.now() };
+  }
+
   private resolveWebProvider(config: AgentConfig): WebProvider | undefined {
     const providerName = config.web?.provider ?? 'defuddle';
 

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3478,6 +3478,14 @@ export class AgentRunner implements SessionRuntime {
 
         const turnCorrelationId = session.currentTurnCorrelationId;
         delete session.currentTurnCorrelationId;
+        // Barrier over every side effect queued so far this turn (user message,
+        // tool results, agent_start, persistSessionIndex). The reply pass persists
+        // its assistant row with a direct appendLogEntry, not queueSideEffect, so
+        // without this a fast/instant rewrite could write the assistant row before
+        // those queued rows land. Awaiting the snapshot before the direct write
+        // restores ordering; it excludes the pass's own later queueSideEffect
+        // chaining (below), so it cannot deadlock on itself.
+        const priorSideEffects = session.sideEffects;
         const replyPass = (async () => {
           if (isTwoStepTurn && finalText && finalText.trim() !== '<NO_REPLY>') {
             // Use the user-text snapshot captured before this pass was queued;
@@ -3528,6 +3536,9 @@ export class AgentRunner implements SessionRuntime {
           // empty, so the turn never loses its assistant history row.
           const persistedContent = finalText || draftText;
           if (isTwoStepTurn && persistedContent && persistedContent.trim() !== '<NO_REPLY>') {
+            // Order after this turn's already-queued rows so the assistant row
+            // never overtakes the user/tool/agent_start entries.
+            await priorSideEffects;
             await this.store.messages.appendLogEntry(this.scope, session.spec.sessionId, {
               ts,
               role: 'assistant',

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -3034,7 +3034,7 @@ export class AgentRunner implements SessionRuntime {
           const tail = flushSpeakerTagStream(session.speakerTagStream, session.groupSenderNames ?? []);
           if (tail.length > 0) {
             void this.events.publish({
-              type: 'text_delta',
+              type: session.twoStepActive ? 'thinking_delta' : 'text_delta',
               sessionId: session.spec.sessionId,
               text: tail,
               ...(session.currentTurnCorrelationId ? { correlationId: session.currentTurnCorrelationId } : {}),

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -1216,6 +1216,13 @@ export class AgentRunner implements SessionRuntime {
 
     const run = async (): Promise<void> => {
       try {
+        if (session.pendingReplyPass) {
+          // Two-step turns publish text_final from a queue-chained but
+          // un-awaited-by-run() reply pass; wait for it here so this turn's
+          // events can never interleave ahead of the prior turn's final.
+          await session.pendingReplyPass.catch(() => undefined);
+          delete session.pendingReplyPass;
+        }
         await this.refreshAgentConfiguration(session);
         // Snapshot this turn's roster
         session.turnGroupParticipants = message.participants ?? undefined;
@@ -3359,7 +3366,7 @@ export class AgentRunner implements SessionRuntime {
 
         const turnCorrelationId = session.currentTurnCorrelationId;
         delete session.currentTurnCorrelationId;
-        void (async () => {
+        const replyPass = (async () => {
           if (isTwoStepTurn && finalText && finalText.trim() !== '<NO_REPLY>') {
             const rewrite = await this.generateStyledReply(session, draftText!);
             finalText = this.acceptRewrite(draftText!, rewrite) ? (rewrite as string) : draftText;
@@ -3421,6 +3428,17 @@ export class AgentRunner implements SessionRuntime {
             sessionId: session.spec.sessionId,
           });
         })();
+
+        if (isTwoStepTurn) {
+          // The next queued turn's run() awaits this before starting, so
+          // turn ordering holds even though the pass itself is not awaited
+          // here. Also chain it through session.sideEffects so teardown's
+          // `await session.sideEffects` never orphans it fire-and-forget.
+          session.pendingReplyPass = replyPass;
+          void this.queueSideEffect(session, () => replyPass);
+        } else {
+          void replyPass;
+        }
 
         if (this.options.langfuse && session.langfuseTurnContext) {
           void endTurnTrace(this.options.langfuse, session.langfuseTurnContext, {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -66,14 +66,36 @@ export const stripReasoningTags = (text: string): string => {
   return stripped.length > 0 ? stripped : text.trim();
 };
 
+const REASONING_TAG_RE = /<(think|thinking|reasoning)>[\s\S]*?<\/\1>/gi;
+
 /**
  * The reply pass must never silently drop a code block the draft had. Counts
- * ``` fence markers rather than parsing markdown, and rejects any rewrite with
- * fewer fences than the draft (a dropped or unclosed code block).
+ * ``` fence markers rather than parsing markdown, and rejects a rewrite with
+ * fewer fences than the draft (a dropped block) or an odd fence count (an
+ * unclosed block the rewrite introduced).
  */
 export const hasCodeFenceParity = (draft: string, rewrite: string): boolean => {
   const fences = (s: string) => (s.match(/```/g) ?? []).length;
-  return fences(rewrite) >= fences(draft);
+  return fences(rewrite) >= fences(draft) && fences(rewrite) % 2 === 0;
+};
+
+/** True if the text still has user-facing content once reasoning tags are removed. */
+export const hasVisibleReply = (text: string): boolean =>
+  text
+    .replace(REASONING_TAG_RE, '')
+    // An unclosed reasoning block (truncated output) leaks reasoning too, so
+    // treat everything from an unmatched opening tag onward as reasoning.
+    .replace(/<(think|thinking|reasoning)>[\s\S]*$/i, '')
+    .trim().length > 0;
+
+/** Every http(s) URL in the draft must survive verbatim in the rewrite. */
+export const preservesLinks = (draft: string, rewrite: string): boolean => {
+  // Trailing sentence punctuation is not part of the URL; keep it out of the
+  // comparison so a preserved link that is re-punctuated isn't false-rejected.
+  const urls = (draft.match(/https?:\/\/[^\s)\]]+/gi) ?? []).map((url) =>
+    url.replace(/[.,!?;:]+$/, ''),
+  );
+  return urls.every((url) => rewrite.includes(url));
 };
 
 export const extractAssistantText = (message: AssistantMessage): string => {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -49,13 +49,30 @@ export const isEmptyAssistantTurn = (message: AgentMessage): boolean => {
 export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage[] =>
   messages.filter((message) => !isEmptyAssistantTurn(message));
 
+/**
+ * Remove inline reasoning tags a provider may emit inside a normal text block
+ * (`<think>…</think>`, `<thinking>…</thinking>`, `<reasoning>…</reasoning>`),
+ * so model reasoning never leaks into the user-facing reply. Structured
+ * `thinking` blocks are handled separately and are unaffected. Only paired tags
+ * are stripped; an unclosed tag is left as-is to avoid blanking a truncated
+ * real reply. If stripping empties the text entirely (a pathological
+ * reasoning-only text block), the original is returned unchanged.
+ */
+export const stripReasoningTags = (text: string): string => {
+  const stripped = text
+    .replace(/<(think|thinking|reasoning)>[\s\S]*?<\/\1>/gi, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return stripped.length > 0 ? stripped : text.trim();
+};
+
 export const extractAssistantText = (message: AssistantMessage): string => {
   const textParts = message.content
     .filter((content): content is Extract<typeof content, { type: 'text' }> => content.type === 'text')
     .map((content) => content.text.trim())
     .filter((text) => text.length > 0);
 
-  return textParts.join('\n\n');
+  return stripReasoningTags(textParts.join('\n\n'));
 };
 
 export const extractThinkingText = (message: AssistantMessage): string => {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -66,6 +66,17 @@ export const stripReasoningTags = (text: string): string => {
   return stripped.length > 0 ? stripped : text.trim();
 };
 
+/**
+ * The reply pass must never silently drop a code block the draft had. Counts
+ * fence markers rather than parsing markdown, since an odd count in either
+ * string already signals a truncated/malformed fence the rewrite shouldn't
+ * be trusted to have preserved faithfully.
+ */
+export const hasCodeFenceParity = (draft: string, rewrite: string): boolean => {
+  const fences = (s: string) => (s.match(/```/g) ?? []).length;
+  return fences(rewrite) >= fences(draft);
+};
+
 export const extractAssistantText = (message: AssistantMessage): string => {
   const textParts = message.content
     .filter((content): content is Extract<typeof content, { type: 'text' }> => content.type === 'text')

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -92,10 +92,12 @@ export const hasVisibleReply = (text: string): boolean =>
 export const preservesLinks = (draft: string, rewrite: string): boolean => {
   // Trailing sentence punctuation is not part of the URL; keep it out of the
   // comparison so a preserved link that is re-punctuated isn't false-rejected.
-  const urls = (draft.match(/https?:\/\/[^\s)\]]+/gi) ?? []).map((url) =>
-    url.replace(/[.,!?;:]+$/, ''),
-  );
-  return urls.every((url) => rewrite.includes(url));
+  const extractUrls = (text: string): string[] =>
+    (text.match(/https?:\/\/[^\s)\]]+/gi) ?? []).map((url) => url.replace(/[.,!?;:]+$/, ''));
+  // Compare whole URLs, not substrings: `includes` would accept a rewrite that
+  // redirected `https://trusted.example` to `https://trusted.example.evil`.
+  const rewriteUrls = new Set(extractUrls(rewrite));
+  return extractUrls(draft).every((url) => rewriteUrls.has(url));
 };
 
 export const extractAssistantText = (message: AssistantMessage): string => {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -68,9 +68,8 @@ export const stripReasoningTags = (text: string): string => {
 
 /**
  * The reply pass must never silently drop a code block the draft had. Counts
- * fence markers rather than parsing markdown, since an odd count in either
- * string already signals a truncated/malformed fence the rewrite shouldn't
- * be trusted to have preserved faithfully.
+ * ``` fence markers rather than parsing markdown, and rejects any rewrite with
+ * fewer fences than the draft (a dropped or unclosed code block).
  */
 export const hasCodeFenceParity = (draft: string, rewrite: string): boolean => {
   const fences = (s: string) => (s.match(/```/g) ?? []).length;

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -43,6 +43,10 @@ export interface RunnerSession extends SessionDescriptor {
   resolvedChannelUserId?: string;
   langfuseTurnContext?: LangfuseTurnContext;
   turnStartMs?: number;
+  /** Stamped fresh at the top of every turn from `config.experiments.two_step.enabled`. */
+  twoStepActive?: boolean;
+  /** In-flight reply pass for the current turn; the turn queue awaits this when set. */
+  pendingReplyPass?: Promise<void>;
   /** Consecutive failed tool results in the current turn. Resets at turn
    *  start and on any successful tool result. The agent aborts the turn
    *  when this reaches `MAX_CONSECUTIVE_TOOL_FAILURES` to prevent the

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -1,4 +1,5 @@
 import type { Agent, StreamFn } from '@mariozechner/pi-agent-core';
+import type { StopReason, Usage } from '@mariozechner/pi-ai';
 import type { MessageParticipant, SessionStatus } from '@openhermit/protocol';
 import type { ApprovalRequestStore, AttachmentStorage, AttachmentStore, InternalStateStore, McpServerStore, PolicyStore, SandboxStore, SkillStore, UserRole } from '@openhermit/store';
 
@@ -15,6 +16,16 @@ export interface RunnerSession extends SessionDescriptor {
   checkpointInProgress: boolean;
   idleSummaryTimer: ReturnType<typeof setTimeout> | undefined;
   latestAssistantText: string | undefined;
+  /** Draft assistant message's provider/model/usage/stopReason (+ thinkingSignature),
+   *  captured at message_end so a two-step agent_end can persist the single
+   *  assistant row with the same shape as a normal turn. */
+  latestAssistantMeta?: {
+    provider: string;
+    model: string;
+    usage: Usage;
+    stopReason: StopReason;
+    thinkingSignature?: string;
+  };
   lastUserMessageText?: string;
   // Sender names for stripping a copied `[Name]` tag from the reply. Group only.
   groupSenderNames?: Set<string>;

--- a/apps/agent/src/core/security.ts
+++ b/apps/agent/src/core/security.ts
@@ -146,6 +146,16 @@ const VoiceConfigSchema = z.object({
   tts: TtsConfigSchema.optional(),
 });
 
+const TwoStepConfigSchema = z.object({
+  enabled: z.boolean(),
+  reply_model: ModelConfigSchema.optional(),
+  reply_timeout_ms: z.number().int().positive().optional(),
+});
+
+const ExperimentsConfigSchema = z.object({
+  two_step: TwoStepConfigSchema.optional(),
+});
+
 const AgentRuntimeConfigSchema = z.object({
   workspace_root: z.string(),
   model: ModelConfigSchema,
@@ -154,7 +164,12 @@ const AgentRuntimeConfigSchema = z.object({
   web: WebConfigSchema.optional(),
   channels: ChannelsConfigSchema.optional(),
   voice: VoiceConfigSchema.optional(),
+  experiments: ExperimentsConfigSchema.optional(),
 });
+
+/** Schema-boundary parse for tests; validates known fields without requiring the full config. */
+export const parseAgentRuntimeConfig = (config: unknown) =>
+  AgentRuntimeConfigSchema.partial().parse(config);
 
 function validateConfig(config: unknown, filePath: string): asserts config is AgentRuntimeConfig {
   const result = AgentRuntimeConfigSchema.safeParse(config);

--- a/apps/agent/src/core/types.ts
+++ b/apps/agent/src/core/types.ts
@@ -48,6 +48,12 @@ export const DEFAULT_INTROSPECTION_CONFIG: IntrospectionConfig = {
   model: null,
 };
 
+export interface TwoStepConfig {
+  enabled: boolean;
+  reply_model?: AgentModelConfig | undefined;
+  reply_timeout_ms?: number | undefined;
+}
+
 export interface MemoryConfig {
   context_entry_limit?: number | undefined;
   introspection?: IntrospectionConfig | undefined;
@@ -141,6 +147,7 @@ export interface AgentRuntimeConfig {
    * `@openhermit/voice`).
    */
   voice?: import('@openhermit/voice').VoiceConfig;
+  experiments?: { two_step?: TwoStepConfig | undefined } | undefined;
 }
 
 export type AgentConfig = AgentRuntimeConfig;

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+
 import { stripReasoningTags, extractAssistantText } from '../src/agent-runner/message-utils.js';
+
+const assistantMsg = (text: string): AgentMessage =>
+  ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 1 }) as unknown as AgentMessage;
 
 test('stripReasoningTags removes a leading think block, keeps the answer', () => {
   assert.equal(
@@ -25,9 +30,6 @@ test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', 
 });
 
 test('extractAssistantText strips inline reasoning from a text block', () => {
-  const msg = {
-    role: 'assistant',
-    content: [{ type: 'text', text: '<think>plan</think>Final answer.' }],
-  } as any;
+  const msg = assistantMsg('<think>plan</think>Final answer.');
   assert.equal(extractAssistantText(msg), 'Final answer.');
 });

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { stripReasoningTags, extractAssistantText } from '../src/agent-runner/message-utils.js';
+
+test('stripReasoningTags removes a leading think block, keeps the answer', () => {
+  assert.equal(
+    stripReasoningTags('<think>let me reason about this</think>Hello there'),
+    'Hello there',
+  );
+});
+
+test('stripReasoningTags removes thinking/reasoning variants anywhere', () => {
+  assert.equal(stripReasoningTags('A<thinking>hmm</thinking>B'), 'AB');
+  assert.equal(stripReasoningTags('<reasoning>x</reasoning>done'), 'done');
+});
+
+test('stripReasoningTags is a no-op when there are no tags', () => {
+  assert.equal(stripReasoningTags('just a normal reply'), 'just a normal reply');
+});
+
+test('stripReasoningTags leaves a pure-reasoning text unchanged (no blanking)', () => {
+  const only = '<think>only reasoning, no answer</think>';
+  assert.equal(stripReasoningTags(only), only);
+});
+
+test('extractAssistantText strips inline reasoning from a text block', () => {
+  const msg = {
+    role: 'assistant',
+    content: [{ type: 'text', text: '<think>plan</think>Final answer.' }],
+  } as any;
+  assert.equal(extractAssistantText(msg), 'Final answer.');
+});

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -185,9 +185,10 @@ const createTwoStepFixture = async (t: TestContext, options?: { langfuse?: Langf
         const agentEnds = runner.events
           .getBacklog(sessionId)
           .filter((entry) => entry.event.type === 'agent_end').length;
-        if (agentEnds >= ordinal) break;
+        if (agentEnds >= ordinal) return;
         await new Promise((resolve) => setImmediate(resolve));
       }
+      throw new Error(`postAndIdle: turn ${ordinal} never reached agent_end within 10s`);
     },
     /**
      * Fire-and-continue variant of `postAndIdle`: queues the turn and
@@ -383,6 +384,18 @@ const fidelityCases: [string, string, boolean][] = [
   ['plain draft', 'plain reply', true],
   ['```js\nx\n```', 'no fence here', false],
   ['has content', '', false],
+  // Reasoning-only rewrite must fall back to the draft, never publish reasoning.
+  ['real draft', '<think>just reasoning</think>', false],
+  // An unclosed reasoning block is still reasoning-only and must be rejected.
+  ['real draft', '<think>truncated reasoning that never closes', false],
+  // A link re-punctuated in the rewrite is still preserved (no false reject).
+  ['see https://example.com/docs. more', 'yo https://example.com/docs now', true],
+  // Unclosed/odd fence count in the rewrite is rejected even if >= the draft.
+  ['```js\nx\n```', '```js\nx\n```\n```extra', false],
+  // A draft URL dropped by the rewrite is rejected.
+  ['see https://example.com/docs', 'see the docs', false],
+  // A draft URL preserved verbatim is accepted.
+  ['see https://example.com/docs', 'check out https://example.com/docs now', true],
 ];
 for (const [draft, rewrite, keepRewrite] of fidelityCases) {
   test(`fidelity guard: ${draft.slice(0, 12)}`, async (t) => {

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -218,15 +218,18 @@ test('flag on + group source: message_end backstop flushes thinking_delta, not t
   assert.ok(kinds.includes('thinking_delta'));
 });
 
-test('flag on: thinking-only draft is not promoted to a premature text_final', async (t) => {
+test('flag on: thinking-only draft is not promoted at message_end, but survives as the agent_end fallback', async (t) => {
   const fx = await createTwoStepFixture(t);
   await fx.setFlag(true);
   await fx.postAndIdle('hi', { responders: [thinkingOnlyTurn('internal reasoning only')] });
   // isFinalThinkingOnly is gated off while two-step is active, so message_end
-  // never promotes thinking to text_final (only a future agent_end reply
-  // pass would ever publish one for this draft).
+  // never promotes thinking to an early text_final. But latestAssistantText
+  // still carries the draft's thinking as its fallback content, so agent_end
+  // publishes exactly one text_final from it (no reply pass wired yet) --
+  // the answer must never be silently dropped.
   const finals = fx.backlog().filter((e) => e.type === 'text_final');
-  assert.equal(finals.length, 0);
+  assert.equal(finals.length, 1);
+  assert.match((finals[0] as { text: string }).text, /internal reasoning/);
 });
 
 test('flag off: thinking-only promotion behavior is unchanged', async (t) => {

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -87,13 +87,17 @@ const thinkingOnlyTurn = (thinking: string) => () => createThinkingOnlyResponseS
  * per-turn scripted streamFn, so a "turn" is just `postAndIdle(text)`.
  * Reused by every two-step task's tests.
  */
+type Responder = () =>
+  | ReturnType<typeof createAssistantMessageEventStream>
+  | Promise<ReturnType<typeof createAssistantMessageEventStream>>;
+
 const createTwoStepFixture = async (t: TestContext) => {
   const { workspace, security } = await createSecurityFixture(t, {
     secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
   });
   await security.load();
 
-  const responders: Array<() => ReturnType<typeof createAssistantMessageEventStream>> = [];
+  const responders: Responder[] = [];
   let callIndex = 0;
   const streamFn: StreamFn = async () => {
     const responder = responders[callIndex];
@@ -126,35 +130,88 @@ const createTwoStepFixture = async (t: TestContext) => {
     },
     async postAndIdle(
       text: string,
-      options?: { responders?: Array<() => ReturnType<typeof createAssistantMessageEventStream>> },
+      options?: { responders?: Responder[] },
     ): Promise<void> {
       messageCounter += 1;
+      const ordinal = messageCounter;
       if (options?.responders?.length) {
         responders.push(...options.responders);
       } else {
-        responders.push(() => createTextResponseStream(`response ${messageCounter}`));
+        responders.push(() => createTextResponseStream(`response ${ordinal}`));
       }
-      await runner.postMessage(sessionId, { messageId: `msg-${messageCounter}`, text });
+      await runner.postMessage(sessionId, { messageId: `msg-${ordinal}`, text });
       await runner.waitForSessionIdle(sessionId);
-      // The agent_end handler's text_final publish runs in a detached,
-      // un-awaited IIFE (queue chaining lands in a later task), and now
-      // does real work (generateStyledReply) when two-step is active, so
-      // waitForSessionIdle can return before it settles. Give it a few
-      // extra ticks so the backlog reflects the completed turn.
-      for (let i = 0; i < 5000; i += 1) {
+      // The agent_end handler's text_final publish runs in a detached IIFE
+      // (queue-chained via session.pendingReplyPass, not awaited by
+      // waitForSessionIdle) and does real work (generateStyledReply) when
+      // two-step is active, so waitForSessionIdle can return before it
+      // settles. Give it a few extra real time to let the backlog reflect
+      // the completed turn (time-bound, not iteration-bound -- iteration
+      // counts don't map to a fixed amount of wall-clock time under load).
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
         const agentEnds = runner.events
           .getBacklog(sessionId)
           .filter((entry) => entry.event.type === 'agent_end').length;
-        if (agentEnds >= messageCounter) break;
+        if (agentEnds >= ordinal) break;
         await new Promise((resolve) => setImmediate(resolve));
       }
+    },
+    /**
+     * Fire-and-continue variant of `postAndIdle`: queues the turn and
+     * resolves once that turn's own `agent_end` has landed in the backlog,
+     * without waiting for `session.queue`/`sideEffects` overall -- so two
+     * calls can be launched back to back to exercise queue-chaining/ordering
+     * across turns (see the queue-chaining tests).
+     */
+    async post(text: string, options?: { responders?: Responder[] }): Promise<void> {
+      messageCounter += 1;
+      const ordinal = messageCounter;
+      const messageId = `msg-${ordinal}`;
+      if (options?.responders?.length) {
+        responders.push(...options.responders);
+      } else {
+        responders.push(() => createTextResponseStream(`response ${ordinal}`));
+      }
+      await runner.postMessage(sessionId, { messageId, text });
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        const agentEnds = runner.events
+          .getBacklog(sessionId)
+          .filter((entry) => entry.event.type === 'agent_end').length;
+        if (agentEnds >= ordinal) return;
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      throw new Error(`timed out waiting for turn "${messageId}" to complete`);
     },
     backlog() {
       return runner.events.getBacklog(sessionId).map((entry) => entry.event);
     },
+    /** Number of streamFn calls made so far -- used to observe queue ordering directly. */
+    callCount(): number {
+      return callIndex;
+    },
     /** Scripts the next raw streamFn call — used to drive generateStyledReply directly. */
-    scriptReply(responder: () => ReturnType<typeof createAssistantMessageEventStream>): void {
+    scriptReply(responder: Responder): void {
       responders.push(responder);
+    },
+    /**
+     * A gated responder: the stream is only produced once `release()` is
+     * called, so it can hold a two-step reply pass open mid-flight to
+     * exercise queue-chaining/teardown ordering.
+     */
+    deferReply(replyText = 'gated reply'): { responder: Responder; release: () => void } {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return {
+        responder: async () => {
+          await gate;
+          return createTextResponseStream(replyText);
+        },
+        release,
+      };
     },
     /** Test-only accessor for the private reply-pass method (TS `private` is compile-time only). */
     generateStyledReplyForTest(session: RunnerSession, draftText: string): Promise<string | null> {
@@ -341,4 +398,111 @@ test('two-step: reply failure falls back to draft in text_final', async (t) => {
   const finals = fx.backlog().filter((e) => e.type === 'text_final');
   assert.equal(finals.length, 1);
   assert.equal((finals[0] as { text: string }).text, 'raw draft');
+});
+
+test('two-step: A text_final precedes any B event', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  const gate = fx.deferReply('A reply');
+
+  const a = fx.post('A message', { responders: [draftTurn('A draft'), gate.responder] });
+  // Wait for A's draft turn to finish and its reply pass to reach (and
+  // block on) the gated streamFn call -- exactly 2 calls made so far.
+  // Time-bound (not iteration-bound): the real DB round trips in
+  // postMessage/refreshAgentConfiguration take a variable amount of wall
+  // clock time under load.
+  const draftDeadline = Date.now() + 5000;
+  while (fx.callCount() < 2 && Date.now() < draftDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(fx.callCount(), 2, 'expected A draft + gated A reply call before B is posted');
+
+  const b = fx.post('B message', { responders: [draftTurn('B draft'), replyTurn('B reply')] });
+  // Give B's queued turn real wall-clock time to attempt running while A's
+  // reply pass is still gated open. Without chaining the next turn on
+  // session.pendingReplyPass, nothing stops B's draft from starting here,
+  // which would bump the call count to 3.
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  assert.equal(fx.callCount(), 2, "B's draft must not start until A's reply pass settles");
+
+  gate.release();
+  await Promise.all([a, b]);
+
+  const backlog = fx.backlog();
+  const idxAFinal = backlog.findIndex(
+    (e) => e.type === 'text_final' && (e as { text: string }).text === 'A reply',
+  );
+  const idxBFirst = backlog.findIndex(
+    (e) => 'correlationId' in e && (e as { correlationId?: string }).correlationId === 'msg-2',
+  );
+  assert.notEqual(idxAFinal, -1);
+  assert.notEqual(idxBFirst, -1);
+  assert.ok(idxAFinal < idxBFirst, `expected A's text_final (${idxAFinal}) before B's first event (${idxBFirst})`);
+});
+
+test('two-step: reply pass is awaited at teardown, not orphaned', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+  const config = await security.readConfig();
+  await security.writeConfig({ ...config, experiments: { two_step: { enabled: true } } });
+
+  const responders: Responder[] = [];
+  let callIndex = 0;
+  const streamFn: StreamFn = async () => {
+    const responder = responders[callIndex];
+    callIndex += 1;
+    if (!responder) {
+      throw new Error(`Unexpected stream call #${callIndex}`);
+    }
+    return responder();
+  };
+
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  responders.push(
+    () => createTextResponseStream('teardown draft'),
+    async () => {
+      await gate;
+      return createTextResponseStream('teardown reply');
+    },
+  );
+
+  const runner = await AgentRunner.create({ workspace, security, streamFn });
+  const sessionId = `schedule:teardown-${randomBytes(4).toString('hex')}`;
+
+  const teardown = runner.runScheduledJob(
+    {
+      agentId: security.agentId,
+      scheduleId: `sched-${randomBytes(4).toString('hex')}`,
+      type: 'once',
+      status: 'active',
+      prompt: 'run once',
+      sessionMode: { kind: 'ephemeral' },
+      delivery: { kind: 'silent' },
+      policy: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      runCount: 0,
+      consecutiveErrors: 0,
+    },
+    sessionId,
+  );
+
+  // Release the gated reply responder before the teardown sequence
+  // (session.queue -> session.sideEffects -> status='inactive') reaches its
+  // sideEffects wait -- if the reply pass isn't chained into sideEffects,
+  // teardown proceeds without it and the styled reply never lands.
+  release();
+  await teardown;
+
+  const finals = runner.events
+    .getBacklog(sessionId)
+    .filter((entry) => entry.event.type === 'text_final')
+    .map((entry) => entry.event);
+  assert.equal(finals.length, 1);
+  assert.equal((finals[0] as { text: string }).text, 'teardown reply');
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -1,7 +1,108 @@
-import { test } from 'node:test';
+import { randomBytes } from 'node:crypto';
 import assert from 'node:assert/strict';
+import { test, type TestContext } from 'node:test';
 
+import type { StreamFn } from '@mariozechner/pi-agent-core';
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Usage,
+} from '@mariozechner/pi-ai';
+
+import { AgentRunner } from '../src/agent-runner.js';
+import type { RunnerSession } from '../src/agent-runner/types.js';
 import { parseAgentRuntimeConfig } from '../src/core/security.js';
+import { createSecurityFixture } from './helpers.js';
+
+const zeroUsage: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
+const createAssistantMessage = (content: AssistantMessage['content']): AssistantMessage => ({
+  role: 'assistant',
+  content,
+  api: 'anthropic-messages',
+  provider: 'anthropic',
+  model: 'claude-opus-4-5',
+  usage: zeroUsage,
+  stopReason: 'stop',
+  timestamp: Date.now(),
+});
+
+const createTextResponseStream = (text: string) => {
+  const stream = createAssistantMessageEventStream();
+  const partial = createAssistantMessage([{ type: 'text', text }]);
+
+  stream.push({ type: 'start', partial: createAssistantMessage([]) });
+  stream.push({ type: 'text_start', contentIndex: 0, partial });
+  stream.push({ type: 'text_delta', contentIndex: 0, delta: text, partial });
+  stream.push({ type: 'text_end', contentIndex: 0, content: text, partial });
+  stream.push({ type: 'done', reason: 'stop', message: partial });
+
+  return stream;
+};
+
+/**
+ * Wraps createSecurityFixture + AgentRunner.create + openSession behind a
+ * per-turn scripted streamFn, so a "turn" is just `postAndIdle(text)`.
+ * Reused by every two-step task's tests.
+ */
+const createTwoStepFixture = async (t: TestContext) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+
+  const responders: Array<() => ReturnType<typeof createAssistantMessageEventStream>> = [];
+  let callIndex = 0;
+  const streamFn: StreamFn = async () => {
+    const responder = responders[callIndex];
+    callIndex += 1;
+    if (!responder) {
+      throw new Error(`Unexpected stream call #${callIndex}`);
+    }
+    return responder();
+  };
+
+  const runner = await AgentRunner.create({ workspace, security, streamFn });
+
+  const sessionId = `cli:two-step-${randomBytes(4).toString('hex')}`;
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'cli', interactive: true },
+  });
+
+  let messageCounter = 0;
+
+  return {
+    runner,
+    sessionId,
+    get session(): RunnerSession {
+      return (runner as unknown as { sessions: Map<string, RunnerSession> }).sessions.get(sessionId)!;
+    },
+    async setFlag(enabled: boolean): Promise<void> {
+      const config = await security.readConfig();
+      await security.writeConfig({ ...config, experiments: { two_step: { enabled } } });
+    },
+    async postAndIdle(text: string): Promise<void> {
+      messageCounter += 1;
+      responders.push(() => createTextResponseStream(`response ${messageCounter}`));
+      await runner.postMessage(sessionId, { messageId: `msg-${messageCounter}`, text });
+      await runner.waitForSessionIdle(sessionId);
+    },
+  };
+};
 
 test('two_step config block validates and defaults to off when absent', () => {
   const on = parseAgentRuntimeConfig({ experiments: { two_step: { enabled: true, reply_timeout_ms: 8000 } } });
@@ -10,4 +111,15 @@ test('two_step config block validates and defaults to off when absent', () => {
 
   const off = parseAgentRuntimeConfig({});
   assert.equal(off.experiments?.two_step, undefined);
+});
+
+test('twoStepActive re-stamps hot each turn', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(false);
+  await fx.postAndIdle('hi');
+  assert.equal(fx.session.twoStepActive, false);
+
+  await fx.setFlag(true); // configStore.setConfig, no restart
+  await fx.postAndIdle('again');
+  assert.equal(fx.session.twoStepActive, true);
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -156,9 +156,9 @@ const createTwoStepFixture = async (t: TestContext, options?: { langfuse?: Langf
     get session(): RunnerSession {
       return (runner as unknown as { sessions: Map<string, RunnerSession> }).sessions.get(sessionId)!;
     },
-    async setFlag(enabled: boolean): Promise<void> {
+    async setFlag(enabled: boolean, extra?: { reply_timeout_ms?: number }): Promise<void> {
       const config = await security.readConfig();
-      await security.writeConfig({ ...config, experiments: { two_step: { enabled } } });
+      await security.writeConfig({ ...config, experiments: { two_step: { enabled, ...extra } } });
     },
     async postAndIdle(
       text: string,
@@ -597,4 +597,69 @@ test('flag off: exact baseline event sequence and call count', async (t) => {
   assert.ok(kinds.includes('text_delta'));
   assert.equal(kinds.filter((k) => k === 'text_final').length, 1);
   assert.ok(!kinds.includes('thinking_delta')); // no gating when off
+});
+
+test('two-step: reply pass that overruns the deadline falls back to the draft', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true, { reply_timeout_ms: 50 });
+  // The reply responder never resolves, so agent.prompt/waitForIdle hangs past
+  // the 50ms deadline. generateStyledReply must abort and return null, and the
+  // turn must publish the draft rather than stall forever or lose the answer.
+  const neverResolves: Responder = () => new Promise(() => {});
+  await fx.postAndIdle('hi', { responders: [draftTurn('raw draft'), neverResolves] });
+  const finals = fx.backlog().filter((e) => e.type === 'text_final');
+  assert.equal(finals.length, 1);
+  assert.equal((finals[0] as { text: string }).text, 'raw draft');
+});
+
+test('two-step: reply pass honors reply_model and threads the user text + draft into its prompt', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+  const config = await security.readConfig();
+  await security.writeConfig({
+    ...config,
+    experiments: {
+      two_step: {
+        enabled: true,
+        // Default model is openrouter; the reply pass must route through this
+        // anthropic override instead (and its ANTHROPIC_API_KEY resolves).
+        reply_model: { provider: 'anthropic', model: 'claude-opus-4-5', max_tokens: 4096 },
+      },
+    },
+  });
+
+  // Capture (model, context) of every streamFn call so we can inspect the
+  // second (reply) call: draft = call #1, styled reply = call #2.
+  const calls: Array<{ model: { provider?: string }; contextText: string }> = [];
+  let callIndex = 0;
+  const streamFn: StreamFn = async (model, context) => {
+    callIndex += 1;
+    const contextText = JSON.stringify(context);
+    calls.push({ model: model as { provider?: string }, contextText });
+    return callIndex === 1
+      ? createTextResponseStream('raw draft')
+      : createTextResponseStream('styled reply');
+  };
+
+  const runner = await AgentRunner.create({ workspace, security, streamFn });
+  const sessionId = `cli:reply-model-${randomBytes(4).toString('hex')}`;
+  await runner.openSession({ sessionId, source: { kind: 'cli', interactive: true } });
+  await runner.postMessage(sessionId, { messageId: 'msg-1', text: 'what is up' });
+  await runner.waitForSessionIdle(sessionId);
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (runner.events.getBacklog(sessionId).some((e) => e.event.type === 'agent_end')) break;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  assert.equal(calls.length, 2, 'expected a draft call and a reply call');
+  const draftCall = calls[0]!;
+  const replyCall = calls[1]!;
+  assert.equal(draftCall.model.provider, 'openrouter', 'draft uses the base model');
+  assert.equal(replyCall.model.provider, 'anthropic', 'reply pass uses reply_model override');
+  // buildReplyInput folds the last user message and the draft into the prompt.
+  assert.match(replyCall.contextText, /User: what is up/);
+  assert.match(replyCall.contextText, /Draft: raw draft/);
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -564,3 +564,14 @@ test('flag off: no reply-pass trace is created', async (t) => {
 
   assert.equal(langfuse.traces.filter((tr) => tr.body.name === 'openhermit.two_step_reply').length, 0);
 });
+
+test('flag off: exact baseline event sequence and call count', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(false);
+  // createSequentialStreamFn-style responders throw on an unexpected extra call -- a stray reply pass fails the test
+  await fx.postAndIdle('hi', { responders: [draftTurn('answer')] }); // exactly one turn allowed
+  const kinds = fx.backlog().map((e) => e.type);
+  assert.ok(kinds.includes('text_delta'));
+  assert.equal(kinds.filter((k) => k === 'text_final').length, 1);
+  assert.ok(!kinds.includes('thinking_delta')); // no gating when off
+});

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -247,10 +247,18 @@ const createTwoStepFixture = async (t: TestContext, options?: { langfuse?: Langf
       };
     },
     /** Test-only accessor for the private reply-pass method (TS `private` is compile-time only). */
-    generateStyledReplyForTest(session: RunnerSession, draftText: string): Promise<string | null> {
+    generateStyledReplyForTest(
+      session: RunnerSession,
+      draftText: string,
+      lastUserMessageText?: string,
+    ): Promise<string | null> {
       return (runner as unknown as {
-        generateStyledReply(session: RunnerSession, draftText: string): Promise<string | null>;
-      }).generateStyledReply(session, draftText);
+        generateStyledReply(
+          session: RunnerSession,
+          draftText: string,
+          lastUserMessageText: string | undefined,
+        ): Promise<string | null>;
+      }).generateStyledReply(session, draftText, lastUserMessageText);
     },
     /** Test-only accessor for the private fidelity-guard predicate. */
     acceptRewriteForTest(draft: string, rewrite: string | null): boolean {

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -12,7 +12,34 @@ import {
 import { AgentRunner } from '../src/agent-runner.js';
 import type { RunnerSession } from '../src/agent-runner/types.js';
 import { parseAgentRuntimeConfig } from '../src/core/security.js';
+import type { LangfuseClientLike } from '../src/langfuse.js';
 import { createSecurityFixture } from './helpers.js';
+
+/** Mirrors agent-runner.test.ts's FakeLangfuseClient — records trace()/update() calls. */
+class FakeLangfuseTrace {
+  readonly updates: Array<Record<string, unknown>> = [];
+
+  generation() {
+    return { end: () => undefined };
+  }
+
+  update(body: Record<string, unknown>) {
+    this.updates.push(body);
+    return this;
+  }
+}
+
+class FakeLangfuseClient implements LangfuseClientLike {
+  readonly traces: Array<{ body: Record<string, unknown>; client: FakeLangfuseTrace }> = [];
+
+  async flushAsync(): Promise<void> {}
+
+  trace(body: Record<string, unknown>) {
+    const client = new FakeLangfuseTrace();
+    this.traces.push({ body, client });
+    return client;
+  }
+}
 
 const zeroUsage: Usage = {
   input: 0,
@@ -91,7 +118,7 @@ type Responder = () =>
   | ReturnType<typeof createAssistantMessageEventStream>
   | Promise<ReturnType<typeof createAssistantMessageEventStream>>;
 
-const createTwoStepFixture = async (t: TestContext) => {
+const createTwoStepFixture = async (t: TestContext, options?: { langfuse?: LangfuseClientLike }) => {
   const { workspace, security } = await createSecurityFixture(t, {
     secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
   });
@@ -108,7 +135,12 @@ const createTwoStepFixture = async (t: TestContext) => {
     return responder();
   };
 
-  const runner = await AgentRunner.create({ workspace, security, streamFn });
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn,
+    ...(options?.langfuse ? { langfuse: options.langfuse } : {}),
+  });
 
   const sessionId = `cli:two-step-${randomBytes(4).toString('hex')}`;
   await runner.openSession({
@@ -505,4 +537,30 @@ test('two-step: reply pass is awaited at teardown, not orphaned', async (t) => {
     .map((entry) => entry.event);
   assert.equal(finals.length, 1);
   assert.equal((finals[0] as { text: string }).text, 'teardown reply');
+});
+
+test('two-step: reply pass traces to langfuse under <sid>:reply with twoStep metadata', async (t) => {
+  const langfuse = new FakeLangfuseClient();
+  const fx = await createTwoStepFixture(t, { langfuse });
+  await fx.setFlag(true);
+  await fx.postAndIdle('hi', { responders: [draftTurn('raw draft'), replyTurn('styled reply')] });
+
+  const replyTrace = langfuse.traces.find((tr) => tr.body.name === 'openhermit.two_step_reply');
+  assert.ok(replyTrace, 'expected a openhermit.two_step_reply trace');
+  assert.equal(replyTrace!.body.sessionId, `${fx.sessionId}:reply`);
+
+  const metadata = replyTrace!.client.updates.at(-1)?.metadata as Record<string, unknown> | undefined;
+  assert.equal(metadata?.twoStep, true);
+  assert.equal(metadata?.draftText, 'raw draft');
+  assert.equal(metadata?.replyText, 'styled reply');
+  assert.equal(typeof metadata?.rewriteLatencyMs, 'number');
+});
+
+test('flag off: no reply-pass trace is created', async (t) => {
+  const langfuse = new FakeLangfuseClient();
+  const fx = await createTwoStepFixture(t, { langfuse });
+  await fx.setFlag(false);
+  await fx.postAndIdle('hi', { responders: [draftTurn('raw draft')] });
+
+  assert.equal(langfuse.traces.filter((tr) => tr.body.name === 'openhermit.two_step_reply').length, 0);
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -176,6 +176,48 @@ test('flag off: event stream unchanged (text_delta present)', async (t) => {
   assert.ok(fx.backlog().some((e) => e.type === 'text_delta'));
 });
 
+test('flag on + group source: message_end backstop flushes thinking_delta, not text_delta', async (t) => {
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: { ANTHROPIC_API_KEY: 'test-anthropic-key' },
+  });
+  await security.load();
+  const config = await security.readConfig();
+  await security.writeConfig({ ...config, experiments: { two_step: { enabled: true } } });
+
+  // An unclosed `[Name` tag never resolves without a text_end, so the
+  // message_end backstop (not the text_end path) is what flushes it.
+  const streamFn: StreamFn = async () => {
+    const stream = createAssistantMessageEventStream();
+    const text = '[Unclosed tag with no closing bracket';
+    const partial = createAssistantMessage([{ type: 'text', text }]);
+    stream.push({ type: 'start', partial: createAssistantMessage([]) });
+    stream.push({ type: 'text_start', contentIndex: 0, partial });
+    stream.push({ type: 'text_delta', contentIndex: 0, delta: text, partial });
+    // No text_end pushed: the provider skipped it, exercising the backstop.
+    stream.push({ type: 'done', reason: 'stop', message: partial });
+    return stream;
+  };
+
+  const runner = await AgentRunner.create({ workspace, security, streamFn });
+  const sessionId = `group:backstop-${randomBytes(4).toString('hex')}`;
+  await runner.openSession({
+    sessionId,
+    source: { kind: 'channel', interactive: false, type: 'group' },
+  });
+  await runner.postMessage(sessionId, {
+    messageId: 'msg-1',
+    text: 'hello group',
+    mentioned: true,
+    sender: { channel: 'web', channelUserId: 'u-1', displayName: 'User' },
+    participants: [{ id: 'u-1', type: 'user', displayName: 'User' }],
+  });
+  await runner.waitForSessionIdle(sessionId);
+
+  const kinds = runner.events.getBacklog(sessionId).map((entry) => entry.event.type);
+  assert.equal(kinds.filter((k) => k === 'text_delta').length, 0);
+  assert.ok(kinds.includes('thinking_delta'));
+});
+
 test('flag on: thinking-only draft is not promoted to a premature text_final', async (t) => {
   const fx = await createTwoStepFixture(t);
   await fx.setFlag(true);

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -316,6 +316,17 @@ test('two-step: one text_final carrying the reply', async (t) => {
   assert.equal((finals[0] as { text: string }).text, 'styled reply');
 });
 
+test('two-step persists one assistant entry: content=reply, thinking=draft', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  await fx.postAndIdle('hi', { responders: [draftTurn('raw draft'), replyTurn('styled reply')] });
+  const entries = (await fx.runner.listSessionLogEntries(fx.session.spec.sessionId))
+    .filter((e) => e.role === 'assistant');
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]!.content, 'styled reply');
+  assert.equal(entries[0]!.thinking, 'raw draft');
+});
+
 test('two-step: reply failure falls back to draft in text_final', async (t) => {
   const fx = await createTwoStepFixture(t);
   await fx.setFlag(true);

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -137,6 +137,16 @@ const createTwoStepFixture = async (t: TestContext) => {
     backlog() {
       return runner.events.getBacklog(sessionId).map((entry) => entry.event);
     },
+    /** Scripts the next raw streamFn call — used to drive generateStyledReply directly. */
+    scriptReply(responder: () => ReturnType<typeof createAssistantMessageEventStream>): void {
+      responders.push(responder);
+    },
+    /** Test-only accessor for the private reply-pass method (TS `private` is compile-time only). */
+    generateStyledReplyForTest(session: RunnerSession, draftText: string): Promise<string | null> {
+      return (runner as unknown as {
+        generateStyledReply(session: RunnerSession, draftText: string): Promise<string | null>;
+      }).generateStyledReply(session, draftText);
+    },
   };
 };
 
@@ -243,4 +253,18 @@ test('flag off: thinking-only promotion behavior is unchanged', async (t) => {
   for (const final of finals) {
     assert.match((final as { text: string }).text, /internal reasoning/);
   }
+});
+
+test('generateStyledReply returns rewrite on success, null on failure', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+
+  fx.scriptReply(() => createTextResponseStream('styled reply'));
+  const ok = await fx.generateStyledReplyForTest(fx.session, 'raw draft');
+  assert.equal(typeof ok, 'string');
+  assert.equal(ok, 'styled reply');
+
+  fx.scriptReply(() => { throw new Error('provider down'); });
+  const bad = await fx.generateStyledReplyForTest(fx.session, 'raw draft');
+  assert.equal(bad, null);
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -56,6 +56,9 @@ const createTextResponseStream = (text: string) => {
 /** Scripts a plain no-tools draft turn for `postAndIdle`'s `responders` option. */
 const draftTurn = (text: string) => () => createTextResponseStream(text);
 
+/** Scripts the reply-pass turn (second scripted streamFn call) for `postAndIdle`'s `responders` option. */
+const replyTurn = (text: string) => () => createTextResponseStream(text);
+
 /**
  * Stream where the model emits only a thinking block and no text, mirroring
  * the DeepSeek R1 / kimi-k2.6 final-thinking-only shape that isFinalThinkingOnly
@@ -133,6 +136,18 @@ const createTwoStepFixture = async (t: TestContext) => {
       }
       await runner.postMessage(sessionId, { messageId: `msg-${messageCounter}`, text });
       await runner.waitForSessionIdle(sessionId);
+      // The agent_end handler's text_final publish runs in a detached,
+      // un-awaited IIFE (queue chaining lands in a later task), and now
+      // does real work (generateStyledReply) when two-step is active, so
+      // waitForSessionIdle can return before it settles. Give it a few
+      // extra ticks so the backlog reflects the completed turn.
+      for (let i = 0; i < 5000; i += 1) {
+        const agentEnds = runner.events
+          .getBacklog(sessionId)
+          .filter((entry) => entry.event.type === 'agent_end').length;
+        if (agentEnds >= messageCounter) break;
+        await new Promise((resolve) => setImmediate(resolve));
+      }
     },
     backlog() {
       return runner.events.getBacklog(sessionId).map((entry) => entry.event);
@@ -290,4 +305,29 @@ for (const [draft, rewrite, keepRewrite] of fidelityCases) {
 test('NO_REPLY draft skips the pass', async (t) => {
   const fx = await createTwoStepFixture(t);
   assert.equal(fx.acceptRewriteForTest('<NO_REPLY>', 'anything'), false);
+});
+
+test('two-step: one text_final carrying the reply', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  await fx.postAndIdle('hi', { responders: [draftTurn('raw draft'), replyTurn('styled reply')] });
+  const finals = fx.backlog().filter((e) => e.type === 'text_final');
+  assert.equal(finals.length, 1);
+  assert.equal((finals[0] as { text: string }).text, 'styled reply');
+});
+
+test('two-step: reply failure falls back to draft in text_final', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  await fx.postAndIdle('hi', {
+    responders: [
+      draftTurn('raw draft'),
+      () => {
+        throw new Error('boom');
+      },
+    ],
+  });
+  const finals = fx.backlog().filter((e) => e.type === 'text_final');
+  assert.equal(finals.length, 1);
+  assert.equal((finals[0] as { text: string }).text, 'raw draft');
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -147,6 +147,12 @@ const createTwoStepFixture = async (t: TestContext) => {
         generateStyledReply(session: RunnerSession, draftText: string): Promise<string | null>;
       }).generateStyledReply(session, draftText);
     },
+    /** Test-only accessor for the private fidelity-guard predicate. */
+    acceptRewriteForTest(draft: string, rewrite: string | null): boolean {
+      return (runner as unknown as {
+        acceptRewrite(draft: string, rewrite: string | null): boolean;
+      }).acceptRewrite(draft, rewrite);
+    },
   };
 };
 
@@ -267,4 +273,21 @@ test('generateStyledReply returns rewrite on success, null on failure', async (t
   fx.scriptReply(() => { throw new Error('provider down'); });
   const bad = await fx.generateStyledReplyForTest(fx.session, 'raw draft');
   assert.equal(bad, null);
+});
+
+const fidelityCases: [string, string, boolean][] = [
+  ['plain draft', 'plain reply', true],
+  ['```js\nx\n```', 'no fence here', false],
+  ['has content', '', false],
+];
+for (const [draft, rewrite, keepRewrite] of fidelityCases) {
+  test(`fidelity guard: ${draft.slice(0, 12)}`, async (t) => {
+    const fx = await createTwoStepFixture(t);
+    assert.equal(fx.acceptRewriteForTest(draft, rewrite), keepRewrite);
+  });
+}
+
+test('NO_REPLY draft skips the pass', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  assert.equal(fx.acceptRewriteForTest('<NO_REPLY>', 'anything'), false);
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -57,6 +57,29 @@ const createTextResponseStream = (text: string) => {
 const draftTurn = (text: string) => () => createTextResponseStream(text);
 
 /**
+ * Stream where the model emits only a thinking block and no text, mirroring
+ * the DeepSeek R1 / kimi-k2.6 final-thinking-only shape that isFinalThinkingOnly
+ * rescues on the flag-off path (see agent-runner.test.ts's
+ * createThinkingOnlyToolUseStream). stopReason 'stop' with zero tool calls
+ * exercises the same guard as stopReason 'toolUse' with zero toolCall blocks.
+ */
+const createThinkingOnlyResponseStream = (thinking: string) => {
+  const stream = createAssistantMessageEventStream();
+  const message = createAssistantMessage([{ type: 'thinking', thinking }]);
+
+  stream.push({ type: 'start', partial: createAssistantMessage([]) });
+  stream.push({ type: 'thinking_start', contentIndex: 0, partial: message });
+  stream.push({ type: 'thinking_delta', contentIndex: 0, delta: thinking, partial: message });
+  stream.push({ type: 'thinking_end', contentIndex: 0, content: thinking, partial: message });
+  stream.push({ type: 'done', reason: 'stop', message });
+
+  return stream;
+};
+
+/** Scripts a thinking-only draft turn for `postAndIdle`'s `responders` option. */
+const thinkingOnlyTurn = (thinking: string) => () => createThinkingOnlyResponseStream(thinking);
+
+/**
  * Wraps createSecurityFixture + AgentRunner.create + openSession behind a
  * per-turn scripted streamFn, so a "turn" is just `postAndIdle(text)`.
  * Reused by every two-step task's tests.
@@ -151,4 +174,28 @@ test('flag off: event stream unchanged (text_delta present)', async (t) => {
   await fx.setFlag(false);
   await fx.postAndIdle('hello', { responders: [draftTurn('raw draft')] });
   assert.ok(fx.backlog().some((e) => e.type === 'text_delta'));
+});
+
+test('flag on: thinking-only draft is not promoted to a premature text_final', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  await fx.postAndIdle('hi', { responders: [thinkingOnlyTurn('internal reasoning only')] });
+  // isFinalThinkingOnly is gated off while two-step is active, so message_end
+  // never promotes thinking to text_final (only a future agent_end reply
+  // pass would ever publish one for this draft).
+  const finals = fx.backlog().filter((e) => e.type === 'text_final');
+  assert.equal(finals.length, 0);
+});
+
+test('flag off: thinking-only promotion behavior is unchanged', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(false);
+  await fx.postAndIdle('hi', { responders: [thinkingOnlyTurn('internal reasoning only')] });
+  // Matches agent-runner.test.ts's kimi-k2.6 regression: message_end promotes
+  // thinking to text_final, and agent_end double-publishes it, so >= 1.
+  const finals = fx.backlog().filter((e) => e.type === 'text_final');
+  assert.ok(finals.length >= 1);
+  for (const final of finals) {
+    assert.match((final as { text: string }).text, /internal reasoning/);
+  }
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -53,6 +53,9 @@ const createTextResponseStream = (text: string) => {
   return stream;
 };
 
+/** Scripts a plain no-tools draft turn for `postAndIdle`'s `responders` option. */
+const draftTurn = (text: string) => () => createTextResponseStream(text);
+
 /**
  * Wraps createSecurityFixture + AgentRunner.create + openSession behind a
  * per-turn scripted streamFn, so a "turn" is just `postAndIdle(text)`.
@@ -95,11 +98,21 @@ const createTwoStepFixture = async (t: TestContext) => {
       const config = await security.readConfig();
       await security.writeConfig({ ...config, experiments: { two_step: { enabled } } });
     },
-    async postAndIdle(text: string): Promise<void> {
+    async postAndIdle(
+      text: string,
+      options?: { responders?: Array<() => ReturnType<typeof createAssistantMessageEventStream>> },
+    ): Promise<void> {
       messageCounter += 1;
-      responders.push(() => createTextResponseStream(`response ${messageCounter}`));
+      if (options?.responders?.length) {
+        responders.push(...options.responders);
+      } else {
+        responders.push(() => createTextResponseStream(`response ${messageCounter}`));
+      }
       await runner.postMessage(sessionId, { messageId: `msg-${messageCounter}`, text });
       await runner.waitForSessionIdle(sessionId);
+    },
+    backlog() {
+      return runner.events.getBacklog(sessionId).map((entry) => entry.event);
     },
   };
 };
@@ -122,4 +135,20 @@ test('twoStepActive re-stamps hot each turn', async (t) => {
   await fx.setFlag(true); // configStore.setConfig, no restart
   await fx.postAndIdle('again');
   assert.equal(fx.session.twoStepActive, true);
+});
+
+test('flag on: draft streams as thinking_delta, no text_delta', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(true);
+  await fx.postAndIdle('hello', { responders: [draftTurn('raw draft')] });
+  const kinds = fx.backlog().map((e) => e.type);
+  assert.equal(kinds.filter((k) => k === 'text_delta').length, 0);
+  assert.ok(kinds.includes('thinking_delta'));
+});
+
+test('flag off: event stream unchanged (text_delta present)', async (t) => {
+  const fx = await createTwoStepFixture(t);
+  await fx.setFlag(false);
+  await fx.postAndIdle('hello', { responders: [draftTurn('raw draft')] });
+  assert.ok(fx.backlog().some((e) => e.type === 'text_delta'));
 });

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseAgentRuntimeConfig } from '../src/core/security.js';
+
+test('two_step config block validates and defaults to off when absent', () => {
+  const on = parseAgentRuntimeConfig({ experiments: { two_step: { enabled: true, reply_timeout_ms: 8000 } } });
+  assert.equal(on.experiments?.two_step?.enabled, true);
+  assert.equal(on.experiments?.two_step?.reply_timeout_ms, 8000);
+
+  const off = parseAgentRuntimeConfig({});
+  assert.equal(off.experiments?.two_step, undefined);
+});

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -632,12 +632,12 @@ test('two-step: reply pass honors reply_model and threads the user text + draft 
 
   // Capture (model, context) of every streamFn call so we can inspect the
   // second (reply) call: draft = call #1, styled reply = call #2.
-  const calls: Array<{ model: { provider?: string }; contextText: string }> = [];
+  const calls: Array<{ model: { provider?: string; id?: string }; contextText: string }> = [];
   let callIndex = 0;
   const streamFn: StreamFn = async (model, context) => {
     callIndex += 1;
     const contextText = JSON.stringify(context);
-    calls.push({ model: model as { provider?: string }, contextText });
+    calls.push({ model: model as { provider?: string; id?: string }, contextText });
     return callIndex === 1
       ? createTextResponseStream('raw draft')
       : createTextResponseStream('styled reply');
@@ -658,7 +658,9 @@ test('two-step: reply pass honors reply_model and threads the user text + draft 
   const draftCall = calls[0]!;
   const replyCall = calls[1]!;
   assert.equal(draftCall.model.provider, 'openrouter', 'draft uses the base model');
+  assert.equal(draftCall.model.id, 'google/gemini-3-flash-preview', 'draft uses the base model id');
   assert.equal(replyCall.model.provider, 'anthropic', 'reply pass uses reply_model override');
+  assert.equal(replyCall.model.id, 'claude-opus-4-5', 'reply pass uses the configured reply_model id');
   // buildReplyInput folds the last user message and the draft into the prompt.
   assert.match(replyCall.contextText, /User: what is up/);
   assert.match(replyCall.contextText, /Draft: raw draft/);

--- a/apps/agent/test/two-step-reply.test.ts
+++ b/apps/agent/test/two-step-reply.test.ts
@@ -398,6 +398,8 @@ const fidelityCases: [string, string, boolean][] = [
   ['real draft', '<think>truncated reasoning that never closes', false],
   // A link re-punctuated in the rewrite is still preserved (no false reject).
   ['see https://example.com/docs. more', 'yo https://example.com/docs now', true],
+  // A rewrite that redirects the link to a lookalike host is rejected (not a substring match).
+  ['visit https://trusted.example', 'visit https://trusted.example.evil', false],
   // Unclosed/odd fence count in the rewrite is rejected even if >= the draft.
   ['```js\nx\n```', '```js\nx\n```\n```extra', false],
   // A draft URL dropped by the rewrite is rejected.


### PR DESCRIPTION
Flag-gated experiment. Adds an optional second "reply" LLM pass that restyles the tool-loop draft in the twin's voice before the final message is published.

Default off (`experiments.two_step`) is byte-identical to today; any reply-pass failure (timeout, error, empty, missing key) falls back to the draft, so the answer is never lost.

Based on #233 for the reasoning-strip reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional, experiment-gated two-step reply flow that rewrites drafts via a queued internal pass before emitting the final assistant response.
  * Removed inline reasoning markers from assistant text for cleaner user-visible output.
* **Bug Fixes**
  * Ensured “thinking-only” turns in two-step mode still produce exactly one visible final reply, with consistent log persistence and delayed telemetry reflecting the rewritten output.
  * Added rewrite validation (code-fence parity, visible content, link preservation) with safe fallback to the original draft.
* **Tests**
  * Expanded end-to-end coverage for streaming shapes, ordering, rewrite acceptance/rejection, timeouts, and new text utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->