### PR TITLE
fix(gateway): reject sender-identity impersonation on message ingress

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -76,6 +76,7 @@ import {
   type AuthResolverOptions,
   type JwtConfig,
   type UserAuthProvider,
+  enforceSenderIdentity,
   resolveAuth,
   signJwt,
   tokensMatch,
@@ -1262,6 +1263,13 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
       throw new ValidationError('Invalid SessionMessage payload.');
     }
 
+    // Security: the runtime resolves this message's acting identity and role
+    // from `payload.sender`. Reject a sender the authenticated caller isn't
+    // entitled to assert — before any side effect (attachment fetch, post) —
+    // so a low-privilege token can't impersonate the owner (e.g. forge
+    // `cli:root`) and unlock owner-gated tools.
+    enforceSenderIdentity(auth, payload.sender);
+
     // URL-passthrough: convert `{ url, !id }` attachments into real
     // session_attachments rows (fetch + persist + materialize) before
     // forwarding. Mutates `payload.attachments` in place. Fetch failures
@@ -1291,15 +1299,6 @@ export const createGatewayApp = (options: GatewayAppOptions): Hono => {
         delete payload.attachments;
       } else {
         payload.attachments = resolvedAttachments;
-      }
-    }
-
-    // Channel namespace enforcement
-    if (auth.mode === 'channel' && auth.channelNamespace && payload.sender) {
-      if (payload.sender.channel !== auth.channelNamespace) {
-        throw new ValidationError(
-          `Channel namespace violation: channel "${auth.channelNamespace}" cannot declare sender identity for "${payload.sender.channel}".`,
-        );
       }
     }
 

--- a/apps/gateway/src/auth.ts
+++ b/apps/gateway/src/auth.ts
@@ -20,6 +20,8 @@
 import { SignJWT, jwtVerify, type JWTPayload } from 'jose';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
 
