### PR TITLE
deliver generated media into chat sessions out of band

### DIFF
--- a/apps/agent/src/tools/attachment.ts
+++ b/apps/agent/src/tools/attachment.ts
@@ -320,6 +320,27 @@ export const createAttachmentUploadTool = (
       path,
       ...(args.name !== undefined ? { name: args.name } : {}),
     });
+
+    // Skeleton keyed by the new attachment id; attachment_send reuses that id as
+    // correlationId to swap real media in. Only renderable media gets one so an
+    // unsent upload, e.g. a document read, can't strand a skeleton.
+    const skeletonMime = result.mimeType ?? '';
+    const skeletonKind = skeletonMime.startsWith('image/')
+      ? 'image'
+      : skeletonMime.startsWith('audio/')
+        ? 'audio'
+        : skeletonMime.startsWith('video/')
+          ? 'video'
+          : null;
+    if (skeletonKind && context.publishEvent && context.sessionId) {
+      context.publishEvent({
+        type: 'pending_media',
+        sessionId: context.sessionId,
+        correlationId: result.id,
+        kind: skeletonKind,
+      });
+    }
+
     return {
       content: asTextContent(formatJson(result)),
       details: {
@@ -344,18 +365,10 @@ const AttachmentSendParams = Type.Object({
     }),
   ),
   kind: Type.Optional(
-    Type.Union(
-      [
-        Type.Literal('image'),
-        Type.Literal('audio'),
-        Type.Literal('video'),
-        Type.Literal('document'),
-      ],
-      {
-        description:
-          "Override the rendering hint for channels. By default it is inferred from the MIME type (image/* → image, audio/* → audio, video/* → video, anything else → document).",
-      },
-    ),
+    Type.String({
+      description:
+        "Optional rendering hint (e.g. 'image', 'audio', 'video', 'document'). Model-speak aliases like 'photo'/'picture' are accepted; anything unrecognized falls back to the attachment's MIME type.",
+    }),
   ),
 });
 
@@ -406,20 +419,48 @@ export const createAttachmentSendTool = (
       );
     }
 
