### PR TITLE
fix(agent): stop unclosed reasoning tags from leaking thinking into replies

### DIFF
--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -54,17 +54,35 @@ export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage
 const REASONING_INNERMOST_RE =
   /<(think|thinking|reasoning)>((?:(?!<(?:think|thinking|reasoning)>)[\s\S])*?)<\/\1>/gi;
 
+const REASONING_UNCLOSED_RE = /<(think|thinking|reasoning)>[\s\S]*$/i;
+
 /**
  * Remove inline reasoning tags a provider may emit inside a normal text block
  * (`<think>…</think>`, `<thinking>…</thinking>`, `<reasoning>…</reasoning>`),
  * so model reasoning never leaks into the user-facing reply. Structured
- * `thinking` blocks are handled separately and are unaffected. Only paired tags
- * are stripped; an unclosed tag is left as-is to avoid blanking a truncated
- * real reply. If stripping empties the text entirely (a pathological
- * reasoning-only text block), return the tag interiors without wrappers so the
- * reply is not blanked and raw markup does not leak.
+ * `thinking` blocks are handled separately and are unaffected.
+ *
+ * An UNCLOSED tag is treated as reasoning that runs to the end of the block
+ * and is cut: minimax-m2.7 (thinking=high) routinely opens `<think>` and
+ * jumps straight into tool calls without ever closing it, which used to
+ * re-emit the whole reasoning body to the user. Text before the tag is kept.
+ *
+ * If stripping empties the text entirely (a reasoning-only block):
+ * `allowEmpty` callers (message also carries tool calls or a structured
+ * thinking block) get `''` — blanking is safe there because the turn
+ * continues via tools or the thinking-promotion path owns the fallback.
+ * Otherwise the tag interiors are returned without wrappers so a
+ * reasoning-only final reply is not blanked into silence or raw markup.
+ *
+ * Known tradeoff (accepted): tag literals inside prose or code fences (a
+ * reply *explaining* `<think>` tags) are stripped like real reasoning — an
+ * unclosed literal cuts the rest of the reply. Leaking reasoning to end
+ * users is the worse failure, so detection stays syntactic.
  */
-export const stripReasoningTags = (text: string): string => {
+export const stripReasoningTags = (
+  text: string,
+  opts?: { allowEmpty?: boolean },
+): string => {
   const interiors: string[] = [];
   let working = text;
   // Peel innermost pairs first so nested same-name tags collapse cleanly.
@@ -78,8 +96,15 @@ export const stripReasoningTags = (text: string): string => {
     });
     if (!progressed) break;
   }
+  // Whatever follows an unpaired open tag is reasoning that never closed.
+  working = working.replace(REASONING_UNCLOSED_RE, (match) => {
+    const inner = match.slice(match.indexOf('>') + 1).trim();
+    if (inner.length > 0) interiors.push(inner);
+    return '';
+  });
   const stripped = working.replace(/\n{3,}/g, '\n\n').trim();
   if (stripped.length > 0) return stripped;
+  if (opts?.allowEmpty) return '';
   if (interiors.length > 0) return interiors.join('\n\n');
   return text.trim();
 };
@@ -151,8 +176,12 @@ const drainReasoningTagBuffer = (
         continue;
       }
       if (flush) {
-        // Unclosed: surface the remainder (including the open tag) unchanged.
-        out += (state.openRaw ?? '') + state.suppressed + state.buf;
+        // Unclosed at end-of-stream: reasoning that never got its close
+        // (minimax-m2.7 opens <think> and goes straight to tool calls).
+        // Surfacing it was the leak — drop it. The batch pass in
+        // stripReasoningTags governs the persisted/text_final text, so a
+        // genuinely truncated reasoning-only reply still reaches the user
+        // through the interiors fallback there.
         state.buf = '';
         state.inReasoning = false;
         state.openName = null;
@@ -216,7 +245,14 @@ export const extractAssistantText = (message: AssistantMessage): string => {
     .map((content) => content.text.trim())
     .filter((text) => text.length > 0);
 
-  return stripReasoningTags(textParts.join('\n\n'));
+  // Blanking a reasoning-only text block is safe when the turn has tool
+  // calls to continue with, or a structured thinking block that the
+  // final-thinking-only promotion path can fall back on. Only a bare
+  // reasoning-only reply keeps the interiors fallback.
+  const allowEmpty = message.content.some(
+    (content) => content.type === 'toolCall' || content.type === 'thinking',
+  );
+  return stripReasoningTags(textParts.join('\n\n'), { allowEmpty });
 };
 
 export const extractThinkingText = (message: AssistantMessage): string => {

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -63,14 +63,61 @@ test('stripReasoningTags peels nested same-name tags without residual close mark
   );
 });
 
