### PR TITLE
feat(cli): add channels enable and status subcommands

### DIFF
--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 
 import type { Command } from 'commander';
 
-import { createGateway, handleError } from './shared.js';
+import { createGateway, handleError, printTable } from './shared.js';
 
 /**
  * Pull the bare package name out of an npm install spec.
@@ -119,6 +119,102 @@ export const registerChannelsCommand = (program: Command): void => {
           return;
         }
         for (const p of packages) console.log(p);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  ch.command('enable <channelType>')
+    .description(
+      'Configure and enable a builtin channel on an agent.\n' +
+      'Sets the bot token secret and starts the channel bridge.\n' +
+      'Example: hermit channels enable telegram --agent <agentId> --token <bot-token>',
+    )
+    .requiredOption('--agent <agentId>', 'Agent ID')
+    .requiredOption('--token <token>', 'Bot token or API key for the channel')
+    .option('--mode <mode>', 'Connection mode: polling or webhook (telegram only)', 'polling')
+    .action(async (channelType: string, opts: { agent: string; token: string; mode: string }) => {
+      try {
+        const gateway = createGateway();
+
+        // 1. Find the channel record for this type.
+        const channels = await gateway.listAgentChannels(opts.agent);
+        const entry = channels.find((c) => c.channelType === channelType);
+        if (!entry) {
+          console.error(
+            `No ${channelType} channel found on agent ${opts.agent}.\n` +
+            `Builtin channels (telegram, discord, slack) are auto-seeded at agent create.\n` +
+            `Run: hermit channels status --agent ${opts.agent}`,
+          );
+          process.exit(1);
+        }
+
+        // 2. Derive the secret key name from the channel's descriptor
+        //    (e.g. TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN).
+        const primarySecretKey = entry.secretKeys?.[0]?.key;
+        if (!primarySecretKey) {
+          console.error(
+            `Channel "${channelType}" does not expose a secret key descriptor. ` +
+            `Configure credentials via the gateway API directly.`,
+          );
+          process.exit(1);
+        }
+
+        // 3. Write the token as an agent secret.
+        await gateway.setAgentSecret(opts.agent, primarySecretKey, opts.token);
+        console.log(`  ✓ ${primarySecretKey} updated`);
+
+        // 4. Enable the channel. The gateway auto-applies defaultConfig
+        //    (which contains the ${{SECRET}} placeholder) when config is empty.
+        //    For a mode override we merge into existing config.
+        const configOverride =
+          opts.mode !== 'polling' ? { ...entry.config, mode: opts.mode } : undefined;
+
+        const result = await gateway.updateAgentChannel(opts.agent, entry.id, {
+          enabled: true,
+          ...(configOverride ? { config: configOverride } : {}),
+        });
+
+        if (result.error) {
+          console.error(`\nBridge error: ${result.error}`);
+          console.error('Check that the token is valid and try again.');
+          process.exit(1);
+        }
+
+        console.log(`\n  Channel "${channelType}" is live on agent ${opts.agent}.`);
+        if (result.runtimeStatus) console.log(`  Bridge status: ${result.runtimeStatus}`);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  ch.command('status')
+    .description('Show runtime status for all channels on an agent.')
+    .requiredOption('--agent <agentId>', 'Agent ID')
+    .action(async (opts: { agent: string }) => {
+      try {
+        const gateway = createGateway();
+        const channels = await gateway.listAgentChannels(opts.agent);
+        if (channels.length === 0) {
+          console.log('No channels found on this agent.');
+          return;
+        }
+        printTable(
+          channels.map((c) => ({
+            type: c.channelType,
+            id: c.id,
+            status: c.runtimeStatus,
+            secrets: c.secretsSet ? 'set' : 'missing',
+            error: c.lastError ?? '',
+          })),
+          [
+            { key: 'type', label: 'Channel', width: 12 },
+            { key: 'id', label: 'ID', width: 28 },
+            { key: 'status', label: 'Status', width: 10 },
+            { key: 'secrets', label: 'Secrets', width: 8 },
+            { key: 'error', label: 'Error' },
+          ],
+        );
       } catch (error) {
         handleError(error);
       }

--- a/apps/cli/test/channels.test.ts
+++ b/apps/cli/test/channels.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { test } from 'node:test';
+
+import { Command } from 'commander';
+
+import { registerChannelsCommand } from '../src/commands/channels.js';
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+/**
+ * Fake gateway server exercising the real request/response shapes the SDK
+ * expects, so this test proves the actual HTTP wiring of `channels enable`
+ * (endpoint, method, body, and call order) — not just that it typechecks.
+ */
+async function startFakeGateway(agentId: string): Promise<{
+  url: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: CapturedRequest[] = [];
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const body = raw ? JSON.parse(raw) : undefined;
+      requests.push({ method: req.method ?? '', path: req.url ?? '', body });
+
+      res.setHeader('content-type', 'application/json');
+
+      if (req.method === 'GET' && req.url === `/api/agents/${agentId}/channels`) {
+        res.end(JSON.stringify([
+          {
+            id: 'ch1',
+            agentId,
+            kind: 'builtin',
+            channelType: 'telegram',
+            namespace: 'ns1',
+            label: null,
+            enabled: false,
+            config: {},
+            tokenPrefix: '',
+            createdBy: null,
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+            lastUsedAt: null,
+            revokedAt: null,
+            secretsSet: false,
+            runtimeStatus: 'stopped',
+            secretKeys: [{ key: 'TELEGRAM_BOT_TOKEN', label: 'Bot Token', placeholder: '${{TELEGRAM_BOT_TOKEN}}' }],
+          },
+        ]));
+        return;
+      }
+
+      if (req.method === 'PUT' && req.url === `/api/agents/${agentId}/secrets/TELEGRAM_BOT_TOKEN`) {
+        res.end(JSON.stringify({}));
+        return;
+      }
+
+      if (req.method === 'PATCH' && req.url === `/api/agents/${agentId}/channels/ch1`) {
+        res.end(JSON.stringify({
+          id: 'ch1',
+          agentId,
+          kind: 'builtin',
+          channelType: 'telegram',
+          namespace: 'ns1',
+          label: null,
+          enabled: true,
+          config: {},
+          tokenPrefix: 'abc***',
+          createdBy: null,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          lastUsedAt: null,
+          revokedAt: null,
+          runtimeStatus: 'running',
+        }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: `no handler for ${req.method} ${req.url}` }));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('failed to bind fake gateway');
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+test('`channels enable` sets the secret then enables the channel, in order', async () => {
+  const agentId = 'agent-1';
+  const { url, requests, close } = await startFakeGateway(agentId);
+  const prevGatewayUrl = process.env.OPENHERMIT_GATEWAY_URL;
+  const prevToken = process.env.OPENHERMIT_TOKEN;
+  const prevExit = process.exit;
+  const logs: string[] = [];
+  const prevLog = console.log;
+
+  process.env.OPENHERMIT_GATEWAY_URL = url;
+  process.env.OPENHERMIT_TOKEN = 'test-token';
+  console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
+  // Guard: if the command hits an error path it calls process.exit(1), which
+  // would kill the test runner. Fail loudly instead so the assertion below
+  // (rather than the whole process) reports what went wrong.
+  process.exit = ((code?: number) => {
+    throw new Error(`command called process.exit(${code}) — see console output above`);
+  }) as typeof process.exit;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerChannelsCommand(program);
+    await program.parseAsync(
+      ['channel', 'enable', 'telegram', '--agent', agentId, '--token', 'shh-secret'],
+      { from: 'user' },
+    );
+
+    assert.deepEqual(
+      requests.map((r) => `${r.method} ${r.path}`),
+      [
+        `GET /api/agents/${agentId}/channels`,
+        `PUT /api/agents/${agentId}/secrets/TELEGRAM_BOT_TOKEN`,
+        `PATCH /api/agents/${agentId}/channels/ch1`,
+      ],
+      'expected: look up the channel, THEN write the secret, THEN enable it — in that order',
+    );
+
+    assert.deepEqual(requests[1]?.body, { value: 'shh-secret' });
+    assert.deepEqual(requests[2]?.body, { enabled: true });
+    assert.ok(
+      logs.some((l) => l.includes('is live on agent')),
+      `expected success output, got: ${JSON.stringify(logs)}`,
+    );
+  } finally {
+    console.log = prevLog;
+    process.exit = prevExit;
+    process.env.OPENHERMIT_GATEWAY_URL = prevGatewayUrl;
+    process.env.OPENHERMIT_TOKEN = prevToken;
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary
There was no self-serve path for operators to key or re-key a builtin channel (telegram/discord/slack) without touching the database directly. Rotating a bot token, or swapping to a different bot entirely, required a one-off script against `agent_secrets` plus a manual PATCH to flip the channel's `enabled` flag.

- `hermit channels enable <channelType> --agent <id> --token <token> [--mode polling|webhook]`
  - Looks up the channel record and its `secretKeys` descriptor via `listAgentChannels`
  - Writes the token via `setAgentSecret` under the correct key (e.g. `TELEGRAM_BOT_TOKEN`)
  - Calls `updateAgentChannel({ enabled: true })` — the gateway always treats `enabled: true` as start-or-restart, so re-keying an already-live bot restarts it with the fresh token immediately, no separate step
- `hermit channels status --agent <id>`
  - Lists every channel on an agent with live bridge status, secret presence, and last error

## Test plan
- [x] Added `apps/cli/test/channels.test.ts`: spins up a fake local gateway server and drives the real `enable` command through Commander, asserting the actual HTTP call order (`GET channels` → `PUT secret` → `PATCH enable`) and request bodies
- [x] Full `apps/cli` test suite passes (14/14, no regressions)
- [x] `npm run build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to enable an agent channel using a token, with optional mode configuration.
  * Added a CLI status command showing channel IDs, runtime states, secret availability, and errors in a table.
  * Added clear reporting for channel bridge and runtime errors.

* **Tests**
  * Added integration coverage for channel enabling, including request validation and success output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->