### PR TITLE
inject session and agent ids into sandbox execs

### DIFF
--- a/apps/agent/src/core/backends/daytona.ts
+++ b/apps/agent/src/core/backends/daytona.ts
@@ -163,7 +163,10 @@ class DaytonaExecBackend implements ExecBackend {
     const startedAt = Date.now();
     try {
       const timeoutSec = Math.max(1, Math.ceil(this.timeoutMs / 1000));
-      const passEnv = (await this.context.passThroughEnvProvider?.()) ?? {};
+      const passEnv = {
+        ...((await this.context.passThroughEnvProvider?.()) ?? {}),
+        ...(opts?.env ?? {}),
+      };
       const response = await this.sandbox!.process.executeCommand(
         command,
         opts?.cwd ?? this.agentHome,

--- a/apps/agent/src/core/backends/docker.ts
+++ b/apps/agent/src/core/backends/docker.ts
@@ -56,7 +56,7 @@ class DockerExecBackend implements ExecBackend {
   }
 
   async exec(command: string, opts?: ExecOpts): Promise<ExecResult> {
-    return this.containerManager.execInWorkspace(this.agentId, command, opts?.cwd);
+    return this.containerManager.execInWorkspace(this.agentId, command, opts?.cwd, opts?.env);
   }
 
   async syncSkills(skills: SyncSkillEntry[]): Promise<void> {

--- a/apps/agent/src/core/backends/e2b.ts
+++ b/apps/agent/src/core/backends/e2b.ts
@@ -197,7 +197,10 @@ class E2BExecBackend implements ExecBackend {
 
     const startedAt = Date.now();
     try {
-      const passEnv = (await this.context.passThroughEnvProvider?.()) ?? {};
+      const passEnv = {
+        ...((await this.context.passThroughEnvProvider?.()) ?? {}),
+        ...(opts?.env ?? {}),
+      };
       const result = await this.sandbox!.commands.run(command, {
         cwd: opts?.cwd ?? this.agentHome,
         timeoutMs: this.timeoutMs,

--- a/apps/agent/src/core/backends/host.ts
+++ b/apps/agent/src/core/backends/host.ts
@@ -65,7 +65,7 @@ class HostExecBackend implements ExecBackend {
     return new Promise<ExecResult>((resolve, reject) => {
       const child = spawn(this.shell, ['-lc', command], {
         cwd,
-        env: { ...process.env, ...passEnv, ...(this.env ?? {}) },
+        env: { ...process.env, ...passEnv, ...(this.env ?? {}), ...(opts?.env ?? {}) },
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -192,7 +192,10 @@ export class TenkiExecBackend implements ExecBackend {
     const startedAt = Date.now();
     const cwd = opts?.cwd ?? this.agentHome;
     try {
-      const passEnv = (await this.context.passThroughEnvProvider?.()) ?? {};
+      const passEnv = {
+        ...((await this.context.passThroughEnvProvider?.()) ?? {}),
+        ...(opts?.env ?? {}),
+      };
       const handle = this.session!.run(['sh', '-c', command], {
         cwd,
         ...(Object.keys(passEnv).length > 0 ? { env: passEnv } : {}),

--- a/apps/agent/src/core/container-manager.ts
+++ b/apps/agent/src/core/container-manager.ts
@@ -358,6 +358,7 @@ export class DockerContainerManager {
     agentId: string,
     command: string,
     cwd?: string,
+    env?: Record<string, string>,
   ): Promise<ContainerProcessResult> {
     const name = this.containerName('workspace');
 
@@ -383,9 +384,10 @@ export class DockerContainerManager {
       }
     }
 
+    const envArgs = Object.entries(env ?? {}).flatMap(([key, value]) => ['--env', `${key}=${value}`]);
     const execArgs = cwd
-      ? ['exec', '-w', cwd, name, 'sh', '-lc', command]
-      : ['exec', name, 'sh', '-lc', command];
+      ? ['exec', ...envArgs, '-w', cwd, name, 'sh', '-lc', command]
+      : ['exec', ...envArgs, name, 'sh', '-lc', command];
     const result = await this.docker.run(execArgs, 300_000);
     const parsedOutput = parseStructuredOutput(result.stdout);
 

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -35,6 +35,9 @@ export interface SyncSkillEntry {
 
 export interface ExecOpts {
   cwd?: string;
+  /** Extra env for this single exec (e.g. the calling session's id so
+   *  sandbox CLIs can route async results back into the right session). */
+  env?: Record<string, string>;
 }
 
 export interface ExecBackend {

--- a/apps/agent/src/tools/sandbox-exec.ts
+++ b/apps/agent/src/tools/sandbox-exec.ts
@@ -76,17 +76,12 @@ export const createSandboxExecTool = (
 
     await backend.ensure();
     context.onExec?.();
-    // Expose the calling session to sandbox CLIs (e.g. `amiko create ...`) so
-    // async media jobs can publish their skeleton + result back into THIS chat
-    // session instead of returning a bare URL.
+    // Expose the calling session and agent to sandbox CLIs so tools running in
+    // the sandbox can tie their work back to THIS chat session. Consumers map
+    // these to whatever names their downstream expects.
     const sessionEnv: Record<string, string> = {
-      ...(context.sessionId ? { AMIKO_SESSION_ID: context.sessionId } : {}),
-      ...(context.agentId ? { AMIKO_AGENT_ID: context.agentId } : {}),
-      // Spend autonomy: lets the amiko CLI auto-approve create jobs whose
-      // quoted cost is under this limit (gateway-level env, deploy-scoped).
-      ...(process.env.AMIKO_AUTO_APPROVE_LIMIT
-        ? { AMIKO_AUTO_APPROVE_LIMIT: process.env.AMIKO_AUTO_APPROVE_LIMIT }
-        : {}),
+      ...(context.sessionId ? { OPENHERMIT_SESSION_ID: context.sessionId } : {}),
+      ...(context.agentId ? { OPENHERMIT_AGENT_ID: context.agentId } : {}),
     };
     const result = await backend.exec(args.command, {
       ...(args.cwd ? { cwd: args.cwd } : {}),

--- a/apps/agent/src/tools/sandbox-exec.ts
+++ b/apps/agent/src/tools/sandbox-exec.ts
@@ -76,7 +76,22 @@ export const createSandboxExecTool = (
 
     await backend.ensure();
     context.onExec?.();
-    const result = await backend.exec(args.command, args.cwd ? { cwd: args.cwd } : undefined);
+    // Expose the calling session to sandbox CLIs (e.g. `amiko create ...`) so
+    // async media jobs can publish their skeleton + result back into THIS chat
+    // session instead of returning a bare URL.
+    const sessionEnv: Record<string, string> = {
+      ...(context.sessionId ? { AMIKO_SESSION_ID: context.sessionId } : {}),
+      ...(context.agentId ? { AMIKO_AGENT_ID: context.agentId } : {}),
+      // Spend autonomy: lets the amiko CLI auto-approve create jobs whose
+      // quoted cost is under this limit (gateway-level env, deploy-scoped).
+      ...(process.env.AMIKO_AUTO_APPROVE_LIMIT
+        ? { AMIKO_AUTO_APPROVE_LIMIT: process.env.AMIKO_AUTO_APPROVE_LIMIT }
+        : {}),
+    };
+    const result = await backend.exec(args.command, {
+      ...(args.cwd ? { cwd: args.cwd } : {}),
+      ...(Object.keys(sessionEnv).length > 0 ? { env: sessionEnv } : {}),
+    });
 
     const details = {
       stdout: result.stdout,

--- a/apps/agent/test/exec-backend-env.test.ts
+++ b/apps/agent/test/exec-backend-env.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  createExecBackend,
+  DockerContainerManager,
+  type BackendFactoryContext,
+  type DockerCommandResult,
+  type DockerRunner,
+} from '../src/core/index.js';
+import { createWorkspaceFixture } from './helpers.js';
+
+const fakeContext: BackendFactoryContext = {
+  containerManager: {} as DockerContainerManager,
+  agentId: 'test-agent',
+  workspaceDir: '/tmp/workspace',
+};
+
+// ── host backend: env reaches the spawned process ─────────────────────────
+
+const restoreEnv = (key: string, prev: string | undefined): void => {
+  if (prev === undefined) delete process.env[key];
+  else process.env[key] = prev;
+};
+
+test('host backend: ExecOpts.env is visible to the spawned command', async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), 'oh-env-host-'));
+  const prevHome = process.env['HOME'];
+  const prevMyTestVar = process.env['MY_TEST_VAR'];
+  try {
+    process.env['HOME'] = tmp;
+    delete process.env['MY_TEST_VAR'];
+    const backend = createExecBackend({ type: 'host' }, fakeContext);
+    const result = await backend.exec(`printf '%s' "$MY_TEST_VAR"`, {
+      env: { MY_TEST_VAR: 'hello-from-opts' },
+    });
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'hello-from-opts');
+  } finally {
+    restoreEnv('HOME', prevHome);
+    restoreEnv('MY_TEST_VAR', prevMyTestVar);
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('host backend: absent env means the var is unset in the process', async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), 'oh-env-host-'));
+  const prevHome = process.env['HOME'];
+  const prevMyTestVar = process.env['MY_TEST_VAR'];
+  try {
+    process.env['HOME'] = tmp;
+    delete process.env['MY_TEST_VAR'];
+    const backend = createExecBackend({ type: 'host' }, fakeContext);
+    const result = await backend.exec(`printf '%s' "${'$'}{MY_TEST_VAR:-<unset>}"`);
+    assert.equal(result.stdout, '<unset>');
+  } finally {
+    restoreEnv('HOME', prevHome);
+    restoreEnv('MY_TEST_VAR', prevMyTestVar);
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── docker backend: env plumbs into the docker exec argv ──────────────────
+
+class FakeDockerRunner implements DockerRunner {
+  readonly calls: string[][] = [];
+  constructor(private readonly results: DockerCommandResult[]) {}
+  async run(args: string[]): Promise<DockerCommandResult> {
+    this.calls.push(args);
+    const next = this.results.shift();
+    if (!next) throw new Error(`Unexpected docker call: ${args.join(' ')}`);
+    return next;
+  }
+}
+
+const okResult = (o: Partial<DockerCommandResult> = {}): DockerCommandResult => ({
+  stdout: '',
+  stderr: '',
+  exitCode: 0,
+  durationMs: 1,
+  ...o,
+});
+
+test('container-manager: execInWorkspace threads env into --env argv flags', async (t) => {
+  const { workspace } = await createWorkspaceFixture(t);
+  const runner = new FakeDockerRunner([
+    // listLiveContainers re-probe: report the workspace container as Up.
+    okResult({
+      stdout: JSON.stringify({
+        ID: 'live-1',
+        Names: 'openhermit-default-workspace',
+        Image: 'ubuntu:24.04',
+        Status: 'Up 2 minutes',
+      }),
+    }),
+    // the exec itself
+    okResult({ stdout: 'done' }),
+  ]);
+  const manager = new DockerContainerManager(workspace, { runner });
+
+  await manager.execInWorkspace('default', 'run-it', '/root/work', {
+    AMIKO_SESSION_ID: 'sess-1',
+    AMIKO_AGENT_ID: 'agent-1',
+  });
+
+  const execCall = runner.calls[1]!;
+  assert.equal(execCall[0], 'exec');
+  // Each env var becomes an adjacent `--env KEY=VALUE` pair.
+  const sessIdx = execCall.indexOf('AMIKO_SESSION_ID=sess-1');
+  const agentIdx = execCall.indexOf('AMIKO_AGENT_ID=agent-1');
+  assert.ok(sessIdx > 0 && execCall[sessIdx - 1] === '--env');
+  assert.ok(agentIdx > 0 && execCall[agentIdx - 1] === '--env');
+  // cwd and command are still present.
+  assert.ok(execCall.includes('-w'));
+  assert.ok(execCall.includes('/root/work'));
+  assert.ok(execCall.includes('run-it'));
+});
+
+test('container-manager: no env means no --env flags in the argv', async (t) => {
+  const { workspace } = await createWorkspaceFixture(t);
+  const runner = new FakeDockerRunner([
+    okResult({
+      stdout: JSON.stringify({
+        ID: 'live-2',
+        Names: 'openhermit-default-workspace',
+        Image: 'ubuntu:24.04',
+        Status: 'Up 2 minutes',
+      }),
+    }),
+    okResult({ stdout: 'done' }),
+  ]);
+  const manager = new DockerContainerManager(workspace, { runner });
+
+  await manager.execInWorkspace('default', 'run-it');
+
+  const execCall = runner.calls[1]!;
+  assert.ok(!execCall.includes('--env'), `expected no --env flags, got: ${execCall.join(' ')}`);
+});
+
+// ── e2b backend: env is merged into the sandbox run options ────────────────
+
+interface RunOptions {
+  cwd?: string;
+  timeoutMs?: number;
+  envs?: Record<string, string>;
+}
+
+interface RunCapture {
+  command?: string;
+  options?: RunOptions;
+}
+
+function e2bBackendWithFakeSandbox(
+  capture: RunCapture,
+  over: Partial<BackendFactoryContext> = {},
+) {
+  const ctx: BackendFactoryContext = { ...fakeContext, ...over };
+  const backend = createExecBackend({ type: 'e2b', template: 'tpl' }, ctx);
+  // Inject a live sandbox so exec() skips ensure() and never touches the real
+  // e2b SDK; commands.run captures whatever the backend forwards.
+  (backend as unknown as { sandbox: unknown }).sandbox = {
+    sandboxId: 'sbx-fake',
+    commands: {
+      run: async (command: string, options: RunOptions) => {
+        capture.command = command;
+        capture.options = options;
+        return { stdout: 'ok', stderr: '', exitCode: 0 };
+      },
+    },
+  };
+  return backend;
+}
+
+test('e2b backend: ExecOpts.env is forwarded as sandbox run envs', async () => {
+  const cap: RunCapture = {};
+  const backend = e2bBackendWithFakeSandbox(cap);
+  await backend.exec('do-thing', { env: { AMIKO_SESSION_ID: 'sess-e2b' } });
+  assert.deepEqual(cap.options?.envs, { AMIKO_SESSION_ID: 'sess-e2b' });
+});
+
+test('e2b backend: passthrough secrets merge with opts.env, opts wins on conflict', async () => {
+  const cap: RunCapture = {};
+  const backend = e2bBackendWithFakeSandbox(cap, {
+    passThroughEnvProvider: async () => ({ SHARED: 'from-secret', SECRET_ONLY: 's' }),
+  });
+  await backend.exec('do-thing', { env: { SHARED: 'from-opts', OPT_ONLY: 'o' } });
+  assert.deepEqual(cap.options?.envs, {
+    SHARED: 'from-opts',
+    SECRET_ONLY: 's',
+    OPT_ONLY: 'o',
+  });
+});
+
+test('e2b backend: no env and no passthrough means envs is omitted', async () => {
+  const cap: RunCapture = {};
+  const backend = e2bBackendWithFakeSandbox(cap);
+  await backend.exec('do-thing');
+  assert.equal(cap.options?.envs, undefined);
+});

--- a/apps/agent/test/exec-backend-env.test.ts
+++ b/apps/agent/test/exec-backend-env.test.ts
@@ -102,15 +102,15 @@ test('container-manager: execInWorkspace threads env into --env argv flags', asy
   const manager = new DockerContainerManager(workspace, { runner });
 
   await manager.execInWorkspace('default', 'run-it', '/root/work', {
-    AMIKO_SESSION_ID: 'sess-1',
-    AMIKO_AGENT_ID: 'agent-1',
+    OPENHERMIT_SESSION_ID: 'sess-1',
+    OPENHERMIT_AGENT_ID: 'agent-1',
   });
 
   const execCall = runner.calls[1]!;
   assert.equal(execCall[0], 'exec');
   // Each env var becomes an adjacent `--env KEY=VALUE` pair.
-  const sessIdx = execCall.indexOf('AMIKO_SESSION_ID=sess-1');
-  const agentIdx = execCall.indexOf('AMIKO_AGENT_ID=agent-1');
+  const sessIdx = execCall.indexOf('OPENHERMIT_SESSION_ID=sess-1');
+  const agentIdx = execCall.indexOf('OPENHERMIT_AGENT_ID=agent-1');
   assert.ok(sessIdx > 0 && execCall[sessIdx - 1] === '--env');
   assert.ok(agentIdx > 0 && execCall[agentIdx - 1] === '--env');
   // cwd and command are still present.
@@ -177,8 +177,8 @@ function e2bBackendWithFakeSandbox(
 test('e2b backend: ExecOpts.env is forwarded as sandbox run envs', async () => {
   const cap: RunCapture = {};
   const backend = e2bBackendWithFakeSandbox(cap);
-  await backend.exec('do-thing', { env: { AMIKO_SESSION_ID: 'sess-e2b' } });
-  assert.deepEqual(cap.options?.envs, { AMIKO_SESSION_ID: 'sess-e2b' });
+  await backend.exec('do-thing', { env: { OPENHERMIT_SESSION_ID: 'sess-e2b' } });
+  assert.deepEqual(cap.options?.envs, { OPENHERMIT_SESSION_ID: 'sess-e2b' });
 });
 
 test('e2b backend: passthrough secrets merge with opts.env, opts wins on conflict', async () => {

--- a/apps/agent/test/sandbox-exec.test.ts
+++ b/apps/agent/test/sandbox-exec.test.ts
@@ -45,16 +45,23 @@ function makeContext(rec: Recorder, over: Partial<ToolContext>): ToolContext {
 }
 
 test('exec injects AMIKO_SESSION_ID and AMIKO_AGENT_ID when the context has them', async () => {
-  const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
-  const ctx = makeContext(rec, { sessionId: 'sess-42', agentId: 'agent-7' });
-  const tool = createSandboxExecTool(ctx);
-  await tool.execute('tc-1', { command: 'echo hi' });
+  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  try {
+    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+    const ctx = makeContext(rec, { sessionId: 'sess-42', agentId: 'agent-7' });
+    const tool = createSandboxExecTool(ctx);
+    await tool.execute('tc-1', { command: 'echo hi' });
 
-  assert.equal(rec.ensured, 1);
-  assert.deepEqual(rec.lastOpts?.env, {
-    AMIKO_SESSION_ID: 'sess-42',
-    AMIKO_AGENT_ID: 'agent-7',
-  });
+    assert.equal(rec.ensured, 1);
+    assert.deepEqual(rec.lastOpts?.env, {
+      AMIKO_SESSION_ID: 'sess-42',
+      AMIKO_AGENT_ID: 'agent-7',
+    });
+  } finally {
+    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
+    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
+  }
 });
 
 test('exec omits the env object entirely when there is no session/agent context', async () => {

--- a/apps/agent/test/sandbox-exec.test.ts
+++ b/apps/agent/test/sandbox-exec.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createSandboxExecTool } from '../src/tools/sandbox-exec.js';
+import { ExecBackendManager, type ExecBackend, type ExecOpts, type ExecResult } from '../src/core/index.js';
+import type { ToolContext } from '../src/tools/shared.js';
+
+interface Recorder {
+  lastCommand: string | undefined;
+  lastOpts: ExecOpts | undefined;
+  ensured: number;
+}
+
+function makeBackend(rec: Recorder): ExecBackend {
+  return {
+    id: 'default',
+    type: 'host',
+    label: 'test',
+    username: 'tester',
+    agentHome: '/home/agent',
+    ensure: async () => { rec.ensured += 1; },
+    exec: async (command: string, opts?: ExecOpts): Promise<ExecResult> => {
+      rec.lastCommand = command;
+      rec.lastOpts = opts;
+      return { stdout: 'ok', stderr: '', exitCode: 0, durationMs: 1 };
+    },
+    syncSkills: async () => {},
+    shutdown: async () => {},
+    files: {
+      read: async () => { throw new Error('not used'); },
+      write: async () => { throw new Error('not used'); },
+      list: async () => [],
+      stat: async () => null,
+      delete: async () => { throw new Error('not used'); },
+    },
+  };
+}
+
+function makeContext(rec: Recorder, over: Partial<ToolContext>): ToolContext {
+  const mgr = new ExecBackendManager([makeBackend(rec)]);
+  return {
+    execBackendManager: mgr,
+    ...over,
+  } as unknown as ToolContext;
+}
+
+test('exec injects AMIKO_SESSION_ID and AMIKO_AGENT_ID when the context has them', async () => {
+  const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+  const ctx = makeContext(rec, { sessionId: 'sess-42', agentId: 'agent-7' });
+  const tool = createSandboxExecTool(ctx);
+  await tool.execute('tc-1', { command: 'echo hi' });
+
+  assert.equal(rec.ensured, 1);
+  assert.deepEqual(rec.lastOpts?.env, {
+    AMIKO_SESSION_ID: 'sess-42',
+    AMIKO_AGENT_ID: 'agent-7',
+  });
+});
+
+test('exec omits the env object entirely when there is no session/agent context', async () => {
+  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  try {
+    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+    const ctx = makeContext(rec, {});
+    const tool = createSandboxExecTool(ctx);
+    await tool.execute('tc-1', { command: 'echo hi' });
+
+    assert.equal(rec.lastOpts?.env, undefined);
+  } finally {
+    if (prev !== undefined) process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
+  }
+});
+
+test('exec forwards AMIKO_AUTO_APPROVE_LIMIT from process env', async () => {
+  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  process.env.AMIKO_AUTO_APPROVE_LIMIT = '5.00';
+  try {
+    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+    const ctx = makeContext(rec, { sessionId: 'sess-1', agentId: 'agent-1' });
+    const tool = createSandboxExecTool(ctx);
+    await tool.execute('tc-1', { command: 'echo hi' });
+
+    assert.deepEqual(rec.lastOpts?.env, {
+      AMIKO_SESSION_ID: 'sess-1',
+      AMIKO_AGENT_ID: 'agent-1',
+      AMIKO_AUTO_APPROVE_LIMIT: '5.00',
+    });
+  } finally {
+    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
+    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
+  }
+});
+
+test('exec forwards AMIKO_AUTO_APPROVE_LIMIT even without a session context', async () => {
+  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
+  process.env.AMIKO_AUTO_APPROVE_LIMIT = '2.50';
+  try {
+    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+    const ctx = makeContext(rec, {});
+    const tool = createSandboxExecTool(ctx);
+    await tool.execute('tc-1', { command: 'echo hi' });
+
+    assert.deepEqual(rec.lastOpts?.env, { AMIKO_AUTO_APPROVE_LIMIT: '2.50' });
+  } finally {
+    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
+    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
+  }
+});
+
+test('exec passes cwd through alongside the session env', async () => {
+  const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+  const ctx = makeContext(rec, { sessionId: 'sess-9', agentId: 'agent-9' });
+  const tool = createSandboxExecTool(ctx);
+  await tool.execute('tc-1', { command: 'ls', cwd: '/home/agent/work' });
+
+  assert.equal(rec.lastOpts?.cwd, '/home/agent/work');
+  assert.equal(rec.lastOpts?.env?.AMIKO_SESSION_ID, 'sess-9');
+});

--- a/apps/agent/test/sandbox-exec.test.ts
+++ b/apps/agent/test/sandbox-exec.test.ts
@@ -44,75 +44,26 @@ function makeContext(rec: Recorder, over: Partial<ToolContext>): ToolContext {
   } as unknown as ToolContext;
 }
 
-test('exec injects AMIKO_SESSION_ID and AMIKO_AGENT_ID when the context has them', async () => {
-  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  try {
-    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
-    const ctx = makeContext(rec, { sessionId: 'sess-42', agentId: 'agent-7' });
-    const tool = createSandboxExecTool(ctx);
-    await tool.execute('tc-1', { command: 'echo hi' });
+test('exec injects OPENHERMIT_SESSION_ID and OPENHERMIT_AGENT_ID when the context has them', async () => {
+  const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+  const ctx = makeContext(rec, { sessionId: 'sess-42', agentId: 'agent-7' });
+  const tool = createSandboxExecTool(ctx);
+  await tool.execute('tc-1', { command: 'echo hi' });
 
-    assert.equal(rec.ensured, 1);
-    assert.deepEqual(rec.lastOpts?.env, {
-      AMIKO_SESSION_ID: 'sess-42',
-      AMIKO_AGENT_ID: 'agent-7',
-    });
-  } finally {
-    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
-    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
-  }
+  assert.equal(rec.ensured, 1);
+  assert.deepEqual(rec.lastOpts?.env, {
+    OPENHERMIT_SESSION_ID: 'sess-42',
+    OPENHERMIT_AGENT_ID: 'agent-7',
+  });
 });
 
 test('exec omits the env object entirely when there is no session/agent context', async () => {
-  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  try {
-    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
-    const ctx = makeContext(rec, {});
-    const tool = createSandboxExecTool(ctx);
-    await tool.execute('tc-1', { command: 'echo hi' });
+  const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
+  const ctx = makeContext(rec, {});
+  const tool = createSandboxExecTool(ctx);
+  await tool.execute('tc-1', { command: 'echo hi' });
 
-    assert.equal(rec.lastOpts?.env, undefined);
-  } finally {
-    if (prev !== undefined) process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
-  }
-});
-
-test('exec forwards AMIKO_AUTO_APPROVE_LIMIT from process env', async () => {
-  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  process.env.AMIKO_AUTO_APPROVE_LIMIT = '5.00';
-  try {
-    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
-    const ctx = makeContext(rec, { sessionId: 'sess-1', agentId: 'agent-1' });
-    const tool = createSandboxExecTool(ctx);
-    await tool.execute('tc-1', { command: 'echo hi' });
-
-    assert.deepEqual(rec.lastOpts?.env, {
-      AMIKO_SESSION_ID: 'sess-1',
-      AMIKO_AGENT_ID: 'agent-1',
-      AMIKO_AUTO_APPROVE_LIMIT: '5.00',
-    });
-  } finally {
-    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
-    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
-  }
-});
-
-test('exec forwards AMIKO_AUTO_APPROVE_LIMIT even without a session context', async () => {
-  const prev = process.env.AMIKO_AUTO_APPROVE_LIMIT;
-  process.env.AMIKO_AUTO_APPROVE_LIMIT = '2.50';
-  try {
-    const rec: Recorder = { ensured: 0, lastCommand: undefined, lastOpts: undefined };
-    const ctx = makeContext(rec, {});
-    const tool = createSandboxExecTool(ctx);
-    await tool.execute('tc-1', { command: 'echo hi' });
-
-    assert.deepEqual(rec.lastOpts?.env, { AMIKO_AUTO_APPROVE_LIMIT: '2.50' });
-  } finally {
-    if (prev === undefined) delete process.env.AMIKO_AUTO_APPROVE_LIMIT;
-    else process.env.AMIKO_AUTO_APPROVE_LIMIT = prev;
-  }
+  assert.equal(rec.lastOpts?.env, undefined);
 });
 
 test('exec passes cwd through alongside the session env', async () => {
@@ -122,5 +73,5 @@ test('exec passes cwd through alongside the session env', async () => {
   await tool.execute('tc-1', { command: 'ls', cwd: '/home/agent/work' });
 
   assert.equal(rec.lastOpts?.cwd, '/home/agent/work');
-  assert.equal(rec.lastOpts?.env?.AMIKO_SESSION_ID, 'sess-9');
+  assert.equal(rec.lastOpts?.env?.OPENHERMIT_SESSION_ID, 'sess-9');
 });


### PR DESCRIPTION
Adds a generic `env` option to `ExecOpts` and threads it through every exec backend (host, docker via container-manager `--env`, e2b, daytona, tenki).

The sandbox exec tool uses it to inject `OPENHERMIT_SESSION_ID` and `OPENHERMIT_AGENT_ID` so tools running inside a sandbox can tie their work back to the calling chat session.

Consumers map these to whatever names their own downstream expects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-exec environment variable support (`env`) for sandboxed command execution across host, Docker, and E2B backends.
  * Sandbox tool now forwards `OPENHERMIT_SESSION_ID` and `OPENHERMIT_AGENT_ID` to the launched sandbox CLI when available.
* **Bug Fixes**
  * Per-call environment overrides are now consistently applied and correctly take precedence over inherited values.
* **Tests**
  * Added coverage for environment-variable propagation across host, Docker, and E2B, plus sandbox tool option construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->