-test('stripReasoningTags leaves an unclosed tag as-is', () => {
-  const open = '<think>partial answer continues';
-  assert.equal(stripReasoningTags(open), open);
+test('stripReasoningTags cuts an unclosed tag to end-of-text, keeping preceding text', () => {
+  assert.equal(
+    stripReasoningTags('Real answer.<think>runaway reasoning that never closes'),
+    'Real answer.',
+  );
+});
+
+test('stripReasoningTags returns interiors for a bare unclosed reasoning-only block', () => {
+  // No tool calls / structured thinking context: do not blank the only content.
+  assert.equal(
+    stripReasoningTags('<think>partial answer continues'),
+    'partial answer continues',
+  );
+});
+
+test('stripReasoningTags with allowEmpty blanks an unclosed reasoning-only block', () => {
+  // The minimax-m2.7 shape: text is a lone unterminated <think> body and the
+  // message continues with tool calls — nothing should reach the user.
+  assert.equal(
+    stripReasoningTags('<think>Still getting "NotEnoughPositionToClose". Let me try', {
+      allowEmpty: true,
+    }),
+    '',
+  );
 });
 
 test('extractAssistantText strips inline reasoning from a text block', () => {
   const msg = assistantMsg('<think>plan</think>Final answer.');
   assert.equal(extractAssistantText(msg), 'Final answer.');
+});
+
+test('extractAssistantText blanks an unclosed reasoning-only block on a tool-call turn', () => {
+  // minimax-m2.7 (thinking=high) opens <think> in the text, never closes it,
+  // and proceeds to tool calls — the reasoning must not become user text.
+  const msg = {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: '<think>The position clearly exists. Let me try the amend endpoint' },
+      { type: 'toolCall', id: 'call-1', name: 'exec', arguments: {} },
+    ],
+    timestamp: 1,
+  } as unknown as AssistantMessage;
+  assert.equal(extractAssistantText(msg), '');
+});
+
+test('extractAssistantText blanks unclosed reasoning when a structured thinking block exists', () => {
+  const msg = {
+    role: 'assistant',
+    content: [
+      { type: 'thinking', thinking: 'structured reasoning' },
+      { type: 'text', text: '<think>duplicated inline reasoning, unterminated' },
+    ],
+    timestamp: 1,
+  } as unknown as AssistantMessage;
+  assert.equal(extractAssistantText(msg), '');
 });
 
 test('extractAssistantText strips across multiple text parts', () => {
@@ -111,10 +158,16 @@ describe('reasoning tag stream', () => {
     assert.equal(runReasoningStream(['a < b and <div>ok</div>']), 'a < b and <div>ok</div>');
   });
 
-  test('flush of an unclosed tag surfaces the remainder (no blanking)', () => {
+  test('flush of an unclosed tag drops the suppressed reasoning', () => {
     const state = newReasoningTagStream();
     assert.equal(pushReasoningTagDelta(state, '<think>still going'), '');
-    assert.equal(flushReasoningTagStream(state), '<think>still going');
+    assert.equal(flushReasoningTagStream(state), '');
+  });
+
+  test('flush keeps text emitted before an unclosed tag', () => {
+    const state = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(state, 'Answer first. <think>then reasoning'), 'Answer first. ');
+    assert.equal(flushReasoningTagStream(state), '');
   });
 
   test('handles thinking and reasoning variants mid-stream', () => {
@@ -137,9 +190,9 @@ describe('reasoning tag stream', () => {
     );
   });
 
-  test('flush of an unclosed nested tag surfaces the full remainder', () => {
+  test('flush of an unclosed nested tag drops the full remainder', () => {
     const state = newReasoningTagStream();
     assert.equal(pushReasoningTagDelta(state, '<think>outer <think>inner'), '');
-    assert.equal(flushReasoningTagStream(state), '<think>outer <think>inner');
+    assert.equal(flushReasoningTagStream(state), '');
   });
 });


### PR DESCRIPTION
## Problem

Agent 大枣树 (cmmu62fyp…, `minimax/minimax-m2.7`, `thinking: high`) sends its raw chain-of-thought to users. Production events show the exact shape, dozens of times daily:

- the model emits `<think>…` as **plain text**, never closes the tag, and proceeds straight to tool calls (`stopReason=toolUse`) — while ALSO carrying a structured `thinking` block;
- #233's stripper (deployed) leaves **unclosed** tags untouched by design ("avoid blanking a truncated real reply"), so both the live stream flush and the persisted `extractAssistantText` pass the whole reasoning body through to the user.

## Fix

- **`stripReasoningTags`**: an unpaired open tag now cuts from the tag to end-of-text; text before it is kept (`Real answer.<think>runaway` → `Real answer.`). New `allowEmpty` option: when the message also carries tool calls or a structured thinking block, a reasoning-only text blanks to `''` — safe, because the turn continues via tools or the final-thinking-only promotion path owns the fallback. A *bare* reasoning-only reply keeps the interiors fallback, so a genuinely truncated final answer is still not silenced.
- **`extractAssistantText`** derives `allowEmpty` from the message content.
- **Stream flush** drops an unclosed suppressed block instead of re-emitting it (pre-tag text unaffected).
- Docstring now records the code-fence/prose false-positive tradeoff — the doc note requested in the #233 review that never landed.

## Tests

23/23 in `message-utils.test.ts`: 3 old unclosed-behavior tests flipped to the new contract, plus regressions for the production minimax shape (batch, stream, and `extractAssistantText` with toolCall/thinking blocks). Full compaction + user-facing-error suites still green; `tsc` error count identical to main (15 pre-existing Tenki-types errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unclosed reasoning markup from appearing in assistant responses.
  * Improved handling of truncated live streams by removing incomplete reasoning content.
  * Preserved user-facing text that appears before malformed reasoning markup.
  * Reasoning-only content is now correctly blanked when tool calls or structured thinking continue the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->