### PR TITLE
fix(gateway): assign owner immediately after agent row creation

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -939,6 +939,15 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       updatedAt: now,
     });
 
+    // Assign owner immediately after the agent row exists. The rest of this
+    // handler is a long non-transactional seeding sequence; if it is cut off
+    // mid-way (deploy restart, client timeout) a retry gets a 409 and callers
+    // reasonably treat the agent as created — so ownership must never be the
+    // step that got lost. See the ownerless-agents incident (2026-07-17).
+    if (body.ownerUserId && typeof body.ownerUserId === 'string') {
+      await agentStore.assignOwner(record.agentId, body.ownerUserId, now);
+    }
+
     // Eager-create the per-agent inbox session row so web UI subscribers
     // never race against lazy hydration. See docs/inbox-design.md.
     if (options.sessionStore) {
@@ -1075,9 +1084,7 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       },
     ], now);
 
-    // Assign owner if specified
     if (body.ownerUserId && typeof body.ownerUserId === 'string') {
-      await agentStore.assignOwner(record.agentId, body.ownerUserId, now);
       log(`agent created: ${record.agentId} (owner: ${body.ownerUserId})`);
     } else {
       log(`agent created: ${record.agentId}`);


### PR DESCRIPTION
## Problem

`POST /api/agents` runs ~8 sequential, non-transactional steps (agent row → inbox session → config → security → sandbox → channel seeds → instructions) with **`assignOwner` as the very last step**. If the request dies mid-way (gateway restart, client timeout), the agent row exists but the owner row is never written.

Provisioning callers (amiko-platform `provision.ts`) tolerate a 409 on retry and proceed as if creation succeeded — so the lost ownership is never re-asserted. With `exec` defaulting to owner-only grants (`sandbox-exec.ts`), an ownerless agent can never run CLI commands in any session.

This is not theoretical: 15 ownerless agents were found in the amiko-openhermit production DB (1 on 05-29, 12 during the 06-08 bulk migration of 765 twins, 2 later) and repaired via `promote-to-owner` on 2026-07-17.

## Fix

Move `assignOwner` to immediately after `agentStore.create`. An interrupted create can now lose seeding steps (which callers re-run or reconcile) but never ownership.

Companion PR on the amiko-platform side makes the 409-tolerant retry path re-assert ownership explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent ownership is now saved immediately during agent creation, improving reliability when subsequent setup steps take longer or fail.
  * Agent creation responses and logs continue to reflect the requested ownership details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->