+import { UnauthorizedError } from '@openhermit/shared';
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 /** Verified identity attached to every authenticated request. */
@@ -50,6 +52,62 @@ export interface AuthContext {
    * Channel-declared sender identities must match this namespace.
    */
   channelNamespace?: string;
+}
+
+/**
+ * Guard a caller-supplied message `sender` against the authenticated
+ * principal.
+ *
+ * The agent runtime derives each message's acting identity — and therefore
+ * its role, including `owner`, which gates privileged tools like `exec` —
+ * from `message.sender` (see AgentRunner.resolveMessageSender). That makes
+ * `sender` security-critical: whoever can name an arbitrary sender inherits
+ * that identity's role. Left unchecked, a low-privilege caller could set
+ * `sender = { channel: 'cli', channelUserId: 'root' }`, be resolved as the
+ * agent owner, and unlock owner-only tools — the 2026-08-11 fleet-wide
+ * exec/RCE incident. This clamps who may assert what, per auth mode:
+ *
+ *   - `admin`: fully trusted; may assert any sender.
+ *   - `channel`: a channel-service token speaks for many users, but only
+ *     inside its own channel. Require a namespace (fail closed if the token
+ *     has none) and require `sender.channel` to equal it — so a channel can
+ *     never assert an identity that lives in a different channel.
+ *   - `user`: the token is one specific person; it may only send as itself.
+ *     A `sender` naming a different (channel, channelUserId) is rejected.
+ *
+ * Throws {@link UnauthorizedError} on any disallowed assertion.
+ */
+export function enforceSenderIdentity(
+  auth: AuthContext,
+  sender: { channel?: string; channelUserId?: string } | undefined,
+): void {
+  if (!sender) return;
+  if (auth.mode === 'admin') return;
+
+  if (auth.mode === 'channel') {
+    if (!auth.channelNamespace) {
+      throw new UnauthorizedError(
+        'Channel token without a namespace cannot declare a sender identity.',
+      );
+    }
+    if (sender.channel !== undefined && sender.channel !== auth.channelNamespace) {
+      throw new UnauthorizedError(
+        `Channel namespace violation: "${auth.channelNamespace}" cannot declare sender identity for "${sender.channel}".`,
+      );
+    }
+    return;
+  }
+
+  // user mode: a JWT identifies exactly one person, so it may only speak as
+  // itself. Any divergent channel/channelUserId is an impersonation attempt.
+  if (
+    (sender.channel !== undefined && sender.channel !== auth.channel) ||
+    (sender.channelUserId !== undefined && sender.channelUserId !== auth.channelUserId)
+  ) {
+    throw new UnauthorizedError(
+      'A user token may only send messages as its own identity.',
+    );
+  }
 }
 
 /**

--- a/apps/gateway/src/ws-handler.ts
+++ b/apps/gateway/src/ws-handler.ts
@@ -21,8 +21,10 @@ import {
 import type { AgentRunner, SessionEventEnvelope } from '@openhermit/agent/agent-runner';
 
 import type { AgentInstanceManager } from './agent-instance.js';
+import { UnauthorizedError } from '@openhermit/shared';
+
 import type { AuthContext, AuthResolverOptions } from './auth.js';
-import { resolveAuth } from './auth.js';
+import { enforceSenderIdentity, resolveAuth } from './auth.js';
 import { listSessionsForCaller } from './session-listing.js';
 
 const WS_PING_INTERVAL_MS = 30_000;
@@ -156,6 +158,11 @@ const handleRequest = async (
           return;
         }
         await requireSessionAccess(conn, runtime, callerUserId, sessionId);
+        // Security: `sender` drives the runtime's per-message identity/role
+        // resolution, so a caller may only assert a sender it is entitled to
+        // (see enforceSenderIdentity). Blocks owner impersonation via a
+        // forged `cli:root` sender.
+        enforceSenderIdentity(conn.auth, p.sender as { channel?: string; channelUserId?: string } | undefined);
         const message = {
           text: p.text,
           ...(p.messageId !== undefined ? { messageId: p.messageId } : {}),
@@ -317,6 +324,10 @@ const handleRequest = async (
     const message = error instanceof Error ? error.message : String(error);
     if (error instanceof SessionAccessDeniedError) {
       sendError(ws, id, error.wsCode, message);
+      return;
+    }
+    if (error instanceof UnauthorizedError) {
+      sendError(ws, id, 'UNAUTHORIZED', message);
       return;
     }
     sendError(ws, id, 'INTERNAL_ERROR', message);

--- a/apps/gateway/test/enforce-sender-identity.test.ts
+++ b/apps/gateway/test/enforce-sender-identity.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { UnauthorizedError } from '@openhermit/shared';
+
+import { enforceSenderIdentity, type AuthContext } from '../src/auth.js';
+
+const user = (channel: string, channelUserId: string): AuthContext => ({
+  mode: 'user',
+  channel,
+  channelUserId,
+});
+const channel = (namespace: string | undefined): AuthContext => ({
+  mode: 'channel',
+  channel: namespace ?? 'chan',
+  channelUserId: 'chan',
+  ...(namespace ? { channelNamespace: namespace } : {}),
+});
+const admin: AuthContext = { mode: 'admin', channel: 'admin', channelUserId: 'admin' };
+
+test('no sender is always allowed', () => {
+  assert.doesNotThrow(() => enforceSenderIdentity(user('web', 'w1'), undefined));
+  assert.doesNotThrow(() => enforceSenderIdentity(channel('telegram'), undefined));
+});
+
+test('admin may assert any sender', () => {
+  assert.doesNotThrow(() =>
+    enforceSenderIdentity(admin, { channel: 'cli', channelUserId: 'root' }),
+  );
+});
+
+test('user token may only send as its own identity', () => {
+  const auth = user('web', 'w1');
+  assert.doesNotThrow(() =>
+    enforceSenderIdentity(auth, { channel: 'web', channelUserId: 'w1' }),
+  );
+});
+
+test('EXPLOIT: user token forging cli:root to become owner is rejected', () => {
+  const auth = user('web', 'attacker-guest');
+  assert.throws(
+    () => enforceSenderIdentity(auth, { channel: 'cli', channelUserId: 'root' }),
+    UnauthorizedError,
+  );
+});
+
+test('user token asserting a different channelUserId in its own channel is rejected', () => {
+  const auth = user('web', 'w1');
+  assert.throws(
+    () => enforceSenderIdentity(auth, { channel: 'web', channelUserId: 'someone-else' }),
+    UnauthorizedError,
+  );
+});
+
+test('channel token may assert identities within its own namespace', () => {
+  assert.doesNotThrow(() =>
+    enforceSenderIdentity(channel('telegram'), { channel: 'telegram', channelUserId: '12345' }),
+  );
+});
+
+test('channel token cannot assert an identity in a different channel', () => {
+  assert.throws(
+    () => enforceSenderIdentity(channel('telegram'), { channel: 'cli', channelUserId: 'root' }),
+    UnauthorizedError,
+  );
+});
+
+test('channel token without a namespace fails closed', () => {
+  assert.throws(
+    () => enforceSenderIdentity(channel(undefined), { channel: 'telegram', channelUserId: '1' }),
+    UnauthorizedError,
+  );
+});


### PR DESCRIPTION
## The vulnerability

The agent runtime derives **each message's acting identity — and therefore its role, `owner` included — from the caller-supplied `message.sender`** (`AgentRunner.resolveMessageSender`, apps/agent/src/agent-runner.ts). `resolveMessageSender` looks up `sender.{channel, channelUserId}` in the identity store and, if it maps to a user, stamps `session.resolvedUserRole` for the turn.

Nothing constrained who a caller could *claim* to be. The full chain:

1. A **public agent** auto-admits a guest.
2. `/api/auth/token` mints a self-serve JWT (`user` mode).
3. That token POSTs a message with `sender = { channel: 'cli', channelUserId: 'root' }` — the owner's guessable CLI identity.
4. `resolveMessageSender` resolves it to the **owner**, so `session.resolvedUserRole = 'owner'`.
5. Owner-gated tools (`exec`, gated by `defaultGrants: [{type:'role', value:'owner'}]`) are now exposed to the attacker → sandbox RCE.

This is the escalation path behind the **2026-08-11 fleet-wide incident (139 agents swept in a single day)**.

The pre-existing HTTP guard only covered `channel`-mode tokens that had a namespace and compared `sender.channel` alone. **`user`-mode tokens were entirely unconstrained**, and the WebSocket `session.message` path had **no sender check at all**.

## The fix

Add `enforceSenderIdentity(auth, sender)` (apps/gateway/src/auth.ts) and call it on **both** ingress paths — HTTP `POST /api/agents/:agentId/sessions/:sessionId/messages` and the WS `session.message` frame — **before any side effect** (attachment fetch, post). It clamps who may assert what, per auth mode:

| mode | allowed sender |
|------|----------------|
| `admin` | trusted — any sender |
| `channel` | must have a namespace (**fail closed** if not); `sender.channel` must equal it — cannot assert an identity in another channel |
| `user` | may only speak as its own `(channel, channelUserId)` |

Rejections raise `UnauthorizedError` → **401** (HTTP, via the existing `OpenHermitError` handler) / **`UNAUTHORIZED`** (WS). The old, weaker channel-only HTTP check is removed (superseded).

## Tests

`apps/gateway/test/enforce-sender-identity.test.ts` — 8 cases, including the `cli:root` exploit (a `user` token forging the owner identity must throw). All pass. Typecheck adds zero new errors over baseline.

## Follow-ups (not in this PR)
- Deep-dive of the ~130 attacker accounts (auth channel, mapping to real platform users) — separate report.
- Rotate the exposed `AMIKO_API_KEY` and e2b envd token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added sender-identity validation for messages and attachments.
  * Restricted identity assertions based on authentication type, preventing unauthorized impersonation or cross-channel spoofing.
  * Added clear unauthorized responses for rejected WebSocket requests.

* **Tests**
  * Added coverage for valid identities, administrator access, user restrictions, channel-token validation, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->