-    const kind: 'image' | 'audio' | 'video' | 'document' =
-      args.kind ??
-      (row.mimeType.startsWith('image/')
+    // `kind` is a soft rendering hint, the MIME type is authoritative. Models pass
+    // varying values like "photo" or "img", so map common aliases and fall back to
+    // the MIME type for anything unrecognized instead of rejecting the send.
+    const inferredKind: 'image' | 'audio' | 'video' | 'document' =
+      row.mimeType.startsWith('image/')
         ? 'image'
         : row.mimeType.startsWith('audio/')
           ? 'audio'
           : row.mimeType.startsWith('video/')
             ? 'video'
-            : 'document');
+            : 'document';
+    const KIND_ALIASES: Record<
+      string,
+      'image' | 'audio' | 'video' | 'document'
+    > = {
+      image: 'image',
+      photo: 'image',
+      picture: 'image',
+      img: 'image',
+      pic: 'image',
+      audio: 'audio',
+      voice: 'audio',
+      sound: 'audio',
+      video: 'video',
+      movie: 'video',
+      clip: 'video',
+      document: 'document',
+      doc: 'document',
+      file: 'document',
+      pdf: 'document',
+    };
+    const kind: 'image' | 'audio' | 'video' | 'document' =
+      (args.kind && KIND_ALIASES[args.kind.trim().toLowerCase()]) ||
+      inferredKind;
 
     const event: Record<string, unknown> = {
       type: 'attachment',
       sessionId,
       attachmentId: row.id,
+      // Same id attachment_upload used for its pending_media skeleton, so the
+      // consumer resolves that placeholder instead of appending a second bubble.
+      correlationId: row.id,
       mimeType: row.mimeType,
       kind,
       name: row.originalName,

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -64,7 +64,11 @@ import {
   registerAttachmentRoutes,
   DEFAULT_ATTACHMENT_MAX_BYTES,
 } from './attachment-routes.js';
-import { resolveInboundAttachments } from '@openhermit/agent/attachments';
+import {
+  registerSessionPublishRoute,
+  type AttachmentIngestResult,
+} from './session-publish.js';
+import { resolveAttachmentByUrl, resolveInboundAttachments } from '@openhermit/agent/attachments';
 import type { LogBuffer } from './log-buffer.js';
 import {
   type AuthContext,
@@ -1588,11 +1592,26 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
     }
 
     return streamSSE(c, async (stream) => {
-      for (const envelope of runtime.events.getBacklog(sessionId)) {
-        await writeEvent(stream, envelope);
-      }
+      // Emit ready with nextEventId before the backlog so a client holding a
+      // stale cursor resets to 0 before filtering the burst; a new runner
+      // restarts ids at 1, so sending it after would skip that burst.
+      await stream.writeSSE({
+        event: 'ready',
+        data: JSON.stringify({ sessionId, nextEventId: runtime.events.getNextEventId() }),
+      });
 
+      // Subscribe first, then replay backlog. The old getBacklog-then-subscribe
+      // path awaited each backlog write before subscribe, so a publish in that
+      // window, including out-of-band attachments, landed in the broker backlog
+      // but never on this stream until reconnect. Buffer live events during the
+      // backlog write, then drain with id dedupe.
+      const pendingLive: SessionEventEnvelope[] = [];
+      let replayingBacklog = true;
       const unsubscribe = runtime.events.subscribe(sessionId, async (envelope) => {
+        if (replayingBacklog) {
+          pendingLive.push(envelope);
+          return;
+        }
         await writeEvent(stream, envelope);
       });
 
@@ -1604,19 +1623,64 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       }, SSE_PING_INTERVAL_MS);
 
       try {
-        // Include nextEventId so clients with a stored last-event cursor
-        // can detect sequence resets after runner eviction (broker is
-        // per-runner; new runner restarts ids at 1).
-        await stream.writeSSE({
-          event: 'ready',
-          data: JSON.stringify({ sessionId, nextEventId: runtime.events.getNextEventId() }),
-        });
+        const backlog = runtime.events.getBacklog(sessionId);
+        let maxBacklogId = 0;
+        for (const envelope of backlog) {
+          maxBacklogId = Math.max(maxBacklogId, envelope.id);
+          await writeEvent(stream, envelope);
+        }
+        // Drain buffered live events with the flag still set: an event that
+        // arrives while we await a write is re-buffered here rather than racing
+        // ahead of an older queued one on the live path. Only stop buffering
+        // once the queue is fully empty, then flip synchronously so no publish
+        // can slip in before the live path takes over.
+        while (pendingLive.length > 0) {
+          const envelope = pendingLive.shift()!;
+          if (envelope.id > maxBacklogId) {
+            await writeEvent(stream, envelope);
+          }
+        }
+        replayingBacklog = false;
+
         await waitForAbort(c.req.raw.signal);
       } finally {
         clearInterval(heartbeat);
         unsubscribe();
       }
     });
+  });
+
+  // --- publish-into-session: server to live session out of band ---
+
+  registerSessionPublishRoute(app, {
+    instances,
+    requireAdmin: (authorization) => requireAdmin(authorization),
+    resolveRunner,
+    logger: log,
+    ingestAttachment:
+      options.attachmentStore && options.attachmentStorage
+        ? async ({ agentId, sessionId, url, mimeType, name, runner }): Promise<AttachmentIngestResult> => {
+            const resolved = await resolveAttachmentByUrl({
+              agentId,
+              sessionId,
+              uploaderUserId: null,
+              url,
+              hintMimeType: mimeType,
+              hintName: name,
+              maxBytes: options.attachmentMaxBytes ?? DEFAULT_ATTACHMENT_MAX_BYTES,
+              attachmentStore: options.attachmentStore!,
+              attachmentStorage: options.attachmentStorage!,
+              runtime: runner,
+              logger: log,
+            });
+            return {
+              attachmentId: resolved.id!,
+              mimeType: resolved.mimeType!,
+              size: resolved.size,
+              sha256: resolved.sha256,
+            };
+          }
+        : undefined,
   });
 
   // --- admin API ---

