### PR TITLE
fix(agent): suppress reasoning that spans tool-call turns (orphan close tags)

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -67,6 +67,7 @@ import {
   newReasoningTagStream,
   pushReasoningTagDelta,
   flushReasoningTagStream,
+  reasoningStreamUnclosedTag,
   serializeDetails,
 } from './agent-runner/message-utils.js';
 import {
@@ -1226,6 +1227,7 @@ export class AgentRunner implements SessionRuntime {
         session.latestAssistantText = undefined;
         session.speakerTagStream = undefined;
         session.reasoningTagStream = undefined;
+        session.reasoningCarryTagName = undefined;
         session.consecutiveToolFailures = 0;
         if (message.messageId !== undefined) {
           session.currentTurnCorrelationId = message.messageId;
@@ -3020,7 +3022,7 @@ export class AgentRunner implements SessionRuntime {
         // reasoning tags never flash (or stick, on clients that prefer deltas).
         const isGroupStream = session.spec.source.type === 'group';
         if (event.assistantMessageEvent.type === 'text_start') {
-          session.reasoningTagStream = newReasoningTagStream();
+          session.reasoningTagStream = newReasoningTagStream(session.reasoningCarryTagName);
           if (isGroupStream) {
             session.speakerTagStream = newSpeakerTagStream();
           }
@@ -3029,7 +3031,7 @@ export class AgentRunner implements SessionRuntime {
         if (event.assistantMessageEvent.type === 'text_delta') {
           const rawDelta = event.assistantMessageEvent.delta;
           // In case the provider skipped text_start.
-          session.reasoningTagStream ??= newReasoningTagStream();
+          session.reasoningTagStream ??= newReasoningTagStream(session.reasoningCarryTagName);
           let outText = pushReasoningTagDelta(session.reasoningTagStream, rawDelta);
           if (isGroupStream) {
             session.speakerTagStream ??= newSpeakerTagStream();
@@ -3048,6 +3050,7 @@ export class AgentRunner implements SessionRuntime {
         if (event.assistantMessageEvent.type === 'text_end') {
           let tail = '';
           if (session.reasoningTagStream) {
+            session.reasoningCarryTagName = reasoningStreamUnclosedTag(session.reasoningTagStream);
             tail += flushReasoningTagStream(session.reasoningTagStream);
             session.reasoningTagStream = undefined;
           }
@@ -3090,6 +3093,7 @@ export class AgentRunner implements SessionRuntime {
         {
           let tail = '';
           if (session.reasoningTagStream) {
+            session.reasoningCarryTagName = reasoningStreamUnclosedTag(session.reasoningTagStream);
             tail += flushReasoningTagStream(session.reasoningTagStream);
             session.reasoningTagStream = undefined;
           }

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -55,6 +55,11 @@ const REASONING_INNERMOST_RE =
   /<(think|thinking|reasoning)>((?:(?!<(?:think|thinking|reasoning)>)[\s\S])*?)<\/\1>/gi;
 
 const REASONING_UNCLOSED_RE = /<(think|thinking|reasoning)>[\s\S]*$/i;
+// A close tag with no opener earlier in the block: the open tag lived in a
+// previous assistant message of the same tool loop (cut there as an unclosed
+// tag), and this block starts mid-reasoning. Lazy match: cut through the
+// FIRST orphan close only, so a later literal tag in prose stays prose.
+const REASONING_ORPHAN_CLOSE_RE = /^[\s\S]*?<\/(think|thinking|reasoning)>\s*/i;
 
 /**
  * Remove inline reasoning tags a provider may emit inside a normal text block
@@ -96,6 +101,14 @@ export const stripReasoningTags = (
     });
     if (!progressed) break;
   }
+  // Whatever precedes an unmatched CLOSE tag is reasoning that started in a
+  // previous message of the same tool loop (minimax-m2.7 spans <think>
+  // blocks across tool-call turns; the opener was cut there as unclosed).
+  working = working.replace(REASONING_ORPHAN_CLOSE_RE, (match) => {
+    const inner = match.replace(/<\/(think|thinking|reasoning)>\s*$/i, '').trim();
+    if (inner.length > 0) interiors.push(inner);
+    return '';
+  });
   // Whatever follows an unpaired open tag is reasoning that never closed.
   working = working.replace(REASONING_UNCLOSED_RE, (match) => {
     const inner = match.slice(match.indexOf('>') + 1).trim();
@@ -131,12 +144,20 @@ export interface ReasoningTagStreamState {
   suppressed: string;
 }
 
-export const newReasoningTagStream = (): ReasoningTagStreamState => ({
+/**
+ * `carryTagName` starts the stream already suppressed: the previous assistant
+ * message of this turn ended inside an unclosed reasoning tag (minimax-m2.7
+ * spans <think> across tool-call turns), so this message opens mid-reasoning
+ * and must stay quiet until the matching close tag arrives. If no close ever
+ * arrives, the flush drops the suppressed text and the batch pass in
+ * stripReasoningTags still governs the authoritative text_final.
+ */
+export const newReasoningTagStream = (carryTagName?: string): ReasoningTagStreamState => ({
   buf: '',
-  inReasoning: false,
-  openName: null,
-  openRaw: null,
-  depth: 0,
+  inReasoning: carryTagName !== undefined,
+  openName: carryTagName?.toLowerCase() ?? null,
+  openRaw: carryTagName !== undefined ? `<${carryTagName}>` : null,
+  depth: carryTagName !== undefined ? 1 : 0,
   suppressed: '',
 });
 
@@ -235,6 +256,12 @@ export const pushReasoningTagDelta = (
   state.buf += delta;
   return drainReasoningTagBuffer(state, false);
 };
+
+/** Read BEFORE flushing: the tag name still open at end-of-message, if any.
+ *  Callers thread it into the next message's stream via `newReasoningTagStream`
+ *  so reasoning spanning tool-call turns stays suppressed. */
+export const reasoningStreamUnclosedTag = (state: ReasoningTagStreamState): string | undefined =>
+  state.inReasoning ? (state.openName ?? undefined) : undefined;
 
 export const flushReasoningTagStream = (state: ReasoningTagStreamState): string =>
   drainReasoningTagBuffer(state, true);

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -24,6 +24,9 @@ export interface RunnerSession extends SessionDescriptor {
   speakerTagStream?: SpeakerTagStreamState | undefined;
   // Suppresses inline <think>/<thinking>/<reasoning> bodies on the live stream.
   reasoningTagStream?: ReasoningTagStreamState | undefined;
+  /** Reasoning tag left unclosed by the previous assistant message of this
+   *  turn; the next message's stream starts suppressed under it. */
+  reasoningCarryTagName?: string | undefined;
   /** Inbound messageId of the user message that triggered the in-flight
    *  turn. Stamped onto every outbound event for that turn as
    *  `correlationId`, so callers can group events back to the originating

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -7,6 +7,7 @@ import {
   stripReasoningTags,
   extractAssistantText,
   newReasoningTagStream,
+  reasoningStreamUnclosedTag,
   pushReasoningTagDelta,
   flushReasoningTagStream,
 } from '../src/agent-runner/message-utils.js';
@@ -75,6 +76,22 @@ test('stripReasoningTags returns interiors for a bare unclosed reasoning-only bl
   assert.equal(
     stripReasoningTags('<think>partial answer continues'),
     'partial answer continues',
+  );
+});
+
+test('stripReasoningTags cuts leading reasoning through an orphan close tag', () => {
+  // The opener lived in the previous tool-call message (cut there as
+  // unclosed); this block starts mid-reasoning and closes it before the reply.
+  assert.equal(
+    stripReasoningTags('仓位还在（20 DOGE）。止损问题是参数格式</think>试试去掉 stopPx 只平仓：'),
+    '试试去掉 stopPx 只平仓：',
+  );
+});
+
+test('stripReasoningTags orphan-close cut is lazy: later literal close stays prose', () => {
+  assert.equal(
+    stripReasoningTags('mid-span</think>Reply that mentions a literal </think> tag'),
+    'Reply that mentions a literal </think> tag',
   );
 });
 
@@ -194,5 +211,28 @@ describe('reasoning tag stream', () => {
     const state = newReasoningTagStream();
     assert.equal(pushReasoningTagDelta(state, '<think>outer <think>inner'), '');
     assert.equal(flushReasoningTagStream(state), '');
+  });
+
+  test('carry-over: next message stays suppressed until the spanning close arrives', () => {
+    // Message N ends unclosed; its tag name is read before flush and threaded
+    // into message N+1's stream, which then suppresses the continuation.
+    const first = newReasoningTagStream();
+    assert.equal(pushReasoningTagDelta(first, '<think>spanning reasoning'), '');
+    const carry = reasoningStreamUnclosedTag(first);
+    assert.equal(carry, 'think');
+    assert.equal(flushReasoningTagStream(first), '');
+
+    const second = newReasoningTagStream(carry);
+    assert.equal(pushReasoningTagDelta(second, 'still reasoning</think>Real reply'), 'Real reply');
+    assert.equal(flushReasoningTagStream(second), '');
+  });
+
+  test('carry-over with no close drops the stream but never the batch text', () => {
+    const state = newReasoningTagStream('think');
+    assert.equal(pushReasoningTagDelta(state, 'pure reply that never closes'), '');
+    assert.equal(flushReasoningTagStream(state), '');
+    // The authoritative text_final comes from stripReasoningTags, which leaves
+    // untagged text alone — nothing is lost, only the typing effect.
+    assert.equal(stripReasoningTags('pure reply that never closes'), 'pure reply that never closes');
   });
 });


### PR DESCRIPTION
## Problem (follow-up to #247)

#247 handles the unclosed `<think>` OPEN side. Production shows minimax-m2.7 also spans one reasoning block **across assistant messages** of a tool loop: message N opens `<think>` and ends at a tool call; message N+1's text begins mid-reasoning and closes with `</think>` before the actual reply. The leading reasoning + orphan close tag passed both stripper passes — **223 such replies since 07-18**, and 1 more already after the #247 deploy (agent 大枣树, trading loop):

> `</think> 仓位还在（20 DOGE，强平价 0.06928）。止损问题是…`

## Fix

- **Batch**: text up to and including an unmatched close tag is cut as reasoning. Lazy match — only through the *first* orphan close, so a later literal `</think>` in prose stays prose. Same interiors / `allowEmpty` semantics as #247's unclosed-open cut.
- **Stream**: `reasoningStreamUnclosedTag()` is read before each flush and threaded into the next message's stream, which starts suppressed until the spanning close arrives. No close ever → stream drops it, batch still owns `text_final` — worst case is a lost typing effect, never lost text. Carry resets at turn start.

## Tests

27/27 in `message-utils.test.ts` — new: orphan-close cut (with the production Chinese sample), lazy-match prose protection, stream carry-over (close arrives → suppressed until it; close never arrives → stream empty, batch text intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed reasoning tags that span multiple messages or tool-call turns.
  * Prevented hidden reasoning content from appearing in subsequent streamed responses.
  * Corrected edge cases involving unmatched or orphaned closing reasoning tags.
  * Preserved normal text when reasoning tags remain incomplete or malformed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->