### PR TITLE
fix(agent): send users a classified, language-matched notice on model errors

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -79,6 +79,7 @@ import {
   startTurnTrace,
 } from './langfuse.js';
 import { withOpenRouterAttribution } from './agent-runner/openrouter-attribution.js';
+import { buildUserFacingModelError } from './agent-runner/user-facing-error.js';
 import { withAmikoTwinAttribution } from './agent-runner/amiko-attribution.js';
 import { type Caller, type SessionDescriptor, SessionEventBroker, type SessionRuntime } from './runtime.js';
 export type { SessionEventEnvelope } from './runtime.js';
@@ -1231,6 +1232,7 @@ export class AgentRunner implements SessionRuntime {
         } else {
           delete session.currentTurnCorrelationId;
         }
+        session.currentTurnUserText = message.text;
         if (this.options.langfuse && session.langfuseTurnContext) {
           startTurnTrace(
             this.options.langfuse,
@@ -3068,10 +3070,16 @@ export class AgentRunner implements SessionRuntime {
         }
 
         if (event.assistantMessageEvent.type === 'error') {
+          // Channels forward the error message to the end user verbatim —
+          // publish a classified, language-matched notice, never provider
+          // internals (raw text is logged/persisted on the message_end path).
           void this.events.publish({
             type: 'error',
             sessionId: session.spec.sessionId,
-            message: event.assistantMessageEvent.error.errorMessage ?? 'Model stream failed.',
+            message: buildUserFacingModelError(
+              event.assistantMessageEvent.error.errorMessage ?? 'Model stream failed.',
+              session.currentTurnUserText,
+            ),
           });
         }
         break;
@@ -3136,10 +3144,13 @@ export class AgentRunner implements SessionRuntime {
 
           this.logRuntime(`model error in ${session.spec.sessionId}: ${errorMsg}`);
 
+          // User-facing notice goes out classified + in the user's language;
+          // the raw provider error stays in logRuntime above and in the
+          // persisted entry's errorMessage below for diagnostics.
           void this.events.publish({
             type: 'error',
             sessionId: session.spec.sessionId,
-            message: errorMsg,
+            message: buildUserFacingModelError(errorMsg, session.currentTurnUserText),
           });
 
           void this.queueSideEffect(session, async () => {
@@ -3424,10 +3435,13 @@ export class AgentRunner implements SessionRuntime {
     }
 
     try {
+      // Same contract as the model-error paths: users get a classified,
+      // language-matched notice; the raw message stays in the persisted
+      // role:'error' entry below and in the langfuse trace above.
       await this.events.publish({
         type: 'error',
         sessionId: session.spec.sessionId,
-        message,
+        message: buildUserFacingModelError(message, session.currentTurnUserText),
       });
       await this.events.publish({
         type: 'agent_end',

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -29,6 +29,9 @@ export interface RunnerSession extends SessionDescriptor {
    *  `correlationId`, so callers can group events back to the originating
    *  user message. Cleared at agent_end. */
   currentTurnCorrelationId?: string;
+  /** Text of the user message that triggered the in-flight turn. Used to
+   *  phrase user-facing error notices in the user's own language. */
+  currentTurnUserText?: string;
   approvalGate: ApprovalGate;
   status: SessionStatus;
   messageCount: number;

--- a/apps/agent/src/agent-runner/user-facing-error.ts
+++ b/apps/agent/src/agent-runner/user-facing-error.ts
@@ -1,0 +1,76 @@
+/**
+ * Turn raw model-provider failures into something an end user can act on.
+ *
+ * Channels deliver the `error` event's `message` straight to the chat (e.g.
+ * the WeChat bridge sends `Error: ${message}`), so publishing the provider's
+ * raw text meant users saw things like
+ * `403 Key limit exceeded (total limit). Manage it using https://openrouter.ai/...`
+ * — an English wall of internals, regardless of the user's language. The raw
+ * error still belongs in logs, metrics, and the persisted session event; this
+ * module only shapes what the *user* sees.
+ */
+
+export type ModelErrorKind =
+  | 'quota'
+  | 'rate_limit'
+  | 'auth'
+  | 'context_too_long'
+  | 'unavailable'
+  | 'generic';
+
+/** Order matters: more specific patterns run first (e.g. "403 Key limit
+ *  exceeded" must classify as quota, not auth). */
+const CLASSIFIERS: Array<{ kind: ModelErrorKind; pattern: RegExp }> = [
+  { kind: 'context_too_long', pattern: /context (length|window)|maximum (context|prompt)|prompt is too long|too many tokens/i },
+  { kind: 'quota', pattern: /key limit exceeded|insufficient[\s\w]{0,20}credit|out of credit|quota exceeded|spend(ing)? limit|payment required|\b402\b/i },
+  { kind: 'rate_limit', pattern: /\b429\b|rate.?limit|too many requests/i },
+  { kind: 'auth', pattern: /invalid.{0,10}(api.?key|token)|unauthorized|authentication|\b401\b|no auth credentials/i },
+  { kind: 'unavailable', pattern: /\b5\d\d\b|overloaded|service unavailable|timed?.?out|econn|network error|internal (server )?error|bad gateway/i },
+];
+
+export const classifyModelError = (raw: string): ModelErrorKind => {
+  for (const { kind, pattern } of CLASSIFIERS) {
+    if (pattern.test(raw)) return kind;
+  }
+  return 'generic';
+};
+
+/** Languages we can phrase the notice in. Extend the table below to add one. */
+export type UserLanguage = 'zh' | 'en';
+
+/**
+ * Any Han character marks the message as Chinese. Deliberately not a
+ * majority vote: platform-side prompt injection appends English boilerplate
+ * to user messages, so a Chinese user's text is routinely diluted with more
+ * English characters than Chinese ones.
+ */
+export const detectUserLanguage = (text: string | undefined): UserLanguage =>
+  text && /[一-鿿㐀-䶿]/.test(text) ? 'zh' : 'en';
+
+const MESSAGES: Record<UserLanguage, Record<ModelErrorKind, string>> = {
+  zh: {
+    quota: '我的模型额度已经用完，暂时没法回复。请联系我的管理者充值或调整模型配置。',
+    rate_limit: '当前请求有点多，我需要缓一缓，请稍后再试。',
+    auth: '我的模型访问凭证失效了，请联系我的管理者检查配置。',
+    context_too_long: '这段对话内容太长，我处理不过来了。可以开个新会话，或者把内容拆短一点再发我。',
+    unavailable: '模型服务暂时不可用，请稍等几分钟再试。',
+    generic: '我这边出了点技术问题，暂时没法回复。请稍后再试；如果一直这样，请联系我的管理者。',
+  },
+  en: {
+    quota: "I've run out of model credits and can't reply right now. Please ask my administrator to top up or adjust the model settings.",
+    rate_limit: "I'm getting too many requests at once — give me a moment and try again.",
+    auth: 'My model access credentials stopped working. Please ask my administrator to check the configuration.',
+    context_too_long: 'This conversation is too long for me to process. Try starting a new session or sending a shorter message.',
+    unavailable: 'The model service is temporarily unavailable. Please try again in a few minutes.',
+    generic: "I hit a technical problem and can't reply right now. Please try again later; if it keeps happening, contact my administrator.",
+  },
+};
+
+/**
+ * Build the user-facing text for a failed model turn, phrased in the language
+ * of the message that triggered the turn.
+ */
+export const buildUserFacingModelError = (
+  rawError: string,
+  triggeringUserText: string | undefined,
+): string => MESSAGES[detectUserLanguage(triggeringUserText)][classifyModelError(rawError)];

--- a/apps/agent/test/user-facing-error.test.ts
+++ b/apps/agent/test/user-facing-error.test.ts
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildUserFacingModelError,
+  classifyModelError,
+  detectUserLanguage,
+} from '../src/agent-runner/user-facing-error.js';
+
+// ── classifyModelError ─────────────────────────────────────────────────
+
+test('classifies the OpenRouter key-limit 403 as quota, not auth', () => {
+  assert.equal(
+    classifyModelError(
+      '403 Key limit exceeded (total limit). Manage it using https://openrouter.ai/workspaces/default/keys/abc123',
+    ),
+    'quota',
+  );
+});
+
+test('classifies insufficient credits and 402 as quota', () => {
+  assert.equal(classifyModelError('402 Payment Required'), 'quota');
+  assert.equal(classifyModelError('Insufficient credits to complete request'), 'quota');
+});
+
+test('classifies 429 and rate limits', () => {
+  assert.equal(classifyModelError('429 Too Many Requests'), 'rate_limit');
+  assert.equal(classifyModelError('rate-limited, retry after 30s'), 'rate_limit');
+});
+
+test('classifies auth failures', () => {
+  assert.equal(classifyModelError('401 Unauthorized'), 'auth');
+  assert.equal(classifyModelError('Invalid API key provided'), 'auth');
+});
+
+test('classifies context overflow before quota-ish words', () => {
+  assert.equal(
+    classifyModelError('This model\'s maximum context length is 128000 tokens'),
+    'context_too_long',
+  );
+  assert.equal(classifyModelError('prompt is too long: 210000 tokens'), 'context_too_long');
+});
+
+test('classifies provider outages as unavailable', () => {
+  assert.equal(classifyModelError('502 Bad Gateway'), 'unavailable');
+  assert.equal(classifyModelError('Request timed out'), 'unavailable');
+  assert.equal(classifyModelError('upstream overloaded'), 'unavailable');
+});
+
+test('falls back to generic for unknown errors', () => {
+  assert.equal(classifyModelError('Model returned an error.'), 'generic');
+});
+
+// ── detectUserLanguage ─────────────────────────────────────────────────
+
+test('any Han character marks the message as Chinese', () => {
+  assert.equal(detectUserLanguage('帮我总结一下'), 'zh');
+  // Platform prompt-injection appends English boilerplate longer than the
+  // user's own text — must still detect Chinese.
+  assert.equal(
+    detectUserLanguage(
+      '用中文回复\n\n[Background knowledge about the twin\'s owner. If it already contains the answer, ANSWER DIRECTLY from it.]',
+    ),
+    'zh',
+  );
+});
+
+test('defaults to English otherwise', () => {
+  assert.equal(detectUserLanguage('summarize this for me'), 'en');
+  assert.equal(detectUserLanguage(''), 'en');
+  assert.equal(detectUserLanguage(undefined), 'en');
+});
+
+// ── buildUserFacingModelError ──────────────────────────────────────────
+
+test('quota error for a Chinese user is a Chinese notice with no provider internals', () => {
+  const raw =
+    '403 Key limit exceeded (total limit). Manage it using https://openrouter.ai/workspaces/default/keys/abc';
+  const msg = buildUserFacingModelError(raw, '杨磊哥，你给我回复的用中文，不要用英文');
+  assert.match(msg, /额度/);
+  assert.doesNotMatch(msg, /openrouter|403|Key limit/i);
+});
+
+test('same error for an English user is the English notice', () => {
+  const msg = buildUserFacingModelError('403 Key limit exceeded (total limit)', 'hello there');
+  assert.match(msg, /credits/);
+  assert.doesNotMatch(msg, /openrouter|403/i);
+});
+
+test('missing trigger text falls back to English', () => {
+  const msg = buildUserFacingModelError('Model returned an error.', undefined);
+  assert.match(msg, /technical problem/);
+});


### PR DESCRIPTION
## Problem

Channels forward the `error` event's `message` to the end user verbatim — the WeChat bridge literally sends `Error: ${message}`. So when a model call fails, users receive raw provider internals in English:

> Error: 403 Key limit exceeded (total limit). Manage it using https://openrouter.ai/workspaces/default/keys/...

Real-world impact: a Chinese-speaking user (羊奶哥) reported "my agent only ever replies in English" — his twin's OpenRouter key was exhausted, and the only thing his twin ever sent him was this English error wall. He even sent a voice message begging for Chinese replies, which failed with the same 403 and produced another English error. Fleet-wide, **1,185 agents are currently emitting this exact experience** (~9k failed turns/day since at least 07-14).

## Fix

New `agent-runner/user-facing-error.ts`:

- **Classify** the raw error: `quota` / `rate_limit` / `auth` / `context_too_long` / `unavailable` / `generic` (ordered patterns — `403 Key limit exceeded` is quota, not auth).
- **Localize** by the language of the triggering user message (stamped as `session.currentTurnUserText` at turn start). Any Han character ⇒ Chinese — deliberately not a majority vote, since platform prompt-injection appends English boilerplate longer than the user's own text. Message table is trivially extensible to more languages.
- Applied at **all three** error publish sites: stream error, `stopReason === 'error'`, and `handleRunError`.

Raw errors keep flowing untouched to `logRuntime`, metrics, langfuse, and the persisted session event (`errorMessage` / role `error` entries) — only the user-facing channel text changes.

Example: the 403 above now reaches a Chinese user as
> 我的模型额度已经用完，暂时没法回复。请联系我的管理者充值或调整模型配置。

## Tests

12 new tests: classification (incl. the production 403 string, context-vs-quota ordering), language detection (incl. the prompt-injection dilution case), and end-to-end message building (asserts no provider internals leak). 12/12 pass; `tsc` error count identical to main (15 pre-existing, all from the Tenki backend's missing `@tenkicloud/sandbox` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, user-friendly error messages for model and provider failures.
  * Error messages are categorized and localized in English or Chinese based on the user’s message.
  * Sensitive provider details are no longer exposed in displayed errors.

* **Bug Fixes**
  * Improved handling of quota, rate-limit, authentication, context-length, availability, and unexpected errors.

* **Tests**
  * Added coverage for error classification, language detection, localization, and provider-detail protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->