--- a/apps/gateway/src/session-publish.ts
+++ b/apps/gateway/src/session-publish.ts
@@ -1,0 +1,207 @@
+/**
+ * Gateway route to push an outbound event, attachment/pending_media/error, into
+ * a live session out of band so bridges deliver it with no active turn.
+ * Admin-token auth. An attachment carrying an external assetUrl is first ingested
+ * to a session_attachments row via the same SSRF-guarded path as attachment_send
+ * and published by attachmentId; ingest failure -> 502.
+ */
+import type { Hono } from 'hono';
+
+import {
+  gatewayRoutes,
+  isPublishableOutboundEvent,
+  type OutboundEventBody,
+} from '@openhermit/protocol';
+import { ValidationError } from '@openhermit/shared';
+import { inferAttachmentKind } from '@openhermit/agent/attachments';
+
+import type { AgentRunner } from '@openhermit/agent/agent-runner';
+import type { AgentInstanceManager } from './agent-instance.js';
+
+/** Rendering-hint literal, mirrors `OutboundEventBody`'s attachment kind. */
+type AttachmentKind = 'image' | 'audio' | 'video' | 'document';
+
+export interface AttachmentIngestInput {
+  agentId: string;
+  sessionId: string;
+  /** External URL to fetch and persist as a session attachment. */
+  url: string;
+  /** MIME hint; ingest sniffs the real type regardless. */
+  mimeType?: string | undefined;
+  name?: string | undefined;
+  /** Runner for the target session, already resolved by the route. */
+  runner: AgentRunner;
+}
+
+export interface AttachmentIngestResult {
+  attachmentId: string;
+  mimeType: string;
+  size?: number | undefined;
+  sha256?: string | undefined;
+}
+
+export interface SessionPublishDeps {
+  instances: AgentInstanceManager;
+  requireAdmin: (authorization: string | undefined) => void;
+  resolveRunner: (
+    instances: AgentInstanceManager,
+    agentId: string,
+  ) => Promise<AgentRunner>;
+  logger?: (message: string) => void;
+  /** Ingests an asset URL into a session_attachments row. Omit to 502 `assetUrl` pushes. */
+  ingestAttachment?:
+    | ((input: AttachmentIngestInput) => Promise<AttachmentIngestResult>)
+    | undefined;
+}
+
+const ALLOWED_TYPES = new Set(['attachment', 'pending_media', 'error']);
+
+const MEDIA_KINDS = new Set(['image', 'audio', 'video', 'document']);
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string';
+
+/**
+ * A pushed attachment not yet stored: carries `assetUrl`, not `attachmentId`,
+ * so it is deliberately not a valid `OutboundEventBody` and can never satisfy
+ * `isPublishableOutboundEvent` to leak through unresolved.
+ */
+interface AttachmentIngestRequestBody {
+  type: 'attachment';
+  sessionId: string;
+  assetUrl: string;
+  mimeType?: string | undefined;
+  kind?: AttachmentKind | undefined;
+  correlationId?: string | undefined;
+  caption?: string | undefined;
+  name?: string | undefined;
+}
+
+const parseAttachmentIngestRequest = (
+  value: Record<string, unknown>,
+  sessionId: string,
+): AttachmentIngestRequestBody | null => {
+  if (typeof value.assetUrl !== 'string' || value.assetUrl.length === 0) return null;
+  if (typeof value.sessionId !== 'string' || value.sessionId !== sessionId) return null;
+  // Reject an explicit empty mimeType: it ingests, then fails the published !mimeType check and orphans the row.
+  if (!isOptionalString(value.mimeType)) return null;
+  if (typeof value.mimeType === 'string' && value.mimeType.length === 0) return null;
+  if (value.kind !== undefined && (typeof value.kind !== 'string' || !MEDIA_KINDS.has(value.kind))) {
+    return null;
+  }
+  if (!isOptionalString(value.correlationId)) return null;
+  if (!isOptionalString(value.caption)) return null;
+  if (!isOptionalString(value.name)) return null;
+
+  return {
+    type: 'attachment',
+    sessionId: value.sessionId,
+    assetUrl: value.assetUrl,
+    mimeType: value.mimeType,
+    kind: value.kind as AttachmentKind | undefined,
+    correlationId: value.correlationId,
+    caption: value.caption,
+    name: value.name,
+  };
+};
+
+export const registerSessionPublishRoute = (
+  app: Hono,
+  deps: SessionPublishDeps,
+): void => {
+  const { instances, requireAdmin, resolveRunner, logger, ingestAttachment } = deps;
+  const log = logger ?? (() => {});
+
+  app.post(gatewayRoutes.agentSessionEventsPattern, async (c) => {
+    requireAdmin(c.req.header('authorization'));
+
+    const agentId = c.req.param('agentId') ?? '';
+    const sessionId = c.req.param('sessionId') ?? '';
+
+    const payload = await c.req.json().catch(() => null) as
+      | { event?: unknown }
+      | null;
+
+    const eventBody = payload?.event;
+    if (!eventBody || typeof (eventBody as { type?: unknown }).type !== 'string') {
+      throw new ValidationError('Body must be { event: OutboundEventBody }.');
+    }
+
+    const eventType = (eventBody as { type: string }).type;
+    if (!ALLOWED_TYPES.has(eventType)) {
+      throw new ValidationError(
+        `Event type "${eventType}" cannot be published via this route. Allowed: attachment, pending_media, error.`,
+      );
+    }
+
+    const record = eventBody as Record<string, unknown>;
+    const isAssetIngest = eventType === 'attachment' && typeof record.assetUrl === 'string';
+
+    if (isAssetIngest) {
+      const ingestReq = parseAttachmentIngestRequest(record, sessionId);
+      if (!ingestReq) {
+        throw new ValidationError(
+          'Invalid attachment ingest request. Expected { type:"attachment", sessionId, assetUrl, mimeType?, kind?, correlationId?, caption?, name? }.',
+        );
+      }
+
+      if (!ingestAttachment) {
+        return c.json(
+          { error: 'Attachment asset ingest is not configured on this gateway.', code: 'attachment_ingest_unavailable' },
+          502,
+        );
+      }
+
+      const runner = await resolveRunner(instances, agentId);
+
+      let ingested: AttachmentIngestResult;
+      try {
+        ingested = await ingestAttachment({
+          agentId,
+          sessionId,
+          url: ingestReq.assetUrl,
+          mimeType: ingestReq.mimeType,
+          name: ingestReq.name,
+          runner,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`attachment asset ingest failed for session ${sessionId}: ${message}`);
+        return c.json({ error: message, code: 'attachment_ingest_failed' }, 502);
+      }
+
+      // Publish the persisted type: ingest sniffs it and only falls back to the hint when the fetch declares none.
+      const finalMimeType = ingested.mimeType;
+      const finalEvent: OutboundEventBody = {
+        type: 'attachment',
+        sessionId,
+        attachmentId: ingested.attachmentId,
+        mimeType: finalMimeType,
+        kind: inferAttachmentKind(finalMimeType),
+        ...(ingestReq.name !== undefined ? { name: ingestReq.name } : {}),
+        ...(ingested.size !== undefined ? { size: ingested.size } : {}),
+        ...(ingested.sha256 !== undefined ? { sha256: ingested.sha256 } : {}),
+        ...(ingestReq.caption !== undefined ? { caption: ingestReq.caption } : {}),
+        ...(ingestReq.correlationId !== undefined ? { correlationId: ingestReq.correlationId } : {}),
+      };
+
+      if (!isPublishableOutboundEvent(finalEvent)) {
+        throw new ValidationError('Constructed attachment event failed validation.');
+      }
+
+      await runner.events.publish(finalEvent);
+      log(`ingested asset and published attachment event into session ${sessionId}`);
+      return c.json({ published: true, attachmentId: ingested.attachmentId }, 202);
+    }
+
+    if (!isPublishableOutboundEvent(eventBody) || eventBody.sessionId !== sessionId) {
+      throw new ValidationError('Invalid event body.');
+    }
+
+    const runner = await resolveRunner(instances, agentId);
+    await runner.events.publish(eventBody as OutboundEventBody);
+
+    log(`published ${eventType} event into session ${sessionId}`);
+    return c.json({ published: true }, 202);
+  });
+};

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -313,7 +313,18 @@ export type OutboundEventBody =
     }
   | { type: 'agent_start'; sessionId: string; correlationId?: string }
   | { type: 'agent_end'; sessionId: string }
