### PR TITLE
chore(agent): upgrade @tenkicloud/sandbox to 0.5.4

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -60,7 +60,7 @@
     "@openhermit/shared": "0.2.0",
     "@openhermit/store": "0.2.0",
     "@openhermit/voice": "0.2.0",
-    "@tenkicloud/sandbox": "^0.3.6",
+    "@tenkicloud/sandbox": "^0.5.4",
     "croner": "^10.0.1",
     "defuddle": "^0.11.0",
     "e2b": "^2.19.4",

--- a/apps/agent/src/core/backends/tenki.ts
+++ b/apps/agent/src/core/backends/tenki.ts
@@ -56,7 +56,6 @@ export class TenkiExecBackend implements ExecBackend {
   readonly files: TenkiFileBackend;
 
   private readonly cpuCores: number;
-  private readonly projectId: string;
   private readonly workspaceId: string | undefined;
   private readonly memoryMb: number;
   private readonly diskSizeGb: number;
@@ -75,7 +74,6 @@ export class TenkiExecBackend implements ExecBackend {
     this.label = config.label ?? 'Tenki';
     this.username = TENKI_DEFAULT_USERNAME;
     this.agentHome = config.agent_home ?? TENKI_DEFAULT_AGENT_HOME;
-    this.projectId = config.project_id;
     this.workspaceId = config.workspace_id;
     this.cpuCores = config.cpu_cores ?? TENKI_DEFAULT_CPU_CORES;
     this.memoryMb = config.memory_mb ?? TENKI_DEFAULT_MEMORY_MB;
@@ -153,7 +151,6 @@ export class TenkiExecBackend implements ExecBackend {
     }
 
     const session = await client.createAndWait({
-      projectId: this.projectId,
       ...(this.workspaceId ? { workspaceId: this.workspaceId } : {}),
       cpuCores: this.cpuCores,
       memoryMb: this.memoryMb,

--- a/apps/agent/src/core/exec-backend.ts
+++ b/apps/agent/src/core/exec-backend.ts
@@ -118,7 +118,6 @@ export interface TenkiExecBackendConfig {
   id?: string;
   type: 'tenki';
   label?: string;
-  project_id: string;
   workspace_id?: string;
   cpu_cores?: number;
   memory_mb?: number;

--- a/apps/agent/src/core/security.ts
+++ b/apps/agent/src/core/security.ts
@@ -98,7 +98,6 @@ const TenkiBackendSchema = z.object({
   id: z.string().optional(),
   type: z.literal('tenki'),
   label: z.string().optional(),
-  project_id: z.string().min(1),
   workspace_id: z.string().min(1).optional(),
   cpu_cores: z.number().int().positive().optional(),
   memory_mb: z.number().int().positive().optional(),

--- a/apps/agent/test/security.test.ts
+++ b/apps/agent/test/security.test.ts
@@ -70,7 +70,6 @@ test('AgentSecurity accepts Tenki backend config', async (t) => {
     exec: {
       backends: [{
         type: 'tenki',
-        project_id: 'project-test',
         workspace_id: 'workspace-test',
         cpu_cores: 2,
         memory_mb: 4096,

--- a/apps/agent/test/tenki-backend.test.ts
+++ b/apps/agent/test/tenki-backend.test.ts
@@ -38,7 +38,7 @@ test('Tenki exec preserves normal non-zero command results', async () => {
     return session;
   } };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test' }, context as never, client as never,
+    { type: 'tenki' }, context as never, client as never,
   );
 
   const result = await backend.exec('exit 42');
@@ -46,7 +46,7 @@ test('Tenki exec preserves normal non-zero command results', async () => {
   assert.equal(result.stderr, 'err');
   assert.equal(result.exitCode, 42);
   assert.ok(result.durationMs >= 0);
-  assert.equal(createOptions?.projectId, 'project-test');
+  assert.ok(createOptions && !('projectId' in createOptions));
 });
 
 test('Tenki exec kills timed-out process and returns 137', async () => {
@@ -57,7 +57,7 @@ test('Tenki exec kills timed-out process and returns 137', async () => {
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test', timeout_ms: 1 }, context as never,
+    { type: 'tenki', timeout_ms: 1 }, context as never,
     { createAndWait: async () => session } as never,
   );
 
@@ -74,7 +74,7 @@ test('Tenki ensure serializes concurrent sandbox creation', async () => {
     id: 'session-1', state: 'RUNNING', closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test' }, context as never,
+    { type: 'tenki' }, context as never,
     { createAndWait: async () => { creates += 1; await gate; return session; } } as never,
   );
 
@@ -94,7 +94,7 @@ test('Tenki exec clears timeout when process handle rejects', async () => {
     run: () => processHandle(Promise.reject(new Error('transport'))),
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test', timeout_ms: 60_000 }, context as never,
+    { type: 'tenki', timeout_ms: 60_000 }, context as never,
     { createAndWait: async () => session } as never,
   );
   globalThis.clearTimeout = ((timer: Parameters<typeof clearTimeout>[0]) => {
@@ -113,7 +113,7 @@ test('Tenki exec clears timeout when process handle rejects', async () => {
 test('Tenki reconnect does not create a duplicate after auth failure', async () => {
   let created = false;
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test' },
+    { type: 'tenki' },
     {
       ...context,
       getRuntimeState: async () => ({ tenki: { sessionId: 'old', cwd: '/home/tenki', updatedAt: 'now' } }),
@@ -140,7 +140,7 @@ test('Tenki sessionless skill sync executes immediately without persistence hook
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test' }, context as never,
+    { type: 'tenki' }, context as never,
     { createAndWait: async () => session } as never,
   );
 
@@ -157,7 +157,7 @@ test('Tenki shutdown keeps live handle when pause fails', async () => {
     closeIfOpen: async () => undefined,
   };
   const backend = new TenkiExecBackend(
-    { type: 'tenki', project_id: 'project-test' }, context as never,
+    { type: 'tenki' }, context as never,
     { createAndWait: async () => { creates += 1; return session; } } as never,
   );
   await backend.ensure();

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@openhermit/shared": "0.2.0",
         "@openhermit/store": "0.2.0",
         "@openhermit/voice": "0.2.0",
-        "@tenkicloud/sandbox": "^0.3.6",
+        "@tenkicloud/sandbox": "^0.5.4",
         "croner": "^10.0.1",
         "defuddle": "^0.11.0",
         "e2b": "^2.19.4",
@@ -700,6 +700,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
       "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1486,6 +1487,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1770,7 +1772,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.9",
@@ -1813,6 +1816,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -1911,6 +1915,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1933,6 +1938,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2148,7 +2154,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3164,7 +3169,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3181,7 +3185,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3204,7 +3207,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3227,7 +3229,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3244,7 +3245,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3261,7 +3261,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3278,7 +3277,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3295,7 +3293,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3312,7 +3309,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3329,7 +3325,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3346,7 +3341,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3363,7 +3357,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3380,7 +3373,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3397,7 +3389,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3420,7 +3411,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3443,7 +3433,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3466,7 +3455,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3489,7 +3477,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3512,7 +3499,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3535,7 +3521,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3558,7 +3543,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3578,7 +3562,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -3601,7 +3584,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3621,7 +3603,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3641,7 +3622,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4254,6 +4234,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6172,15 +6153,15 @@
       }
     },
     "node_modules/@tenkicloud/sandbox": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.3.6.tgz",
-      "integrity": "sha512-nCjCStmVUj5OG2Ek5aFMZnNI2UAw2tJb3enZobf1hFcoV7h9QVCYuKrpsf11SWcVVh7P39T+vZq+rlJkcyB6vQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.5.4.tgz",
+      "integrity": "sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "2.12.1",
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-node": "2.1.2",
-        "ws": "8.21.0"
+        "ws": "8.21.1"
       },
       "engines": {
         "node": ">=18"
@@ -6191,6 +6172,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
       "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -6307,6 +6289,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6317,6 +6300,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6349,6 +6333,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6443,6 +6428,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6999,6 +6985,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7602,7 +7589,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8516,6 +8502,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8712,6 +8699,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9428,6 +9416,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9729,6 +9718,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -9923,6 +9913,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -10978,6 +10969,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -11575,6 +11567,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12052,7 +12045,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -12096,7 +12088,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12831,6 +12822,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12881,6 +12873,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13081,6 +13074,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13774,10 +13768,11 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13968,6 +13963,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## What

Upgrades the Tenki SDK in `apps/agent` from `^0.3.6` to `^0.5.4` (current latest on npm) and drops `project_id`, which the SDK removed.

## Why

Tenki removed project scoping from the sandbox API in 0.5.x. `projectId` is gone from every public type in `@tenkicloud/sandbox@0.5.4`, so the existing `createAndWait({ projectId: ... })` call no longer type-checks against the current SDK:

```
src/core/backends/tenki.ts(156,7): error TS2353: Object literal may only specify known properties,
and 'projectId' does not exist in type 'CreateOptions & { timeoutMs?: number; }'.
```

Workspace scoping (`workspace_id`) is unchanged and still the way to target an account scope.

## Changes

- `apps/agent/package.json`: `@tenkicloud/sandbox` `^0.3.6` → `^0.5.4` (+ lockfile). The lockfile also moves `ws` `8.21.0` → `8.21.1` because the SDK pins `ws` exactly.
- `src/core/backends/tenki.ts`: drop the `projectId` field, its assignment, and the `projectId` create option.
- `src/core/exec-backend.ts`: remove `project_id` from `TenkiExecBackendConfig`.
- `src/core/security.ts`: remove `project_id` from `TenkiBackendSchema`.
- tests: drop `project_id` from the fixtures; the exec test now asserts `projectId` is *not* forwarded.

## Note on compatibility

`project_id` was previously required by `TenkiBackendSchema` (`z.string().min(1)`). Any existing config that sets it will now fail validation as an unknown key. Happy to accept-and-ignore it with a deprecation warning instead if you'd prefer a softer migration — say the word.

## Verification

- `npm run typecheck` in `apps/agent`: **74 errors on pristine main → 73 on this branch** with the 0.5.4 SDK installed. The single difference is the `projectId` error above, now fixed. The remaining 73 are pre-existing failures in unrelated test files (`user-store`, `tools`, `policy`, `attachment-*`, `mcp-client`, `channel-setup`, `schedule-tools`, `prepare-attachment-content`) and are untouched by this PR.
- `npx tsx --test test/tenki-backend.test.ts`: **11/11 pass**
- `npx tsx --test test/security.test.ts`: **8/8 pass**

Not run: the full suite (it does not pass on main for the unrelated reasons above) and any live-sandbox exercise of the tenki backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the sandbox integration to the latest supported version.
  * Tenki sessions can now operate without requiring a project ID; workspace configuration remains supported.

* **Bug Fixes**
  * Improved backend configuration and session handling by removing obsolete project ID requirements.
  * Updated execution, reconnect, timeout, concurrency, skill-sync, and shutdown scenarios to reflect the streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->