### PR TITLE
fix(agent): keep parallel tool-call groups intact at the compaction boundary

### DIFF
--- a/apps/agent/src/agent-runner/context-compaction.ts
+++ b/apps/agent/src/agent-runner/context-compaction.ts
@@ -212,11 +212,7 @@ export const getCompactionRetainedStartIndex = (
 ): number => {
   let startIndex = Math.max(0, messages.length - retainCount);
 
-  if (
-    startIndex > 0
-    && messages[startIndex]?.role === 'toolResult'
-    && messages[startIndex - 1]?.role === 'assistant'
-  ) {
+  while (startIndex > 0 && messages[startIndex]?.role === 'toolResult') {
     startIndex -= 1;
   }
 

--- a/apps/agent/test/context-compaction.test.ts
+++ b/apps/agent/test/context-compaction.test.ts
@@ -88,6 +88,18 @@ const makeToolResultMessage = (toolName: string, text: string, ts = Date.now()):
   timestamp: ts,
 });
 
+const makeParallelToolCallMessage = (toolNames: string[], ts = Date.now()): AgentMessage => ({
+  role: 'assistant',
+  content: toolNames.map((toolName) => ({
+    type: 'toolCall' as const,
+    id: `call-${toolName}`,
+    name: toolName,
+    arguments: {},
+  })),
+  ...assistantDefaults,
+  timestamp: ts,
+});
+
 const stubConfig: AgentConfig = {
   workspace_root: '/workspace',
   model: { provider: 'anthropic', model: 'claude-sonnet-4-20250514', max_tokens: 4096 },
@@ -158,6 +170,18 @@ test('getCompactionRetainedStartIndex pulls back to include assistant before too
   ];
   // retainCount=2 → startIndex=2, but messages[2] is toolResult and messages[1] is assistant
   assert.equal(getCompactionRetainedStartIndex(messages, 2), 1);
+});
+
+test('getCompactionRetainedStartIndex pulls back over a run of parallel toolResults', () => {
+  const messages = [
+    makeUserMessage('a'),
+    makeParallelToolCallMessage(['search', 'fetch']),
+    makeToolResultMessage('search', 'no results'),
+    makeToolResultMessage('fetch', 'words: 0'),
+    makeUserMessage('c'),
+  ];
+  assert.equal(getCompactionRetainedStartIndex(messages, 2), 1);
+  assert.equal(getCompactionRetainedStartIndex(messages, 3), 1);
 });
 
 // ── summarizeMessageForCompaction ──────────────────────────────────────
@@ -1031,6 +1055,22 @@ test('applyRollingWindow never orphans a toolResult at the boundary', () => {
   const result = applyRollingWindow(messages, 4);
   assert.notEqual(result[0]!.role, 'toolResult');
   assert.equal(result[0]!.role, 'assistant');
+  assert.deepEqual(result, messages.slice(1));
+});
+
+test('applyRollingWindow never orphans a toolResult when the boundary lands mid parallel-call run', () => {
+  const messages = [
+    makeUserMessage('u0'),
+    makeParallelToolCallMessage(['search', 'fetch']),
+    makeToolResultMessage('search', 'no results'),
+    makeToolResultMessage('fetch', 'words: 0'),
+    makeUserMessage('u4'),
+    makeAssistantMessage('a5'),
+  ];
+
+  const result = applyRollingWindow(messages, 3);
+  assert.equal(result[0]!.role, 'assistant');
+  assert.ok(result.every((m, i) => !(i === 0 && m.role === 'toolResult')));
   assert.deepEqual(result, messages.slice(1));
 });
 


### PR DESCRIPTION
## Problem

Chats with MiniMax-backed agents could get permanently wedged: every turn —
including plain `hi` and `/reset` — failed with a friendly error, backed by the
raw upstream rejection:

400 invalid_request_error: "invalid params, tool result's tool id(...) not found (2013)"

The message history sent to the model contained a `tool_result` whose owning
assistant `tool_call` was missing, so the provider rejected the whole request.
Because the corrupted transcript is replayed on every turn, the session never
recovers on its own.

## Root cause

`getCompactionRetainedStartIndex()` (in `context-compaction.ts`) picks where the
verbatim retained window starts — used by both `applyRollingWindow` and
`compactContextIfNeeded`. To avoid orphaning a tool result, it stepped the
boundary back **by one** when it landed on a `toolResult`.

That only covers a *single* tool call per assistant turn. An assistant turn can
issue **parallel** tool calls (`AssistantMessage.content` holds N `toolCall`
blocks), each answered by its own `toolResult` message:

assistant[toolCall A, toolCall B]  →  toolResult A  →  toolResult B

When the cut landed on `toolResult B`, the preceding message was `toolResult A`
(not the assistant), so the guard didn't fire and the retained window began with
an orphaned `toolResult` → the 2013 error.

## Fix

Walk back over the entire run of leading tool results to the assistant turn that
owns them, keeping the tool-call→tool-result group intact:

```js
while (startIndex > 0 && messages[startIndex]?.role === 'toolResult') {
  startIndex -= 1;
}

Byte-identical behavior for the single-call case; correct for parallel calls.
Existing sessions self-heal once the gateway restarts (their transcript is
rebuilt clean from the store, where both the tool call and its result are
intact).

Tests

- Added regression tests for the parallel-tool-call boundary in both
getCompactionRetainedStartIndex and applyRollingWindow.
- Full context-compaction.test.ts suite passes (70/70).
- Negative check: reverting the fix fails exactly the two new tests, confirming
they guard the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history compaction for parallel tool calls.
  * Prevented tool results from being separated from their corresponding assistant messages when older context is removed.
  * Ensured retained conversation history starts at a complete tool-call sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->