-  | { type: 'error'; sessionId: string; message: string };
+  | { type: 'error'; sessionId: string; message: string; correlationId?: string }
+  | {
+      /**
+       * In-flight media placeholder from a media-generation tool; channels/UIs
+       * render a pending state until it resolves, typically to an `attachment`
+       * with the same `correlationId`.
+       */
+      type: 'pending_media';
+      sessionId: string;
+      correlationId: string;
+      kind: 'image' | 'audio' | 'video' | 'document';
+    };
 
 export type OutboundEvent = OutboundEventBody & { eventId: string };
 
@@ -1208,6 +1219,57 @@ export const isToolApprovalRequest = (
     typeof value.toolCallId === 'string' &&
     typeof value.approved === 'boolean'
   );
+};
+
+const OUTBOUND_MEDIA_KINDS = new Set(['image', 'audio', 'video', 'document']);
+
+/**
+ * Subset of OutboundEventBody a trusted server may publish into a live session
+ * via the publish-into-session route; everything else stays runtime-internal.
+ */
+export type PublishableOutboundEvent = Extract<
+  OutboundEventBody,
+  { type: 'attachment' | 'pending_media' | 'error' }
+>;
+
+export const isPublishableOutboundEvent = (
+  value: unknown,
+): value is PublishableOutboundEvent => {
+  if (!isRecord(value)) return false;
+  if (typeof value.sessionId !== 'string' || !value.sessionId) return false;
+
+  if (value.type === 'attachment') {
+    if (typeof value.attachmentId !== 'string' || !value.attachmentId) return false;
+    if (typeof value.mimeType !== 'string' || !value.mimeType) return false;
+    if (typeof value.kind !== 'string' || !OUTBOUND_MEDIA_KINDS.has(value.kind)) return false;
+    if (!isOptionalString(value.name)) return false;
+    if (!isOptionalString(value.sha256)) return false;
+    if (!isOptionalString(value.caption)) return false;
+    if (!isOptionalString(value.correlationId)) return false;
+    if (
+      value.size !== undefined &&
+      (typeof value.size !== 'number' ||
+        !Number.isInteger(value.size) ||
+        value.size < 0)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  if (value.type === 'pending_media') {
+    if (typeof value.correlationId !== 'string' || !value.correlationId) return false;
+    if (typeof value.kind !== 'string' || !OUTBOUND_MEDIA_KINDS.has(value.kind)) return false;
+    return true;
+  }
+
+  if (value.type === 'error') {
+    if (typeof value.message !== 'string' || !value.message) return false;
+    if (!isOptionalString(value.correlationId)) return false;
+    return true;
+  }
+
+  return false;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Generated media is delivered back into the chat session out of band, decoupled from the turn that requested it.

An authenticated publish-into-session gateway route ingests a pushed asset into a session attachment (mime-sniffed, size-bounded, SSRF-guarded) and publishes it onto the session's event stream. A `pending_media` placeholder event is emitted at upload so a client can render a skeleton immediately, and the later `attachment` event resolves it in place, correlated by job id.

Subscribers receive session events over SSE with subscribe-first replay and per-session cursor persistence, or over the websocket session subscription, so a live event is never dropped and a reconnect replays only the backlog it has not seen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pending media placeholder events with correlation IDs for in-flight image/audio/video generation.
  * Added server-side session publishing for attachment, pending media, and error events.
  * When configured, external attachment URLs can be ingested and published into live sessions.
  * Attachment sending now accepts flexible kind hints (aliases) and falls back to MIME-based inference.
* **Bug Fixes**
  * Improved SSE session event replay ordering and deduplication to prevent missed or duplicated events.
  * Strengthened validation for publishable outbound event payloads (including optional error correlation IDs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->