### PR TITLE
feat: add Tenki sandbox exec backend

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -60,6 +60,7 @@
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/voice": "0.2.0",
+    "@tenkicloud/sandbox": "^0.3.6",
     "croner": "^10.0.1",
     "defuddle": "^0.11.0",
     "e2b": "^2.19.4",

--- a/apps/agent/src/core/backends/file-backend.ts
+++ b/apps/agent/src/core/backends/file-backend.ts
@@ -453,6 +453,38 @@ export class DaytonaFileBackend implements FileBackend {
 
 // ── TenkiFileBackend ─────────────────────────────────────────────────────
 
+export const toTenkiFsPath = (agentHome: string, filePath: string): string => {
+  const absolute = requireAbsolutePath(filePath);
+  const root = path.posix.normalize(agentHome);
+  if (absolute === root) return '.';
+  if (!absolute.startsWith(`${root}/`)) {
+    throw new ValidationError(`path "${absolute}" is outside the Tenki workdir "${root}".`);
+  }
+  return absolute.slice(root.length + 1);
+};
+
+export const ensureTenkiDirectories = async (
+  session: import('@tenkicloud/sandbox').Session,
+  directories: string[],
+): Promise<void> => {
+  let stderr = '';
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const result = await session.run(['mkdir', '-p', '--', ...directories]);
+    if (result.exitCode === 0) return;
+    stderr = new TextDecoder().decode(result.stderr);
+    if (attempt < 4) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 200 * 2 ** attempt));
+    }
+  }
+  throw new Error(`Tenki mkdir failed after readiness retries: ${stderr}`);
+};
+
+const isTenkiFileNotFound = async (error: unknown): Promise<boolean> => {
+  const { FileNotFoundError } = await import('@tenkicloud/sandbox');
+  return error instanceof FileNotFoundError ||
+    (error instanceof Error && error.name === 'FileNotFoundError');
+};
+
 /**
  * Delegates to the Tenki sandbox SDK: `session.readFile`/`writeFile` for byte
  * IO and the `list`/`stat`/`remove` helpers for directory ops. The session
@@ -462,6 +494,8 @@ export class TenkiFileBackend implements FileBackend {
   getSession: (() => import('@tenkicloud/sandbox').Session | null) | null = null;
   ensureSession: (() => Promise<void>) | null = null;
   invalidate: (() => void) | null = null;
+
+  constructor(private readonly agentHome = '/home/tenki') {}
 
   private get session(): import('@tenkicloud/sandbox').Session {
     const s = this.getSession?.() ?? null;
@@ -477,8 +511,7 @@ export class TenkiFileBackend implements FileBackend {
     try {
       return await operation();
     } catch (error) {
-      const { FileNotFoundError } = await import('@tenkicloud/sandbox');
-      if (!(error instanceof FileNotFoundError) && !(error instanceof ValidationError)) {
+      if (!(await isTenkiFileNotFound(error)) && !(error instanceof ValidationError)) {
         this.invalidate?.();
       }
       throw error;
@@ -495,16 +528,16 @@ export class TenkiFileBackend implements FileBackend {
   }
 
   async read(filePath: string): Promise<FileReadResult> {
-    requireAbsolutePath(filePath);
+    const sdkPath = toTenkiFsPath(this.agentHome, filePath);
     await this.ready();
-    return this.withInvalidate(async () => ({ data: Buffer.from(await this.session.readFile(filePath)) }));
+    return this.withInvalidate(async () => ({ data: Buffer.from(await this.session.readFile(sdkPath)) }));
   }
 
   async write(filePath: string, data: Buffer, mode: FileWriteMode): Promise<void> {
-    requireAbsolutePath(filePath);
+    const sdkPath = toTenkiFsPath(this.agentHome, filePath);
     await this.ready();
     await this.withInvalidate(async () => {
-      await this.session.mkdir(path.posix.dirname(filePath));
+      await ensureTenkiDirectories(this.session, [path.posix.dirname(filePath)]);
       if (mode === 'append') {
         const result = await this.session.run(
           ['sh', '-c', 'cat >> "$1"', '--', filePath],
@@ -514,29 +547,30 @@ export class TenkiFileBackend implements FileBackend {
         return;
       }
       if (mode === 'create') {
-        const tempPath = `${path.posix.dirname(filePath)}/.openhermit-create-${randomUUID()}`;
+        const tempSdkPath = `${path.posix.dirname(sdkPath)}/.openhermit-create-${randomUUID()}`;
+        const tempGuestPath = `${this.agentHome}/${tempSdkPath}`;
         try {
-          await this.session.writeFile(tempPath, data);
+          await this.session.writeFile(tempSdkPath, data);
           const result = await this.session.run([
             'sh', '-c',
             'if ln "$1" "$2" 2>/dev/null; then exit 0; fi; [ -e "$2" ] && exit 73; exit 74',
-            '--', tempPath, filePath,
+            '--', tempGuestPath, filePath,
           ]);
           if (result.exitCode === 73) throw new ValidationError(`File already exists (mode=create): ${filePath}`);
           if (result.exitCode !== 0) throw new Error(`Tenki create failed for ${filePath}`);
         } finally {
-          await this.session.run(['rm', '-f', '--', tempPath]).then(() => undefined, () => undefined);
+          await this.session.run(['rm', '-f', '--', tempGuestPath]).then(() => undefined, () => undefined);
         }
         return;
       }
-      await this.session.writeFile(filePath, data);
+      await this.session.writeFile(sdkPath, data);
     });
   }
 
   async list(dirPath: string): Promise<DirEntry[]> {
-    requireAbsolutePath(dirPath);
+    const sdkPath = toTenkiFsPath(this.agentHome, dirPath);
     await this.ready();
-    const entries = await this.withInvalidate(() => this.session.list(dirPath, { includeHidden: true }));
+    const entries = await this.withInvalidate(() => this.session.list(sdkPath, { includeHidden: true }));
     return entries.map((e) => ({
       name: path.posix.basename(e.path),
       type: e.isDir ? ('directory' as const) : ('file' as const),
@@ -545,9 +579,9 @@ export class TenkiFileBackend implements FileBackend {
   }
 
   async stat(filePath: string): Promise<FileStat | null> {
-    requireAbsolutePath(filePath);
+    const sdkPath = toTenkiFsPath(this.agentHome, filePath);
     await this.ready();
-    return this.statOrNull(filePath);
+    return this.statOrNull(sdkPath);
   }
 
   private async statOrNull(filePath: string): Promise<FileStat | null> {
@@ -559,18 +593,17 @@ export class TenkiFileBackend implements FileBackend {
         mtime: new Date(Number(info.modifiedUnixNs / 1_000_000n)).toISOString(),
       };
     } catch (error) {
-      const { FileNotFoundError } = await import('@tenkicloud/sandbox');
-      if (error instanceof FileNotFoundError) return null;
+      if (await isTenkiFileNotFound(error)) return null;
       this.invalidate?.();
       throw error;
     }
   }
 
   async delete(filePath: string): Promise<void> {
-    requireAbsolutePath(filePath);
+    const sdkPath = toTenkiFsPath(this.agentHome, filePath);
     await this.ready();
     await this.withInvalidate(async () => {
-      const info = await this.session.stat(filePath);
+      const info = await this.session.stat(sdkPath);
       if (info.isDir) {
         throw new ValidationError(`Refusing to delete a directory (file_delete is single-file only): ${filePath}`);
       }

--- a/apps/agent/src/core/backends/file-backend.ts
+++ b/apps/agent/src/core/backends/file-backend.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
   appendFile,
   mkdir,
@@ -472,36 +473,70 @@ export class TenkiFileBackend implements FileBackend {
     if (!this.getSession?.() && this.ensureSession) await this.ensureSession();
   }
 
+  private async withInvalidate<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      const { FileNotFoundError } = await import('@tenkicloud/sandbox');
+      if (!(error instanceof FileNotFoundError) && !(error instanceof ValidationError)) {
+        this.invalidate?.();
+      }
+      throw error;
+    }
+  }
+
+  private static input(data: Buffer): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(data);
+        controller.close();
+      },
+    });
+  }
+
   async read(filePath: string): Promise<FileReadResult> {
     requireAbsolutePath(filePath);
     await this.ready();
-    return { data: Buffer.from(await this.session.readFile(filePath)) };
+    return this.withInvalidate(async () => ({ data: Buffer.from(await this.session.readFile(filePath)) }));
   }
 
   async write(filePath: string, data: Buffer, mode: FileWriteMode): Promise<void> {
     requireAbsolutePath(filePath);
     await this.ready();
-    if (mode === 'create' && (await this.statOrNull(filePath))) {
-      throw new ValidationError(`File already exists (mode=create): ${filePath}`);
-    }
-    if (mode === 'append') {
-      let existing = Buffer.alloc(0);
-      try {
-        existing = Buffer.from(await this.session.readFile(filePath));
-      } catch {
-        // File doesn't exist yet — append behaves like create.
+    await this.withInvalidate(async () => {
+      await this.session.mkdir(path.posix.dirname(filePath));
+      if (mode === 'append') {
+        const result = await this.session.run(
+          ['sh', '-c', 'cat >> "$1"', '--', filePath],
+          { stdin: TenkiFileBackend.input(data) },
+        );
+        if (result.exitCode !== 0) throw new Error(`Tenki append failed: ${new TextDecoder().decode(result.stderr)}`);
+        return;
       }
-      await this.session.writeFile(filePath, Buffer.concat([existing, data]));
-      return;
-    }
-    await this.session.writeFile(filePath, data);
+      if (mode === 'create') {
+        const tempPath = `${path.posix.dirname(filePath)}/.openhermit-create-${randomUUID()}`;
+        try {
+          await this.session.writeFile(tempPath, data);
+          const result = await this.session.run([
+            'sh', '-c',
+            'if ln "$1" "$2" 2>/dev/null; then exit 0; fi; [ -e "$2" ] && exit 73; exit 74',
+            '--', tempPath, filePath,
+          ]);
+          if (result.exitCode === 73) throw new ValidationError(`File already exists (mode=create): ${filePath}`);
+          if (result.exitCode !== 0) throw new Error(`Tenki create failed for ${filePath}`);
+        } finally {
+          await this.session.run(['rm', '-f', '--', tempPath]).then(() => undefined, () => undefined);
+        }
+        return;
+      }
+      await this.session.writeFile(filePath, data);
+    });
   }
 
   async list(dirPath: string): Promise<DirEntry[]> {
     requireAbsolutePath(dirPath);
     await this.ready();
-    const { list } = await import('@tenkicloud/sandbox');
-    const entries = await list(this.session, dirPath);
+    const entries = await this.withInvalidate(() => this.session.list(dirPath, { includeHidden: true }));
     return entries.map((e) => ({
       name: path.posix.basename(e.path),
       type: e.isDir ? ('directory' as const) : ('file' as const),
@@ -517,23 +552,32 @@ export class TenkiFileBackend implements FileBackend {
 
   private async statOrNull(filePath: string): Promise<FileStat | null> {
     try {
-      const { stat } = await import('@tenkicloud/sandbox');
-      const info = await stat(this.session, filePath);
+      const info = await this.session.stat(filePath);
       return {
         type: info.isDir ? 'directory' : 'file',
         size: Number(info.size),
-        // Tenki's FileInfo carries no mtime; report now so callers get a valid ISO stamp.
-        mtime: new Date().toISOString(),
+        mtime: new Date(Number(info.modifiedUnixNs / 1_000_000n)).toISOString(),
       };
-    } catch {
-      return null;
+    } catch (error) {
+      const { FileNotFoundError } = await import('@tenkicloud/sandbox');
+      if (error instanceof FileNotFoundError) return null;
+      this.invalidate?.();
+      throw error;
     }
   }
 
   async delete(filePath: string): Promise<void> {
     requireAbsolutePath(filePath);
     await this.ready();
-    const { remove } = await import('@tenkicloud/sandbox');
-    await remove(this.session, filePath);
+    await this.withInvalidate(async () => {
+      const info = await this.session.stat(filePath);
+      if (info.isDir) {
+        throw new ValidationError(`Refusing to delete a directory (file_delete is single-file only): ${filePath}`);
+      }
+      const result = await this.session.run(['rm', '--', filePath]);
+      if (result.exitCode !== 0) {
+        throw new Error(`Tenki delete failed: ${new TextDecoder().decode(result.stderr)}`);
+      }
+    });
   }
 }

--- a/apps/agent/src/core/backends/file-backend.ts
+++ b/apps/agent/src/core/backends/file-backend.ts
@@ -449,3 +449,91 @@ export class DaytonaFileBackend implements FileBackend {
     await this.sb.fs.deleteFile(filePath);
   }
 }
+
+// ── TenkiFileBackend ─────────────────────────────────────────────────────
+
+/**
+ * Delegates to the Tenki sandbox SDK: `session.readFile`/`writeFile` for byte
+ * IO and the `list`/`stat`/`remove` helpers for directory ops. The session
+ * handle is lazily provided after `ensure()`.
+ */
+export class TenkiFileBackend implements FileBackend {
+  getSession: (() => import('@tenkicloud/sandbox').Session | null) | null = null;
+  ensureSession: (() => Promise<void>) | null = null;
+  invalidate: (() => void) | null = null;
+
+  private get session(): import('@tenkicloud/sandbox').Session {
+    const s = this.getSession?.() ?? null;
+    if (!s) throw new ValidationError('Tenki session is not connected. Call ensure() first.');
+    return s;
+  }
+
+  private async ready(): Promise<void> {
+    if (!this.getSession?.() && this.ensureSession) await this.ensureSession();
+  }
+
+  async read(filePath: string): Promise<FileReadResult> {
+    requireAbsolutePath(filePath);
+    await this.ready();
+    return { data: Buffer.from(await this.session.readFile(filePath)) };
+  }
+
+  async write(filePath: string, data: Buffer, mode: FileWriteMode): Promise<void> {
+    requireAbsolutePath(filePath);
+    await this.ready();
+    if (mode === 'create' && (await this.statOrNull(filePath))) {
+      throw new ValidationError(`File already exists (mode=create): ${filePath}`);
+    }
+    if (mode === 'append') {
+      let existing = Buffer.alloc(0);
+      try {
+        existing = Buffer.from(await this.session.readFile(filePath));
+      } catch {
+        // File doesn't exist yet — append behaves like create.
+      }
+      await this.session.writeFile(filePath, Buffer.concat([existing, data]));
+      return;
+    }
+    await this.session.writeFile(filePath, data);
+  }
+
+  async list(dirPath: string): Promise<DirEntry[]> {
+    requireAbsolutePath(dirPath);
+    await this.ready();
+    const { list } = await import('@tenkicloud/sandbox');
+    const entries = await list(this.session, dirPath);
+    return entries.map((e) => ({
+      name: path.posix.basename(e.path),
+      type: e.isDir ? ('directory' as const) : ('file' as const),
+      ...(e.isDir ? {} : { size: Number(e.size) }),
+    }));
+  }
+
+  async stat(filePath: string): Promise<FileStat | null> {
+    requireAbsolutePath(filePath);
+    await this.ready();
+    return this.statOrNull(filePath);
+  }
+
+  private async statOrNull(filePath: string): Promise<FileStat | null> {
+    try {
+      const { stat } = await import('@tenkicloud/sandbox');
+      const info = await stat(this.session, filePath);
+      return {
+        type: info.isDir ? 'directory' : 'file',
+        size: Number(info.size),
+        // Tenki's FileInfo carries no mtime; report now so callers get a valid ISO stamp.
+        mtime: new Date().toISOString(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(filePath: string): Promise<void> {
+    requireAbsolutePath(filePath);
+    await this.ready();
+    const { remove } = await import('@tenkicloud/sandbox');
+    await remove(this.session, filePath);
+  }
+}

--- a/apps/agent/src/core/backends/index.ts
+++ b/apps/agent/src/core/backends/index.ts
@@ -5,3 +5,4 @@ import './docker.js';
 import './host.js';
 import './e2b.js';
 import './daytona.js';
+import './tenki.js';

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -1,0 +1,274 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { ValidationError } from '@openhermit/shared';
+
+import type { ExecBackend, ExecOpts, ExecResult, SyncSkillEntry, BackendFactoryContext, TenkiExecBackendConfig } from '../exec-backend.js';
+import { TenkiFileBackend } from './file-backend.js';
+import { registerExecBackend } from '../exec-backend.js';
+
+const TENKI_DEFAULT_USERNAME = 'tenki';
+const TENKI_DEFAULT_AGENT_HOME = '/home/tenki';
+const TENKI_DEFAULT_TIMEOUT_MS = 300_000;
+const TENKI_DEFAULT_CREATE_TIMEOUT_MS = 180_000;
+const TENKI_DEFAULT_CPU_CORES = 2;
+const TENKI_DEFAULT_MEMORY_MB = 4096;
+const TENKI_DEFAULT_DISK_GB = 10;
+
+/** Single-quote a value for safe interpolation into a `sh -c` string. */
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
+
+const uploadDirToTenki = async (
+  session: import('@tenkicloud/sandbox').Session,
+  localDir: string,
+  remoteDir: string,
+): Promise<void> => {
+  const { mkdir: tenkiMkdir } = await import('@tenkicloud/sandbox');
+  await tenkiMkdir(session, remoteDir);
+  const entries = await readdir(localDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const localPath = path.join(localDir, entry.name);
+    const remotePath = `${remoteDir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      await uploadDirToTenki(session, localPath, remotePath);
+    } else if (entry.isFile()) {
+      await session.writeFile(remotePath, await readFile(localPath));
+    }
+  }
+};
+
+interface TenkiBackendPersisted {
+  sessionId: string;
+  cwd: string;
+  updatedAt: string;
+  state?: 'active' | 'paused';
+}
+
+interface TenkiPendingSkillSync {
+  skills: Array<{ id: string; sourcePath: string; source: 'system' | 'user' }>;
+  queuedAt: string;
+}
+
+class TenkiExecBackend implements ExecBackend {
+  readonly id: string;
+  readonly type = 'tenki';
+  readonly label: string;
+  readonly username: string;
+  readonly agentHome: string;
+  readonly files: TenkiFileBackend;
+
+  private readonly cpuCores: number;
+  private readonly memoryMb: number;
+  private readonly diskSizeGb: number;
+  private readonly timeoutMs: number;
+  private readonly baseUrl: string | undefined;
+  private client: import('@tenkicloud/sandbox').TenkiSandbox | null = null;
+  private session: import('@tenkicloud/sandbox').Session | null = null;
+
+  constructor(
+    config: TenkiExecBackendConfig,
+    private readonly context: BackendFactoryContext,
+  ) {
+    this.id = config.id ?? 'tenki';
+    this.label = config.label ?? 'Tenki';
+    this.username = config.username ?? TENKI_DEFAULT_USERNAME;
+    this.agentHome = config.agent_home ?? TENKI_DEFAULT_AGENT_HOME;
+    this.cpuCores = config.cpu_cores ?? TENKI_DEFAULT_CPU_CORES;
+    this.memoryMb = config.memory_mb ?? TENKI_DEFAULT_MEMORY_MB;
+    this.diskSizeGb = config.disk_size_gb ?? TENKI_DEFAULT_DISK_GB;
+    this.timeoutMs = config.timeout_ms ?? TENKI_DEFAULT_TIMEOUT_MS;
+    this.baseUrl = config.base_url;
+
+    this.files = new TenkiFileBackend();
+    this.files.getSession = () => this.session;
+    this.files.ensureSession = () => this.ensure();
+    this.files.invalidate = () => { this.session = null; };
+  }
+
+  private async getClient(): Promise<import('@tenkicloud/sandbox').TenkiSandbox> {
+    if (this.client) return this.client;
+    const apiKey = process.env['TENKI_API_KEY'] ?? process.env['TENKI_AUTH_TOKEN'];
+    if (!apiKey) {
+      throw new ValidationError(
+        'TENKI_API_KEY environment variable is not set. Add it to ~/.openhermit/gateway/.env to use the tenki backend.',
+      );
+    }
+    const { TenkiSandbox } = await import('@tenkicloud/sandbox');
+    this.client = new TenkiSandbox({
+      authToken: apiKey,
+      ...(this.baseUrl ? { baseUrl: this.baseUrl } : {}),
+    });
+    return this.client;
+  }
+
+  async ensure(): Promise<void> {
+    if (this.session) return;
+    const client = await this.getClient();
+
+    const persisted = await this.loadState();
+    if (persisted?.sessionId) {
+      try {
+        const session = await client.get(persisted.sessionId);
+        // Reconnecting to a paused session transparently resumes it; resume()
+        // is harmless on an already-active session.
+        try {
+          await session.resume();
+        } catch {
+          // Already active or nothing to resume.
+        }
+        this.session = session;
+        await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'active' });
+        await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
+        await this.replayPendingSkillSync();
+        return;
+      } catch {
+        // Session is gone / expired. Fall through and create a fresh one.
+      }
+    }
+
+    const session = await client.createAndWait({
+      cpuCores: this.cpuCores,
+      memoryMb: this.memoryMb,
+      diskSizeGb: this.diskSizeGb,
+      sticky: true,
+      metadata: { agentId: this.context.agentId },
+      timeoutMs: TENKI_DEFAULT_CREATE_TIMEOUT_MS,
+    });
+    await session.exec('mkdir', { args: ['-p', this.agentHome] });
+
+    this.session = session;
+    await this.saveState({
+      sessionId: session.id,
+      cwd: this.agentHome,
+      updatedAt: new Date().toISOString(),
+      state: 'active',
+    });
+    await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
+    await this.replayPendingSkillSync();
+  }
+
+  async exec(command: string, opts?: ExecOpts): Promise<ExecResult> {
+    if (!this.session) {
+      await this.ensure();
+    }
+
+    const startedAt = Date.now();
+    const cwd = opts?.cwd ?? this.agentHome;
+    // Tenki's exec runs argv directly (execve-style), so wrap the caller's
+    // shell command in `sh -c` and honour cwd via a leading `cd`.
+    const script = `cd ${shellQuote(cwd)} && ${command}`;
+    try {
+      const passEnv = (await this.context.passThroughEnvProvider?.()) ?? {};
+      const result = await this.session!.exec('sh', {
+        args: ['-c', script],
+        ...(Object.keys(passEnv).length > 0 ? { env: passEnv } : {}),
+        timeoutMs: this.timeoutMs,
+      });
+      return {
+        stdout: new TextDecoder().decode(result.stdout),
+        stderr: new TextDecoder().decode(result.stderr),
+        exitCode: result.exitCode,
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (error: unknown) {
+      // Transport-level failure (session evicted, network). Drop the cached
+      // handle so the next call re-`ensure()`s (reconnect or recreate).
+      this.session = null;
+      return {
+        stdout: '',
+        stderr: error instanceof Error ? error.message : String(error),
+        exitCode: 1,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+  }
+
+  async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
+    if (!this.session) {
+      await this.savePendingSkillSync({
+        skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source })),
+        queuedAt: new Date().toISOString(),
+      });
+      return;
+    }
+    await this.applySkillSync(skills);
+    await this.savePendingSkillSync(null);
+  }
+
+  private async applySkillSync(skills: SyncSkillEntry[]): Promise<void> {
+    if (!this.session) return;
+    const systemDir = `${this.agentHome}/.openhermit/skills/system`;
+    const userDir = `${this.agentHome}/.openhermit/skills/user`;
+    await this.session.exec('sh', {
+      args: ['-c', `rm -rf ${shellQuote(systemDir)} ${shellQuote(userDir)} && mkdir -p ${shellQuote(systemDir)} ${shellQuote(userDir)}`],
+    });
+    for (const skill of skills) {
+      const baseDir = skill.source === 'user' ? userDir : systemDir;
+      await uploadDirToTenki(this.session, skill.sourcePath, `${baseDir}/${skill.id}`);
+    }
+  }
+
+  private async replayPendingSkillSync(): Promise<void> {
+    if (!this.context.getRuntimeState) return;
+    const state = await this.context.getRuntimeState();
+    const pending = state?.['tenki_pending_skills'] as TenkiPendingSkillSync | undefined;
+    if (!pending || !pending.skills?.length) return;
+    try {
+      await this.applySkillSync(
+        pending.skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source ?? 'system' })),
+      );
+      await this.savePendingSkillSync(null);
+    } catch (error) {
+      console.warn(
+        `[exec-backend][tenki][${this.id}] failed to replay pending skill sync: ` +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+  }
+
+  private async savePendingSkillSync(pending: TenkiPendingSkillSync | null): Promise<void> {
+    if (!this.context.setRuntimeState || !this.context.getRuntimeState) return;
+    const current = (await this.context.getRuntimeState()) ?? {};
+    if (pending === null) {
+      const { tenki_pending_skills: _drop, ...rest } = current;
+      void _drop;
+      await this.context.setRuntimeState(rest);
+    } else {
+      await this.context.setRuntimeState({ ...current, tenki_pending_skills: pending });
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.session) return;
+    let paused = false;
+    try {
+      await this.session.pause();
+      paused = true;
+    } catch {
+      // Already paused or gone.
+    }
+    this.session = null;
+    if (paused) {
+      const persisted = await this.loadState();
+      if (persisted?.sessionId) {
+        await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'paused' });
+      }
+    }
+  }
+
+  private async loadState(): Promise<TenkiBackendPersisted | null> {
+    if (!this.context.getRuntimeState) return null;
+    const state = await this.context.getRuntimeState();
+    return (state?.['tenki'] as TenkiBackendPersisted) ?? null;
+  }
+
+  private async saveState(persisted: TenkiBackendPersisted): Promise<void> {
+    if (!this.context.setRuntimeState || !this.context.getRuntimeState) return;
+    const current = (await this.context.getRuntimeState()) ?? {};
+    await this.context.setRuntimeState({ ...current, tenki: persisted });
+  }
+}
+
+registerExecBackend('tenki', (config, context) =>
+  new TenkiExecBackend(config as TenkiExecBackendConfig, context),
+);

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { ValidationError } from '@openhermit/shared';
 
 import type { ExecBackend, ExecOpts, ExecResult, SyncSkillEntry, BackendFactoryContext, TenkiExecBackendConfig } from '../exec-backend.js';
-import { TenkiFileBackend } from './file-backend.js';
+import { ensureTenkiDirectories, TenkiFileBackend, toTenkiFsPath } from './file-backend.js';
 import { registerExecBackend } from '../exec-backend.js';
 
 const TENKI_DEFAULT_USERNAME = 'tenki';
@@ -20,16 +20,17 @@ const uploadDirToTenki = async (
   session: import('@tenkicloud/sandbox').Session,
   localDir: string,
   remoteDir: string,
+  agentHome: string,
 ): Promise<void> => {
-  await session.mkdir(remoteDir);
+  await ensureTenkiDirectories(session, [remoteDir]);
   const entries = await readdir(localDir, { withFileTypes: true });
   for (const entry of entries) {
     const localPath = path.join(localDir, entry.name);
     const remotePath = `${remoteDir}/${entry.name}`;
     if (entry.isDirectory()) {
-      await uploadDirToTenki(session, localPath, remotePath);
+      await uploadDirToTenki(session, localPath, remotePath, agentHome);
     } else if (entry.isFile()) {
-      await session.writeFile(remotePath, await readFile(localPath));
+      await session.writeFile(toTenkiFsPath(agentHome, remotePath), await readFile(localPath));
     }
   }
 };
@@ -55,6 +56,8 @@ export class TenkiExecBackend implements ExecBackend {
   readonly files: TenkiFileBackend;
 
   private readonly cpuCores: number;
+  private readonly projectId: string;
+  private readonly workspaceId: string | undefined;
   private readonly memoryMb: number;
   private readonly diskSizeGb: number;
   private readonly timeoutMs: number;
@@ -71,6 +74,8 @@ export class TenkiExecBackend implements ExecBackend {
     this.label = config.label ?? 'Tenki';
     this.username = TENKI_DEFAULT_USERNAME;
     this.agentHome = config.agent_home ?? TENKI_DEFAULT_AGENT_HOME;
+    this.projectId = config.project_id;
+    this.workspaceId = config.workspace_id;
     this.cpuCores = config.cpu_cores ?? TENKI_DEFAULT_CPU_CORES;
     this.memoryMb = config.memory_mb ?? TENKI_DEFAULT_MEMORY_MB;
     this.diskSizeGb = config.disk_size_gb ?? TENKI_DEFAULT_DISK_GB;
@@ -78,7 +83,7 @@ export class TenkiExecBackend implements ExecBackend {
     this.baseUrl = config.base_url;
     this.client = client ?? null;
 
-    this.files = new TenkiFileBackend();
+    this.files = new TenkiFileBackend(this.agentHome);
     this.files.getSession = () => this.session;
     this.files.ensureSession = () => this.ensure();
     this.files.invalidate = () => { this.session = null; };
@@ -136,6 +141,8 @@ export class TenkiExecBackend implements ExecBackend {
     }
 
     const session = await client.createAndWait({
+      projectId: this.projectId,
+      ...(this.workspaceId ? { workspaceId: this.workspaceId } : {}),
       cpuCores: this.cpuCores,
       memoryMb: this.memoryMb,
       diskSizeGb: this.diskSizeGb,
@@ -145,7 +152,6 @@ export class TenkiExecBackend implements ExecBackend {
     });
     this.session = session;
     try {
-      await session.mkdir(this.agentHome);
       await this.saveState({
         sessionId: session.id,
         cwd: this.agentHome,
@@ -238,12 +244,11 @@ export class TenkiExecBackend implements ExecBackend {
     const nonce = randomUUID();
     const stageDir = `${skillsDir}/.tenki-stage-${nonce}`;
     const backupDir = `${skillsDir}/.tenki-backup-${nonce}`;
-    await this.session.mkdir(`${stageDir}/system`);
-    await this.session.mkdir(`${stageDir}/user`);
+    await ensureTenkiDirectories(this.session, [`${stageDir}/system`, `${stageDir}/user`]);
     try {
       for (const skill of skills) {
         const baseDir = skill.source === 'user' ? `${stageDir}/user` : `${stageDir}/system`;
-        await uploadDirToTenki(this.session, skill.sourcePath, `${baseDir}/${skill.id}`);
+        await uploadDirToTenki(this.session, skill.sourcePath, `${baseDir}/${skill.id}`, this.agentHome);
       }
       const result = await this.session.run([
         'sh', '-c',

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 import { ValidationError } from '@openhermit/shared';
@@ -15,16 +16,12 @@ const TENKI_DEFAULT_CPU_CORES = 2;
 const TENKI_DEFAULT_MEMORY_MB = 4096;
 const TENKI_DEFAULT_DISK_GB = 10;
 
-/** Single-quote a value for safe interpolation into a `sh -c` string. */
-const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
-
 const uploadDirToTenki = async (
   session: import('@tenkicloud/sandbox').Session,
   localDir: string,
   remoteDir: string,
 ): Promise<void> => {
-  const { mkdir: tenkiMkdir } = await import('@tenkicloud/sandbox');
-  await tenkiMkdir(session, remoteDir);
+  await session.mkdir(remoteDir);
   const entries = await readdir(localDir, { withFileTypes: true });
   for (const entry of entries) {
     const localPath = path.join(localDir, entry.name);
@@ -49,7 +46,7 @@ interface TenkiPendingSkillSync {
   queuedAt: string;
 }
 
-class TenkiExecBackend implements ExecBackend {
+export class TenkiExecBackend implements ExecBackend {
   readonly id: string;
   readonly type = 'tenki';
   readonly label: string;
@@ -68,16 +65,18 @@ class TenkiExecBackend implements ExecBackend {
   constructor(
     config: TenkiExecBackendConfig,
     private readonly context: BackendFactoryContext,
+    client?: import('@tenkicloud/sandbox').TenkiSandbox,
   ) {
     this.id = config.id ?? 'tenki';
     this.label = config.label ?? 'Tenki';
-    this.username = config.username ?? TENKI_DEFAULT_USERNAME;
+    this.username = TENKI_DEFAULT_USERNAME;
     this.agentHome = config.agent_home ?? TENKI_DEFAULT_AGENT_HOME;
     this.cpuCores = config.cpu_cores ?? TENKI_DEFAULT_CPU_CORES;
     this.memoryMb = config.memory_mb ?? TENKI_DEFAULT_MEMORY_MB;
     this.diskSizeGb = config.disk_size_gb ?? TENKI_DEFAULT_DISK_GB;
     this.timeoutMs = config.timeout_ms ?? TENKI_DEFAULT_TIMEOUT_MS;
     this.baseUrl = config.base_url;
+    this.client = client ?? null;
 
     this.files = new TenkiFileBackend();
     this.files.getSession = () => this.session;
@@ -102,27 +101,37 @@ class TenkiExecBackend implements ExecBackend {
   }
 
   async ensure(): Promise<void> {
-    if (this.session) return;
+    if (this.session) {
+      await this.readySession(this.session);
+      return;
+    }
     const client = await this.getClient();
 
     const persisted = await this.loadState();
     if (persisted?.sessionId) {
+      let session: import('@tenkicloud/sandbox').Session | null = null;
       try {
-        const session = await client.get(persisted.sessionId);
-        // Reconnecting to a paused session transparently resumes it; resume()
-        // is harmless on an already-active session.
-        try {
-          await session.resume();
-        } catch {
-          // Already active or nothing to resume.
+        session = await client.get(persisted.sessionId);
+      } catch (error) {
+        const { SessionExpiredError, SessionNotFoundError, SessionTerminatedError } = await import('@tenkicloud/sandbox');
+        if (!(error instanceof SessionExpiredError) &&
+            !(error instanceof SessionNotFoundError) &&
+            !(error instanceof SessionTerminatedError)) {
+          throw error;
         }
+      }
+      if (session && session.state !== 'TERMINATED' && session.state !== 'USER_SHUTDOWN') {
+        await this.readySession(session);
         this.session = session;
-        await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'active' });
-        await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
-        await this.replayPendingSkillSync();
-        return;
-      } catch {
-        // Session is gone / expired. Fall through and create a fresh one.
+        try {
+          await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'active' });
+          await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
+          await this.replayPendingSkillSync();
+          return;
+        } catch (error) {
+          this.session = null;
+          throw error;
+        }
       }
     }
 
@@ -134,17 +143,27 @@ class TenkiExecBackend implements ExecBackend {
       metadata: { agentId: this.context.agentId },
       timeoutMs: TENKI_DEFAULT_CREATE_TIMEOUT_MS,
     });
-    await session.exec('mkdir', { args: ['-p', this.agentHome] });
-
     this.session = session;
-    await this.saveState({
-      sessionId: session.id,
-      cwd: this.agentHome,
-      updatedAt: new Date().toISOString(),
-      state: 'active',
-    });
-    await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
-    await this.replayPendingSkillSync();
+    try {
+      await session.mkdir(this.agentHome);
+      await this.saveState({
+        sessionId: session.id,
+        cwd: this.agentHome,
+        updatedAt: new Date().toISOString(),
+        state: 'active',
+      });
+      await this.context.markActive?.({ externalId: session.id, lastSeenAt: new Date().toISOString() });
+      await this.replayPendingSkillSync();
+    } catch (error) {
+      this.session = null;
+      await session.closeIfOpen().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  private async readySession(session: import('@tenkicloud/sandbox').Session): Promise<void> {
+    if (session.state === 'PAUSED') await session.resume();
+    if (session.state !== 'RUNNING') await session.waitReady(TENKI_DEFAULT_CREATE_TIMEOUT_MS);
   }
 
   async exec(command: string, opts?: ExecOpts): Promise<ExecResult> {
@@ -154,16 +173,29 @@ class TenkiExecBackend implements ExecBackend {
 
     const startedAt = Date.now();
     const cwd = opts?.cwd ?? this.agentHome;
-    // Tenki's exec runs argv directly (execve-style), so wrap the caller's
-    // shell command in `sh -c` and honour cwd via a leading `cd`.
-    const script = `cd ${shellQuote(cwd)} && ${command}`;
     try {
       const passEnv = (await this.context.passThroughEnvProvider?.()) ?? {};
-      const result = await this.session!.exec('sh', {
-        args: ['-c', script],
+      const handle = this.session!.run(['sh', '-c', command], {
+        cwd,
         ...(Object.keys(passEnv).length > 0 ? { env: passEnv } : {}),
-        timeoutMs: this.timeoutMs,
       });
+      const timeout = Symbol('timeout');
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        Promise.resolve(handle),
+        new Promise<typeof timeout>((resolve) => { timer = setTimeout(() => resolve(timeout), this.timeoutMs); }),
+      ]);
+      if (timer) clearTimeout(timer);
+      if (outcome === timeout) {
+        await handle.kill().catch(() => undefined);
+        return {
+          stdout: '',
+          stderr: `Command timed out after ${this.timeoutMs}ms`,
+          exitCode: 137,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+      const result = outcome;
       return {
         stdout: new TextDecoder().decode(result.stdout),
         stderr: new TextDecoder().decode(result.stderr),
@@ -185,6 +217,11 @@ class TenkiExecBackend implements ExecBackend {
 
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.session) {
+      if (!this.context.setRuntimeState || !this.context.getRuntimeState) {
+        await this.ensure();
+        await this.applySkillSync(skills);
+        return;
+      }
       await this.savePendingSkillSync({
         skills: skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source })),
         queuedAt: new Date().toISOString(),
@@ -197,14 +234,41 @@ class TenkiExecBackend implements ExecBackend {
 
   private async applySkillSync(skills: SyncSkillEntry[]): Promise<void> {
     if (!this.session) return;
-    const systemDir = `${this.agentHome}/.openhermit/skills/system`;
-    const userDir = `${this.agentHome}/.openhermit/skills/user`;
-    await this.session.exec('sh', {
-      args: ['-c', `rm -rf ${shellQuote(systemDir)} ${shellQuote(userDir)} && mkdir -p ${shellQuote(systemDir)} ${shellQuote(userDir)}`],
-    });
-    for (const skill of skills) {
-      const baseDir = skill.source === 'user' ? userDir : systemDir;
-      await uploadDirToTenki(this.session, skill.sourcePath, `${baseDir}/${skill.id}`);
+    const skillsDir = `${this.agentHome}/.openhermit/skills`;
+    const nonce = randomUUID();
+    const stageDir = `${skillsDir}/.tenki-stage-${nonce}`;
+    const backupDir = `${skillsDir}/.tenki-backup-${nonce}`;
+    await this.session.mkdir(`${stageDir}/system`);
+    await this.session.mkdir(`${stageDir}/user`);
+    try {
+      for (const skill of skills) {
+        const baseDir = skill.source === 'user' ? `${stageDir}/user` : `${stageDir}/system`;
+        await uploadDirToTenki(this.session, skill.sourcePath, `${baseDir}/${skill.id}`);
+      }
+      const result = await this.session.run([
+        'sh', '-c',
+        `set -eu
+mkdir -p "$1" "$3"
+[ ! -e "$1/system" ] || mv "$1/system" "$3/system"
+[ ! -e "$1/user" ] || mv "$1/user" "$3/user"
+rollback() {
+  rm -rf "$1/system" "$1/user"
+  [ ! -e "$3/system" ] || mv "$3/system" "$1/system"
+  [ ! -e "$3/user" ] || mv "$3/user" "$1/user"
+}
+trap rollback EXIT
+mv "$2/system" "$1/system"
+mv "$2/user" "$1/user"
+trap - EXIT
+rm -rf "$2" "$3"`,
+        '--', skillsDir, stageDir, backupDir,
+      ]);
+      if (result.exitCode !== 0) {
+        throw new Error(`Tenki skill swap failed: ${new TextDecoder().decode(result.stderr)}`);
+      }
+    } catch (error) {
+      await this.session.run(['rm', '-rf', stageDir]).then(() => undefined, () => undefined);
+      throw error;
     }
   }
 
@@ -212,18 +276,11 @@ class TenkiExecBackend implements ExecBackend {
     if (!this.context.getRuntimeState) return;
     const state = await this.context.getRuntimeState();
     const pending = state?.['tenki_pending_skills'] as TenkiPendingSkillSync | undefined;
-    if (!pending || !pending.skills?.length) return;
-    try {
-      await this.applySkillSync(
-        pending.skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source ?? 'system' })),
-      );
-      await this.savePendingSkillSync(null);
-    } catch (error) {
-      console.warn(
-        `[exec-backend][tenki][${this.id}] failed to replay pending skill sync: ` +
-          (error instanceof Error ? error.message : String(error)),
-      );
-    }
+    if (!pending) return;
+    await this.applySkillSync(
+      pending.skills.map((s) => ({ id: s.id, sourcePath: s.sourcePath, source: s.source ?? 'system' })),
+    );
+    await this.savePendingSkillSync(null);
   }
 
   private async savePendingSkillSync(pending: TenkiPendingSkillSync | null): Promise<void> {
@@ -240,20 +297,13 @@ class TenkiExecBackend implements ExecBackend {
 
   async shutdown(): Promise<void> {
     if (!this.session) return;
-    let paused = false;
-    try {
-      await this.session.pause();
-      paused = true;
-    } catch {
-      // Already paused or gone.
+    const session = this.session;
+    if (session.state !== 'PAUSED') await session.pause();
+    const persisted = await this.loadState();
+    if (persisted?.sessionId) {
+      await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'paused' });
     }
     this.session = null;
-    if (paused) {
-      const persisted = await this.loadState();
-      if (persisted?.sessionId) {
-        await this.saveState({ ...persisted, updatedAt: new Date().toISOString(), state: 'paused' });
-      }
-    }
   }
 
   private async loadState(): Promise<TenkiBackendPersisted | null> {

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -64,6 +64,7 @@ export class TenkiExecBackend implements ExecBackend {
   private readonly baseUrl: string | undefined;
   private client: import('@tenkicloud/sandbox').TenkiSandbox | null = null;
   private session: import('@tenkicloud/sandbox').Session | null = null;
+  private ensureInFlight: Promise<void> | null = null;
 
   constructor(
     config: TenkiExecBackendConfig,
@@ -106,6 +107,17 @@ export class TenkiExecBackend implements ExecBackend {
   }
 
   async ensure(): Promise<void> {
+    if (this.ensureInFlight) return this.ensureInFlight;
+    const pending = this.ensureSession();
+    this.ensureInFlight = pending;
+    try {
+      await pending;
+    } finally {
+      if (this.ensureInFlight === pending) this.ensureInFlight = null;
+    }
+  }
+
+  private async ensureSession(): Promise<void> {
     if (this.session) {
       await this.readySession(this.session);
       return;
@@ -187,11 +199,15 @@ export class TenkiExecBackend implements ExecBackend {
       });
       const timeout = Symbol('timeout');
       let timer: ReturnType<typeof setTimeout> | undefined;
-      const outcome = await Promise.race([
-        Promise.resolve(handle),
-        new Promise<typeof timeout>((resolve) => { timer = setTimeout(() => resolve(timeout), this.timeoutMs); }),
-      ]);
-      if (timer) clearTimeout(timer);
+      let outcome: Awaited<typeof handle> | typeof timeout;
+      try {
+        outcome = await Promise.race([
+          Promise.resolve(handle),
+          new Promise<typeof timeout>((resolve) => { timer = setTimeout(() => resolve(timeout), this.timeoutMs); }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
       if (outcome === timeout) {
         await handle.kill().catch(() => undefined);
         return {
@@ -254,16 +270,23 @@ export class TenkiExecBackend implements ExecBackend {
         'sh', '-c',
         `set -eu
 mkdir -p "$1" "$3"
-[ ! -e "$1/system" ] || mv "$1/system" "$3/system"
-[ ! -e "$1/user" ] || mv "$1/user" "$3/user"
+system_backed=0
+user_backed=0
+system_installed=0
+user_installed=0
 rollback() {
-  rm -rf "$1/system" "$1/user"
-  [ ! -e "$3/system" ] || mv "$3/system" "$1/system"
-  [ ! -e "$3/user" ] || mv "$3/user" "$1/user"
+  [ "$system_installed" -eq 0 ] || rm -rf "$1/system"
+  [ "$user_installed" -eq 0 ] || rm -rf "$1/user"
+  [ "$system_backed" -eq 0 ] || mv "$3/system" "$1/system"
+  [ "$user_backed" -eq 0 ] || mv "$3/user" "$1/user"
 }
 trap rollback EXIT
+[ ! -e "$1/system" ] || { mv "$1/system" "$3/system"; system_backed=1; }
+[ ! -e "$1/user" ] || { mv "$1/user" "$3/user"; user_backed=1; }
 mv "$2/system" "$1/system"
+system_installed=1
 mv "$2/user" "$1/user"
+user_installed=1
 trap - EXIT
 rm -rf "$2" "$3"`,
         '--', skillsDir, stageDir, backupDir,

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -111,11 +111,25 @@ export interface DaytonaExecBackendConfig {
   resources?: { cpu?: number; memory?: number };
 }
 
+export interface TenkiExecBackendConfig {
+  id?: string;
+  type: 'tenki';
+  label?: string;
+  cpu_cores?: number;
+  memory_mb?: number;
+  disk_size_gb?: number;
+  username?: string;
+  agent_home?: string;
+  timeout_ms?: number;
+  base_url?: string;
+}
+
 export type ExecBackendConfig =
   | DockerExecBackendConfig
   | HostExecBackendConfig
   | E2BExecBackendConfig
-  | DaytonaExecBackendConfig;
+  | DaytonaExecBackendConfig
+  | TenkiExecBackendConfig;
 
 export interface ExecConfig {
   backends: ExecBackendConfig[];

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -115,6 +115,8 @@ export interface TenkiExecBackendConfig {
   id?: string;
   type: 'tenki';
   label?: string;
+  project_id: string;
+  workspace_id?: string;
   cpu_cores?: number;
   memory_mb?: number;
   disk_size_gb?: number;

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -118,7 +118,6 @@ export interface TenkiExecBackendConfig {
   cpu_cores?: number;
   memory_mb?: number;
   disk_size_gb?: number;
-  username?: string;
   agent_home?: string;
   timeout_ms?: number;
   base_url?: string;

--- a/apps/agent/src/core/security.ts
+++ b/apps/agent/src/core/security.ts
@@ -98,6 +98,8 @@ const TenkiBackendSchema = z.object({
   id: z.string().optional(),
   type: z.literal('tenki'),
   label: z.string().optional(),
+  project_id: z.string().min(1),
+  workspace_id: z.string().min(1).optional(),
   cpu_cores: z.number().int().positive().optional(),
   memory_mb: z.number().int().positive().optional(),
   disk_size_gb: z.number().int().positive().optional(),

--- a/apps/agent/src/core/security.ts
+++ b/apps/agent/src/core/security.ts
@@ -80,10 +80,38 @@ const E2BBackendSchema = z.object({
   cwd: z.string().optional(),
 });
 
+const DaytonaBackendSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('daytona'),
+  label: z.string().optional(),
+  snapshot: z.string().optional(),
+  image: z.string().optional(),
+  username: z.string().optional(),
+  agent_home: z.string().optional(),
+  timeout_ms: z.number().optional(),
+  auto_stop_interval_minutes: z.number().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  resources: z.object({ cpu: z.number().optional(), memory: z.number().optional() }).optional(),
+});
+
+const TenkiBackendSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal('tenki'),
+  label: z.string().optional(),
+  cpu_cores: z.number().int().positive().optional(),
+  memory_mb: z.number().int().positive().optional(),
+  disk_size_gb: z.number().int().positive().optional(),
+  agent_home: z.string().optional(),
+  timeout_ms: z.number().int().positive().optional(),
+  base_url: z.string().url().optional(),
+});
+
 const ExecBackendConfigSchema = z.discriminatedUnion('type', [
   DockerBackendSchema,
   HostBackendSchema,
   E2BBackendSchema,
+  DaytonaBackendSchema,
+  TenkiBackendSchema,
 ]);
 
 const ExecConfigSchema = z.object({

--- a/apps/agent/test/security.test.ts
+++ b/apps/agent/test/security.test.ts
@@ -61,6 +61,28 @@ test('AgentSecurity scaffolds and reads the default runtime config', async (t) =
   assert.equal(config.memory.introspection?.enabled, true);
 });
 
+test('AgentSecurity accepts Tenki backend config', async (t) => {
+  const { security } = await createSecurityFixture(t);
+  const config = await security.readRawConfig();
+
+  await security.writeConfig({
+    ...config,
+    exec: {
+      backends: [{
+        type: 'tenki',
+        cpu_cores: 2,
+        memory_mb: 4096,
+        disk_size_gb: 10,
+        agent_home: '/home/tenki',
+      }],
+      default_backend: 'tenki',
+    },
+  });
+
+  const parsed = await security.readConfig();
+  assert.equal(parsed.exec?.backends[0]?.type, 'tenki');
+});
+
 test('AgentSecurity readConfig fails clearly when DB has no config', async (t) => {
   const { security } = await createSecurityFixture(t, { skipConfig: true });
   await assert.rejects(

--- a/apps/agent/test/security.test.ts
+++ b/apps/agent/test/security.test.ts
@@ -70,6 +70,8 @@ test('AgentSecurity accepts Tenki backend config', async (t) => {
     exec: {
       backends: [{
         type: 'tenki',
+        project_id: 'project-test',
+        workspace_id: 'workspace-test',
         cpu_cores: 2,
         memory_mb: 4096,
         disk_size_gb: 10,

--- a/apps/agent/test/tenki-backend.test.ts
+++ b/apps/agent/test/tenki-backend.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { ValidationError } from '@openhermit/shared';
+import { UnauthorizedError } from '@tenkicloud/sandbox';
+
+import { TenkiExecBackend } from '../src/core/backends/tenki.js';
+import { TenkiFileBackend } from '../src/core/backends/file-backend.js';
+
+const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+const processHandle = (
+  result: Promise<{ exitCode: number; stdout: Uint8Array; stderr: Uint8Array }>,
+  kill: () => Promise<void> = async () => undefined,
+) => Object.assign(result, { kill });
+
+const context = {
+  agentId: 'agent-test',
+  workspaceDir: '/tmp/agent-test',
+  containerManager: {} as never,
+};
+
+test('Tenki exec preserves normal non-zero command results', async () => {
+  const session = {
+    id: 'session-1', state: 'RUNNING', mkdir: async () => undefined,
+    run: () => processHandle(Promise.resolve({ exitCode: 42, stdout: bytes('out'), stderr: bytes('err') })),
+    closeIfOpen: async () => undefined,
+  };
+  const client = { createAndWait: async () => session };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki' }, context as never, client as never,
+  );
+
+  const result = await backend.exec('exit 42');
+  assert.equal(result.stdout, 'out');
+  assert.equal(result.stderr, 'err');
+  assert.equal(result.exitCode, 42);
+  assert.ok(result.durationMs >= 0);
+});
+
+test('Tenki exec kills timed-out process and returns 137', async () => {
+  let killed = false;
+  const session = {
+    id: 'session-1', state: 'RUNNING', mkdir: async () => undefined,
+    run: () => processHandle(new Promise(() => undefined), async () => { killed = true; }),
+    closeIfOpen: async () => undefined,
+  };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki', timeout_ms: 1 }, context as never,
+    { createAndWait: async () => session } as never,
+  );
+
+  const result = await backend.exec('sleep 10');
+  assert.equal(result.exitCode, 137);
+  assert.equal(killed, true);
+});
+
+test('Tenki reconnect does not create a duplicate after auth failure', async () => {
+  let created = false;
+  const backend = new TenkiExecBackend(
+    { type: 'tenki' },
+    {
+      ...context,
+      getRuntimeState: async () => ({ tenki: { sessionId: 'old', cwd: '/home/tenki', updatedAt: 'now' } }),
+      setRuntimeState: async () => undefined,
+    } as never,
+    {
+      get: async () => { throw new UnauthorizedError('denied'); },
+      createAndWait: async () => { created = true; throw new Error('must not create'); },
+    } as never,
+  );
+
+  await assert.rejects(() => backend.ensure(), UnauthorizedError);
+  assert.equal(created, false);
+});
+
+test('Tenki sessionless skill sync executes immediately without persistence hooks', async () => {
+  let swaps = 0;
+  const session = {
+    id: 'session-1', state: 'RUNNING', mkdir: async () => undefined,
+    run: () => {
+      swaps += 1;
+      return processHandle(Promise.resolve({ exitCode: 0, stdout: bytes(''), stderr: bytes('') }));
+    },
+    closeIfOpen: async () => undefined,
+  };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki' }, context as never,
+    { createAndWait: async () => session } as never,
+  );
+
+  await backend.syncSkills([]);
+  assert.equal(swaps, 1);
+});
+
+test('Tenki shutdown keeps live handle when pause fails', async () => {
+  let creates = 0;
+  const session = {
+    id: 'session-1', state: 'RUNNING', mkdir: async () => undefined,
+    pause: async () => { throw new Error('pause failed'); },
+    run: () => processHandle(Promise.resolve({ exitCode: 0, stdout: bytes('ok'), stderr: bytes('') })),
+    closeIfOpen: async () => undefined,
+  };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki' }, context as never,
+    { createAndWait: async () => { creates += 1; return session; } } as never,
+  );
+  await backend.ensure();
+
+  await assert.rejects(() => backend.shutdown(), /pause failed/);
+  assert.equal((await backend.exec('true')).stdout, 'ok');
+  assert.equal(creates, 1);
+});
+
+test('Tenki stat uses SDK mtime and list includes hidden entries', async () => {
+  let listOptions: unknown;
+  const session = {
+    stat: async () => ({ path: '/x', size: 3n, mode: 0, isDir: false, modifiedUnixNs: 1_700_000_000_000_000_000n }),
+    list: async (_path: string, options: unknown) => {
+      listOptions = options;
+      return [{ path: '/dir/.hidden', size: 2n, mode: 0, isDir: false, modifiedUnixNs: 0n }];
+    },
+  };
+  const backend = new TenkiFileBackend();
+  backend.getSession = () => session as never;
+
+  assert.equal((await backend.stat('/x'))?.mtime, '2023-11-14T22:13:20.000Z');
+  assert.deepEqual(await backend.list('/dir'), [{ name: '.hidden', type: 'file', size: 2 }]);
+  assert.deepEqual(listOptions, { includeHidden: true });
+});
+
+test('Tenki delete refuses directories and transport stat errors invalidate', async () => {
+  let removed = false;
+  let invalidated = false;
+  const backend = new TenkiFileBackend();
+  backend.invalidate = () => { invalidated = true; };
+  backend.getSession = () => ({
+    stat: async () => ({ path: '/dir', size: 0n, mode: 0, isDir: true, modifiedUnixNs: 0n }),
+    run: async () => { removed = true; return { exitCode: 0, stdout: bytes(''), stderr: bytes('') }; },
+  }) as never;
+
+  await assert.rejects(() => backend.delete('/dir'), ValidationError);
+  assert.equal(removed, false);
+
+  backend.getSession = () => ({ stat: async () => { throw new Error('transport'); } }) as never;
+  await assert.rejects(() => backend.stat('/x'), /transport/);
+  assert.equal(invalidated, true);
+});

--- a/apps/agent/test/tenki-backend.test.ts
+++ b/apps/agent/test/tenki-backend.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { ValidationError } from '@openhermit/shared';
-import { UnauthorizedError } from '@tenkicloud/sandbox';
+import { FileNotFoundError, UnauthorizedError } from '@tenkicloud/sandbox';
 
 import { TenkiExecBackend } from '../src/core/backends/tenki.js';
-import { TenkiFileBackend } from '../src/core/backends/file-backend.js';
+import { TenkiFileBackend, toTenkiFsPath } from '../src/core/backends/file-backend.js';
 
 const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
 
@@ -20,15 +20,25 @@ const context = {
   containerManager: {} as never,
 };
 
+test('Tenki filesystem paths translate from absolute agent paths to SDK-relative paths', () => {
+  assert.equal(toTenkiFsPath('/home/tenki', '/home/tenki/work/probe.txt'), 'work/probe.txt');
+  assert.equal(toTenkiFsPath('/home/tenki', '/home/tenki'), '.');
+  assert.throws(() => toTenkiFsPath('/home/tenki', '/tmp/probe.txt'), ValidationError);
+});
+
 test('Tenki exec preserves normal non-zero command results', async () => {
+  let createOptions: Record<string, unknown> | undefined;
   const session = {
     id: 'session-1', state: 'RUNNING', mkdir: async () => undefined,
     run: () => processHandle(Promise.resolve({ exitCode: 42, stdout: bytes('out'), stderr: bytes('err') })),
     closeIfOpen: async () => undefined,
   };
-  const client = { createAndWait: async () => session };
+  const client = { createAndWait: async (options: Record<string, unknown>) => {
+    createOptions = options;
+    return session;
+  } };
   const backend = new TenkiExecBackend(
-    { type: 'tenki' }, context as never, client as never,
+    { type: 'tenki', project_id: 'project-test' }, context as never, client as never,
   );
 
   const result = await backend.exec('exit 42');
@@ -36,6 +46,7 @@ test('Tenki exec preserves normal non-zero command results', async () => {
   assert.equal(result.stderr, 'err');
   assert.equal(result.exitCode, 42);
   assert.ok(result.durationMs >= 0);
+  assert.equal(createOptions?.projectId, 'project-test');
 });
 
 test('Tenki exec kills timed-out process and returns 137', async () => {
@@ -46,7 +57,7 @@ test('Tenki exec kills timed-out process and returns 137', async () => {
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', timeout_ms: 1 }, context as never,
+    { type: 'tenki', project_id: 'project-test', timeout_ms: 1 }, context as never,
     { createAndWait: async () => session } as never,
   );
 
@@ -58,7 +69,7 @@ test('Tenki exec kills timed-out process and returns 137', async () => {
 test('Tenki reconnect does not create a duplicate after auth failure', async () => {
   let created = false;
   const backend = new TenkiExecBackend(
-    { type: 'tenki' },
+    { type: 'tenki', project_id: 'project-test' },
     {
       ...context,
       getRuntimeState: async () => ({ tenki: { sessionId: 'old', cwd: '/home/tenki', updatedAt: 'now' } }),
@@ -85,12 +96,12 @@ test('Tenki sessionless skill sync executes immediately without persistence hook
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki' }, context as never,
+    { type: 'tenki', project_id: 'project-test' }, context as never,
     { createAndWait: async () => session } as never,
   );
 
   await backend.syncSkills([]);
-  assert.equal(swaps, 1);
+  assert.equal(swaps, 2);
 });
 
 test('Tenki shutdown keeps live handle when pause fails', async () => {
@@ -102,7 +113,7 @@ test('Tenki shutdown keeps live handle when pause fails', async () => {
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki' }, context as never,
+    { type: 'tenki', project_id: 'project-test' }, context as never,
     { createAndWait: async () => { creates += 1; return session; } } as never,
   );
   await backend.ensure();
@@ -124,8 +135,8 @@ test('Tenki stat uses SDK mtime and list includes hidden entries', async () => {
   const backend = new TenkiFileBackend();
   backend.getSession = () => session as never;
 
-  assert.equal((await backend.stat('/x'))?.mtime, '2023-11-14T22:13:20.000Z');
-  assert.deepEqual(await backend.list('/dir'), [{ name: '.hidden', type: 'file', size: 2 }]);
+  assert.equal((await backend.stat('/home/tenki/x'))?.mtime, '2023-11-14T22:13:20.000Z');
+  assert.deepEqual(await backend.list('/home/tenki/dir'), [{ name: '.hidden', type: 'file', size: 2 }]);
   assert.deepEqual(listOptions, { includeHidden: true });
 });
 
@@ -139,10 +150,22 @@ test('Tenki delete refuses directories and transport stat errors invalidate', as
     run: async () => { removed = true; return { exitCode: 0, stdout: bytes(''), stderr: bytes('') }; },
   }) as never;
 
-  await assert.rejects(() => backend.delete('/dir'), ValidationError);
+  await assert.rejects(() => backend.delete('/home/tenki/dir'), ValidationError);
   assert.equal(removed, false);
 
   backend.getSession = () => ({ stat: async () => { throw new Error('transport'); } }) as never;
-  await assert.rejects(() => backend.stat('/x'), /transport/);
+  await assert.rejects(() => backend.stat('/home/tenki/x'), /transport/);
   assert.equal(invalidated, true);
+});
+
+test('Tenki stat maps only SDK file-not-found errors to null', async () => {
+  let invalidated = false;
+  const backend = new TenkiFileBackend();
+  backend.invalidate = () => { invalidated = true; };
+  backend.getSession = () => ({
+    stat: async () => { throw new FileNotFoundError('missing'); },
+  }) as never;
+
+  assert.equal(await backend.stat('/home/tenki/missing'), null);
+  assert.equal(invalidated, false);
 });

--- a/apps/agent/test/tenki-backend.test.ts
+++ b/apps/agent/test/tenki-backend.test.ts
@@ -66,6 +66,50 @@ test('Tenki exec kills timed-out process and returns 137', async () => {
   assert.equal(killed, true);
 });
 
+test('Tenki ensure serializes concurrent sandbox creation', async () => {
+  let creates = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const session = {
+    id: 'session-1', state: 'RUNNING', closeIfOpen: async () => undefined,
+  };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki', project_id: 'project-test' }, context as never,
+    { createAndWait: async () => { creates += 1; await gate; return session; } } as never,
+  );
+
+  const first = backend.ensure();
+  const second = backend.ensure();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(creates, 1);
+  release();
+  await Promise.all([first, second]);
+});
+
+test('Tenki exec clears timeout when process handle rejects', async () => {
+  let cleared = 0;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const session = {
+    id: 'session-1', state: 'RUNNING', closeIfOpen: async () => undefined,
+    run: () => processHandle(Promise.reject(new Error('transport'))),
+  };
+  const backend = new TenkiExecBackend(
+    { type: 'tenki', project_id: 'project-test', timeout_ms: 60_000 }, context as never,
+    { createAndWait: async () => session } as never,
+  );
+  globalThis.clearTimeout = ((timer: Parameters<typeof clearTimeout>[0]) => {
+    cleared += 1;
+    return originalClearTimeout(timer);
+  }) as typeof clearTimeout;
+  try {
+    const result = await backend.exec('true');
+    assert.equal(result.exitCode, 1);
+    assert.equal(cleared, 1);
+  } finally {
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test('Tenki reconnect does not create a duplicate after auth failure', async () => {
   let created = false;
   const backend = new TenkiExecBackend(

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,6 +50,7 @@
     "dev:chat": "tsx src/index.ts"
   },
   "dependencies": {
+    "@openhermit/protocol": "0.2.0",
     "@hono/node-server": "^1.14.0",
     "@mariozechner/pi-agent-core": "^0.70.6",
     "@mariozechner/pi-ai": "^0.70.6",

--- a/apps/cli/src/commands/sandbox.ts
+++ b/apps/cli/src/commands/sandbox.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { isSandboxType, SANDBOX_TYPES } from '@openhermit/protocol';
 
 import { createGateway, handleError, printTable } from './shared.js';
 
@@ -42,13 +43,13 @@ export const registerSandboxCommand = (program: Command): void => {
     .command('add')
     .description('Create a sandbox for an agent')
     .requiredOption('--agent <id>', 'Agent ID')
-    .requiredOption('--type <type>', 'Sandbox type: host | docker | e2b')
+    .requiredOption('--type <type>', `Sandbox type: ${SANDBOX_TYPES.join(' | ')}`)
     .option('--alias <alias>', 'Sandbox alias (default: "default")')
     .option('--config <json>', 'JSON config blob (e.g. \'{"image":"ubuntu:24.04"}\')')
     .action(async (opts: { agent: string; type: string; alias?: string; config?: string }) => {
       try {
         const t = opts.type;
-        if (t !== 'host' && t !== 'docker' && t !== 'e2b' && t !== 'daytona') {
+        if (!isSandboxType(t)) {
           console.error(`Invalid sandbox type: ${t}`);
           process.exit(1);
         }

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -9,6 +9,7 @@ import { serveStatic } from '@hono/node-server/serve-static';
 
 import {
   gatewayRoutes,
+  isSandboxType,
   isSessionSpec,
   isSessionMessage,
   isToolApprovalRequest,
@@ -3499,7 +3500,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       type = body.type;
       config = body.config;
     }
-    if (type !== 'host' && type !== 'docker' && type !== 'e2b' && type !== 'daytona') {
+    if (!isSandboxType(type)) {
       throw new ValidationError(`Invalid sandbox type: ${type}`);
     }
     const store = requireSandboxStore();

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs/promises';
 
+import { isSandboxType, type SandboxType } from '@openhermit/protocol';
 import type { DbMetaStore } from '@openhermit/store';
 
 export interface SandboxPreset {
-  type: 'host' | 'docker' | 'e2b' | 'daytona';
+  type: SandboxType;
   /** Backend-specific config (image/snapshot/template, agent_home, etc.). */
   config: Record<string, unknown>;
 }
@@ -84,8 +85,6 @@ const DEFAULT_CONFIG: GatewayConfig = {
 export const defaultGatewayConfig = (): GatewayConfig =>
   JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as GatewayConfig;
 
-const SUPPORTED_TYPES = new Set(['host', 'docker', 'e2b', 'daytona']);
-
 const getCorsOrigin = (raw: Record<string, unknown>): string | undefined => {
   if (raw.cors && typeof raw.cors === 'object') {
     const origin = (raw.cors as Record<string, unknown>).origin;
@@ -103,13 +102,13 @@ const parsePresets = (raw: unknown): Record<string, SandboxPreset> | undefined =
     }
     const v = val as Record<string, unknown>;
     const type = v['type'];
-    if (typeof type !== 'string' || !SUPPORTED_TYPES.has(type)) {
+    if (!isSandboxType(type)) {
       throw new Error(`Invalid sandboxPresets["${name}"].type: ${String(type)}`);
     }
     const config = v['config'] && typeof v['config'] === 'object' && !Array.isArray(v['config'])
       ? (v['config'] as Record<string, unknown>)
       : {};
-    out[name] = { type: type as SandboxPreset['type'], config };
+    out[name] = { type, config };
   }
   return out;
 };

--- a/apps/gateway/src/sandbox-backfill.ts
+++ b/apps/gateway/src/sandbox-backfill.ts
@@ -28,13 +28,27 @@ export const backfillSandboxes = async (
     if (backends.length === 0) continue;
 
     const defaultId = exec?.default_backend ?? (backends[0]?.['id'] as string | undefined);
-    for (const backend of backends) {
-      const type = backend['type'] as string | undefined;
-      if (!isSandboxType(type)) {
-        log(`skipping unsupported sandbox type ${String(type)} for agent ${agent.agentId}`);
-        continue;
-      }
-      const backendId = (backend['id'] as string | undefined) ?? type;
+    const candidates = backends.map((backend) => ({
+      backend,
+      type: backend['type'],
+      backendId: (backend['id'] as string | undefined) ?? backend['type'],
+    }));
+    const unsupported = candidates.find(({ type }) => !isSandboxType(type));
+    if (unsupported) {
+      log(`skipping sandbox backfill for agent ${agent.agentId}: unsupported type ${String(unsupported.type)}`);
+      continue;
+    }
+    const validated = candidates.filter(
+      (candidate): candidate is typeof candidate & { type: import('@openhermit/protocol').SandboxType; backendId: string } =>
+        isSandboxType(candidate.type) && typeof candidate.backendId === 'string',
+    );
+    if (defaultId !== undefined && !validated.some(({ backendId }) => backendId === defaultId)) {
+      log(`skipping sandbox backfill for agent ${agent.agentId}: default backend ${defaultId} was not found`);
+      continue;
+    }
+
+    let migratedBackends = 0;
+    for (const { backend, type, backendId } of validated) {
       const isDefault = defaultId === undefined ? backend === backends[0] : backendId === defaultId;
       const alias = isDefault ? 'default' : backendId;
 
@@ -50,6 +64,7 @@ export const backfillSandboxes = async (
         type,
         config: rest,
       });
+      migratedBackends += 1;
     }
 
     if (config) {
@@ -58,7 +73,7 @@ export const backfillSandboxes = async (
       await configStore.setConfig(agent.agentId, remaining);
     }
     migrated += 1;
-    log(`backfilled ${backends.length} sandbox row(s) for agent ${agent.agentId}`);
+    log(`backfilled ${migratedBackends} sandbox row(s) for agent ${agent.agentId}`);
   }
   if (migrated > 0) {
     log(`sandbox backfill complete: migrated ${migrated} agent(s)`);

--- a/apps/gateway/src/sandbox-backfill.ts
+++ b/apps/gateway/src/sandbox-backfill.ts
@@ -1,3 +1,4 @@
+import { isSandboxType } from '@openhermit/protocol';
 import type { AgentStore, DbAgentConfigStore, SandboxStore } from '@openhermit/store';
 
 /**
@@ -29,7 +30,10 @@ export const backfillSandboxes = async (
     const defaultId = exec?.default_backend ?? (backends[0]?.['id'] as string | undefined);
     for (const backend of backends) {
       const type = backend['type'] as string | undefined;
-      if (!type) continue;
+      if (!isSandboxType(type)) {
+        log(`skipping unsupported sandbox type ${String(type)} for agent ${agent.agentId}`);
+        continue;
+      }
       const backendId = (backend['id'] as string | undefined) ?? type;
       const isDefault = defaultId === undefined ? backend === backends[0] : backendId === defaultId;
       const alias = isDefault ? 'default' : backendId;
@@ -43,7 +47,7 @@ export const backfillSandboxes = async (
       await sandboxStore.create({
         agentId: agent.agentId,
         alias,
-        type: type as 'host' | 'docker' | 'e2b' | 'daytona',
+        type,
         config: rest,
       });
     }

--- a/apps/gateway/test/sandbox-backfill.test.ts
+++ b/apps/gateway/test/sandbox-backfill.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { backfillSandboxes } from '../src/sandbox-backfill.js';
+
+test('sandbox backfill preserves legacy exec config when any backend is unsupported', async () => {
+  const config = {
+    model: { provider: 'test' },
+    exec: {
+      default_backend: 'future',
+      backends: [
+        { id: 'docker', type: 'docker', image: 'ubuntu:24.04' },
+        { id: 'future', type: 'future-provider' },
+      ],
+    },
+  };
+  const created: unknown[] = [];
+  const writes: unknown[] = [];
+  const logs: string[] = [];
+
+  await backfillSandboxes(
+    { list: async () => [{ agentId: 'agent-1' }] } as never,
+    {
+      getConfig: async () => config,
+      setConfig: async (_agentId: string, value: unknown) => { writes.push(value); },
+    } as never,
+    {
+      listByAgent: async () => [],
+      create: async (value: unknown) => { created.push(value); },
+    } as never,
+    (message) => logs.push(message),
+  );
+
+  assert.deepEqual(created, []);
+  assert.deepEqual(writes, []);
+  assert.ok(logs.some((message) => message.includes('future-provider')));
+});

--- a/apps/gateway/ui/src/components/SandboxesPanel.tsx
+++ b/apps/gateway/ui/src/components/SandboxesPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import type { SandboxType } from '@openhermit/protocol';
 import { api } from '../api';
 import { Pagination, usePagination } from './Pagination';
 
@@ -9,7 +10,7 @@ interface SandboxInfo {
   agentId: string;
   agentName?: string;
   alias: string;
-  type: 'host' | 'docker' | 'e2b' | 'daytona';
+  type: SandboxType;
   status: 'pending' | 'provisioned' | 'deleted';
   externalId: string | null;
   lastSeenAt: string | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,6 +275,7 @@
         "@mariozechner/pi-ai": "^0.70.6",
         "@mariozechner/pi-tui": "^0.70.6",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@openhermit/protocol": "0.2.0",
         "commander": "^12.1.0",
         "croner": "^10.0.1",
         "defuddle": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/voice": "0.2.0",
+        "@tenkicloud/sandbox": "^0.3.6",
         "croner": "^10.0.1",
         "defuddle": "^0.11.0",
         "e2b": "^2.19.4",
@@ -698,7 +699,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
       "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1485,7 +1485,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1767,11 +1766,10 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.9",
@@ -1814,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -1913,7 +1910,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1936,7 +1932,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2152,6 +2147,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3167,6 +3163,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3183,6 +3180,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3205,6 +3203,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3227,6 +3226,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3243,6 +3243,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3259,6 +3260,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3275,6 +3277,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3291,6 +3294,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3307,6 +3311,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3323,6 +3328,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3339,6 +3345,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3355,6 +3362,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3371,6 +3379,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3387,6 +3396,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3409,6 +3419,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3431,6 +3442,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3453,6 +3465,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3475,6 +3488,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3497,6 +3511,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3519,6 +3534,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3541,6 +3557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3560,6 +3577,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -3582,6 +3600,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3601,6 +3620,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3620,6 +3640,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4232,7 +4253,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6150,6 +6170,43 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tenkicloud/sandbox": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.3.6.tgz",
+      "integrity": "sha512-nCjCStmVUj5OG2Ek5aFMZnNI2UAw2tJb3enZobf1hFcoV7h9QVCYuKrpsf11SWcVVh7P39T+vZq+rlJkcyB6vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.1",
+        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect-node": "2.1.2",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -6249,7 +6306,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6260,7 +6316,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6293,7 +6348,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6388,7 +6442,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6945,7 +6998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7549,6 +7601,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8462,7 +8515,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8659,7 +8711,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9376,7 +9427,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9678,7 +9728,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -9873,7 +9922,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -10929,7 +10977,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -11527,7 +11574,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12005,6 +12051,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -12048,6 +12095,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12782,7 +12830,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12833,7 +12880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13034,7 +13080,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13728,11 +13773,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13923,7 +13967,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,13 @@
 export type KnownSourceKind = 'cli' | 'api' | 'channel' | 'schedule';
 
+export const SANDBOX_TYPES = ['host', 'docker', 'e2b', 'daytona', 'tenki'] as const;
+export type SandboxType = (typeof SANDBOX_TYPES)[number];
+
+const SANDBOX_TYPE_SET: ReadonlySet<string> = new Set(SANDBOX_TYPES);
+
+export const isSandboxType = (value: unknown): value is SandboxType =>
+  typeof value === 'string' && SANDBOX_TYPE_SET.has(value);
+
 export type SourceKind = KnownSourceKind | (string & {});
 
 export type MetadataValue = string | number | boolean;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1135,7 +1135,7 @@ export class GatewayClient {
 
   async createSandbox(agentId: string, input: {
     alias?: string;
-    type: 'host' | 'docker' | 'e2b' | 'daytona';
+    type: 'host' | 'docker' | 'e2b' | 'daytona' | 'tenki';
     config?: Record<string, unknown>;
   }): Promise<unknown> {
     return this.postJson(`/api/agents/${encodeURIComponent(agentId)}/sandboxes`, input);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -14,6 +14,7 @@ import {
   type SessionMessage,
   type SessionSummary,
   type SessionSpec,
+  type SandboxType,
   type SyncResponse,
   type ToolApprovalRequest,
   type WsRequest,
@@ -1135,7 +1136,7 @@ export class GatewayClient {
 
   async createSandbox(agentId: string, input: {
     alias?: string;
-    type: 'host' | 'docker' | 'e2b' | 'daytona' | 'tenki';
+    type: SandboxType;
     config?: Record<string, unknown>;
   }): Promise<unknown> {
     return this.postJson(`/api/agents/${encodeURIComponent(agentId)}/sandboxes`, input);

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -208,7 +208,7 @@ export const sandboxes = pgTable('sandboxes', {
   id: text('id').primaryKey(),
   agentId: text('agent_id').notNull(),
   alias: text('alias').notNull(),
-  /** 'host' | 'docker' | 'e2b' | 'daytona' (future) */
+  /** 'host' | 'docker' | 'e2b' | 'daytona' | 'tenki' (future) */
   type: text('type').notNull(),
   externalId: text('external_id'),
   /** 'pending' | 'provisioned' | 'deleted' — see SandboxStatus type. */

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -5,7 +5,10 @@ import type {
   SessionSpec,
   SessionStatus,
   SessionType,
+  SandboxType,
 } from '@openhermit/protocol';
+
+export type { SandboxType } from '@openhermit/protocol';
 
 export interface StoreScope {
   agentId: string;
@@ -22,8 +25,6 @@ export interface AgentRecord {
   createdAt: string;
   updatedAt: string;
 }
-
-export type SandboxType = 'host' | 'docker' | 'e2b' | 'daytona' | 'tenki';
 
 /**
  * Lifecycle state of a sandbox row — intent, not live runtime status.

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -23,7 +23,7 @@ export interface AgentRecord {
   updatedAt: string;
 }
 
-export type SandboxType = 'host' | 'docker' | 'e2b' | 'daytona';
+export type SandboxType = 'host' | 'docker' | 'e2b' | 'daytona' | 'tenki';
 
 /**
  * Lifecycle state of a sandbox row — intent, not live runtime status.


### PR DESCRIPTION
## Why

- Add Tenki microVM sandboxes as a first-class OpenHermit execution backend alongside Docker, E2B, and Daytona.
- Preserve long-lived agent workspaces across gateway restarts through sticky sessions, pause/resume lifecycle, and persisted runtime state.

## How

- Add `TenkiExecBackend` using `@tenkicloud/sandbox@0.3.6` with explicit project/workspace targeting, lazy SDK loading, typed reconnect handling, sticky session recovery, and cleanup of failed session creation.
- Execute commands through `Session.run()` with `cwd`, pass-through environment variables, non-zero exit preservation, and enforced timeout/kill behavior.
- Add `TenkiFileBackend` with absolute-to-workdir-relative SDK path translation, readiness-safe parent creation, streaming append, exclusive create, hidden-file listing, SDK mtime conversion, session invalidation, and non-recursive single-file deletion.
- Stage complete skill uploads before swapping live roots, with checked command results and rollback on failure. Persist pending syncs while disconnected; apply synchronously when persistence hooks are unavailable.
- Define sandbox types once in `@openhermit/protocol`; reuse them across gateway validation, CLI, store, SDK, UI, and legacy sandbox backfill.
- Add Daytona and Tenki to runtime Zod backend validation.

## Configuration

```jsonc
{
  "type": "tenki",
  "project_id": "your-tenki-project-id",
  "workspace_id": "your-tenki-workspace-id",
  "cpu_cores": 2,
  "memory_mb": 4096,
  "disk_size_gb": 10,
  "agent_home": "/home/tenki"
}
```

Authentication uses `TENKI_API_KEY`, with `TENKI_AUTH_TOKEN` accepted as a fallback.

`project_id` is required by the live Tenki API. `workspace_id` is optional when the project already resolves it unambiguously.

## Tests

- `npm run build -w @openhermit/agent` — pass
- Typechecks for protocol, store, gateway, CLI, and SDK — pass
- Focused Tenki lifecycle/filesystem and security-schema tests — 17/17 pass
- Real Tenki sandbox smoke — pass: create, exec, env/cwd, file create/append/read/stat/list/delete, pause, and final close
- `git diff --check` — pass

The full agent test command and agent whole-project typecheck remain red from confirmed pre-existing, unrelated test/database failures also present on `main`; changed production files introduce no new type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tenki as a new execution backend with command execution, session recovery, and skill synchronization.
  * Added Tenki-backed filesystem support for read/write/list/stat/delete operations.
  * Extended sandbox and exec backend configuration to recognize the `tenki` type across APIs and validation.
* **Tests**
  * Added comprehensive Tenki backend tests and an exec backend security/config validation test.
* **Chores**
  * Updated shared sandbox-type contracts and centralized validation logic across SDK, gateway, CLI, and UI; added protocol dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
