### PR TITLE
feat(store): migrate Supabase attachment key to new secret API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Changed** Supabase attachment storage to prefer a new-style Supabase secret API key (`sb_secret_…`). The key now resolves from `SUPABASE_SERVICE_ROLE_KEY` or the new `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`. `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` is **deprecated** — it still works as a fallback but logs a warning; rename it to `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`. The legacy JWT service-role key continues to work.
+
 ## SDK 0.5.1 — 2026-05-18
 
 - **Added** `AgentLocalClient.uploadAttachment` / `listAttachments` / `getAttachment` — the same per-session attachment surface that `GatewayClient` already exposed, but on the per-agent client, so callers holding a channel-mode token (not an admin token) can upload directly under `/api/agents/:id/sessions/:sid/attachments`. Server-side auth is unchanged: same `requireAuth` → `enforceSessionNamespace` → `requireSessionAccessHttp` chain that `postMessage` uses, so any token that can `postMessage` on a session can also `uploadAttachment` to it.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Important environment variables:
 | `OPENHERMIT_WEB_PORT` | End-user web app port, default `4310` |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | Standard AWS credential chain — used when `attachments.storage.provider = s3` |
 | `SUPABASE_URL` | Supabase project URL (e.g. `https://xyz.supabase.co`) — required when `attachments.storage.provider = supabase`. Treated as part of the credential bundle since it embeds the project ID |
-| `SUPABASE_SERVICE_ROLE_KEY` | Required when `attachments.storage.provider = supabase`. Never stored in gateway config |
+| `SUPABASE_SERVICE_ROLE_KEY` or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY` | Supabase secret API key (`sb_secret_…`) — required when `attachments.storage.provider = supabase`. Never stored in gateway config. The legacy service-role JWT still works. (`OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` is deprecated) |
 
 ### Attachment storage backends
 
@@ -269,7 +269,7 @@ Install the SDK on the gateway: `npm install @aws-sdk/client-s3 @aws-sdk/s3-requ
 
 #### Supabase Storage
 
-Install the SDK on the gateway: `npm install @supabase/supabase-js`. Set `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` in env — the project URL embeds the project ID and is treated as part of the credential bundle.
+Install the SDK on the gateway: `npm install @supabase/supabase-js`. Set `SUPABASE_URL` and a Supabase secret API key (`sb_secret_…`) in env as `SUPABASE_SERVICE_ROLE_KEY` (or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`) — the project URL embeds the project ID and is treated as part of the credential bundle. The legacy service-role JWT still works; the older `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` var is deprecated.
 
 ```json
 {

--- a/apps/agent/test/attachment-providers.test.ts
+++ b/apps/agent/test/attachment-providers.test.ts
@@ -91,3 +91,53 @@ test('SupabaseAttachmentStorage.open: actionable error when SDK missing', async 
     else process.env.SUPABASE_SERVICE_ROLE_KEY = prev;
   }
 });
+
+test('SupabaseAttachmentStorage.open: accepts new OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY', async () => {
+  const prevRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const prevSecret = process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY = 'sb_secret_fake';
+  try {
+    // Gets past the key check and fails only because the SDK isn't installed.
+    await SupabaseAttachmentStorage.open({ url: 'https://x.supabase.co', bucket: 'b' });
+    assert.fail('expected open() to throw because @supabase/supabase-js is not installed');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    assert.match(msg, /@supabase\/supabase-js/);
+  } finally {
+    if (prevRole === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevRole;
+    if (prevSecret === undefined) delete process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY;
+    else process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY = prevSecret;
+  }
+});
+
+test('SupabaseAttachmentStorage.open: deprecated OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY still works + warns', async () => {
+  const prevRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const prevSecret = process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY;
+  const prevLegacy = process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY;
+  process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY = 'legacy-jwt-key';
+  const origWarn = console.warn;
+  let warned = '';
+  console.warn = (msg?: unknown) => {
+    warned += String(msg);
+  };
+  try {
+    await SupabaseAttachmentStorage.open({ url: 'https://x.supabase.co', bucket: 'b' });
+    assert.fail('expected open() to throw because @supabase/supabase-js is not installed');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    assert.match(msg, /@supabase\/supabase-js/);
+    assert.match(warned, /OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY is deprecated/);
+  } finally {
+    console.warn = origWarn;
+    if (prevRole === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevRole;
+    if (prevSecret === undefined) delete process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY;
+    else process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY = prevSecret;
+    if (prevLegacy === undefined) delete process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY;
+    else process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY = prevLegacy;
+  }
+});

--- a/packages/store/src/impl/supabase-attachment-storage.ts
+++ b/packages/store/src/impl/supabase-attachment-storage.ts
@@ -19,9 +19,11 @@ export interface SupabaseAttachmentStorageOptions {
   signedUrlExpiresIn?: number;
   /**
    * Supabase API secret key (`sb_secret_…`). If omitted, read from
-   * `SUPABASE_SERVICE_ROLE_KEY` or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`.
-   * Provided as an option for testability — operators should set the env
-   * var, not put the key in gateway config.
+   * `SUPABASE_SERVICE_ROLE_KEY` or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`
+   * (preferred), falling back to the deprecated
+   * `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY`. Provided as an option for
+   * testability — operators should set the env var, not put the key in
+   * gateway config.
    *
    * Named `serviceRoleKey` for backward compatibility; it now also accepts a
    * new-style secret API key, which is the recommended value.
@@ -62,11 +64,12 @@ interface SupabaseSdkModule {
 /**
  * Supabase-Storage-backed `AttachmentStorage`. The project URL and secret
  * key both come from env (`SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`
- * or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`) — gateway config only
- * carries the non-secret bucket pointer. The key accepts a new-style
- * Supabase secret API key (`sb_secret_…`); the legacy JWT service-role key
- * still works. Signed URLs are supported and used by `attachment_fetch`
- * for short-lived inline links.
+ * or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`; the deprecated
+ * `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` still works as a fallback and
+ * logs a warning) — gateway config only carries the non-secret bucket
+ * pointer. The key accepts a new-style Supabase secret API key
+ * (`sb_secret_…`); the legacy JWT service-role key still works. Signed URLs
+ * are supported and used by `attachment_fetch` for short-lived inline links.
  */
 export class SupabaseAttachmentStorage implements AttachmentStorage {
   readonly name = 'supabase';

--- a/packages/store/src/impl/supabase-attachment-storage.ts
+++ b/packages/store/src/impl/supabase-attachment-storage.ts
@@ -18,9 +18,13 @@ export interface SupabaseAttachmentStorageOptions {
   /** Default expiry for `getSignedUrl` when caller passes nothing. */
   signedUrlExpiresIn?: number;
   /**
-   * Service-role key. If omitted, read from `SUPABASE_SERVICE_ROLE_KEY`.
+   * Supabase API secret key (`sb_secret_…`). If omitted, read from
+   * `SUPABASE_SERVICE_ROLE_KEY` or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`.
    * Provided as an option for testability — operators should set the env
    * var, not put the key in gateway config.
+   *
+   * Named `serviceRoleKey` for backward compatibility; it now also accepts a
+   * new-style secret API key, which is the recommended value.
    */
   serviceRoleKey?: string;
 }
@@ -56,11 +60,13 @@ interface SupabaseSdkModule {
 }
 
 /**
- * Supabase-Storage-backed `AttachmentStorage`. The project URL and
- * service-role key both come from env (`SUPABASE_URL`,
- * `SUPABASE_SERVICE_ROLE_KEY`) — gateway config only carries the
- * non-secret bucket pointer. Signed URLs are supported and used by
- * `attachment_fetch` for short-lived inline links.
+ * Supabase-Storage-backed `AttachmentStorage`. The project URL and secret
+ * key both come from env (`SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`
+ * or `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`) — gateway config only
+ * carries the non-secret bucket pointer. The key accepts a new-style
+ * Supabase secret API key (`sb_secret_…`); the legacy JWT service-role key
+ * still works. Signed URLs are supported and used by `attachment_fetch`
+ * for short-lived inline links.
  */
 export class SupabaseAttachmentStorage implements AttachmentStorage {
   readonly name = 'supabase';
@@ -86,14 +92,28 @@ export class SupabaseAttachmentStorage implements AttachmentStorage {
           'Set the env var on the gateway; the URL embeds the project ID and is treated as part of the credential.',
       );
     }
+    const legacyServiceKey = process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY;
     const key =
       options.serviceRoleKey ??
       process.env.SUPABASE_SERVICE_ROLE_KEY ??
-      process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY;
+      process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY ??
+      legacyServiceKey;
+    if (
+      legacyServiceKey &&
+      !options.serviceRoleKey &&
+      !process.env.SUPABASE_SERVICE_ROLE_KEY &&
+      !process.env.OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY
+    ) {
+      console.warn(
+        'SupabaseAttachmentStorage: OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY is deprecated. ' +
+          'Rename it to OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY and set a Supabase secret ' +
+          'API key (sb_secret_…) instead of the legacy service-role key.',
+      );
+    }
     if (!key) {
       throw new Error(
         'SupabaseAttachmentStorage requires SUPABASE_SERVICE_ROLE_KEY ' +
-          '(or OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY). ' +
+          '(or OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY). ' +
           'Set the env var on the gateway; do not put it in gateway config.',
       );
     }


### PR DESCRIPTION
## What

Supabase deprecated the legacy JWT `service_role` key in favor of new API keys (`sb_secret_…`). This migrates the attachment-storage credential to the new scheme.

- **New preferred var:** `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY` (holds a Supabase secret API key `sb_secret_…`).
- **Deprecated:** `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` — still works as a fallback but logs a `console.warn` so live deploys don't break before the env is renamed.
- **Unchanged:** `SUPABASE_SERVICE_ROLE_KEY` (generic standard name) and the legacy JWT value both continue to work — the key string is passed to `createClient` verbatim, so new and old keys are drop-in.

Resolution order:
```
options.serviceRoleKey
  → SUPABASE_SERVICE_ROLE_KEY
  → OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY   (new preferred)
  → OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY  (deprecated, warns)
```

## Files
- `packages/store/src/impl/supabase-attachment-storage.ts` — resolution + deprecation warning + docstrings
- `README.md` — env table + Supabase Storage section
- `CHANGELOG.md` — Unreleased entry
- `apps/agent/test/attachment-providers.test.ts` — tests for the new var and the deprecated-fallback warning

## Testing
- `packages/store` typechecks clean.
- Attachment-provider suite: **9/9 pass** (7 existing + 2 new).
- Note: `apps/agent`'s `tsc -b` fails on pre-existing missing optional peer deps (`@tenkicloud/sandbox`, `@firecrawl/*`), unrelated to this change.

## Deploy follow-up (non-blocking)
On Railway, rename the env var to `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY` and set a Supabase secret key (`sb_secret_…`). The old name keeps working (with a warning) until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supabase attachment storage now supports recommended `sb_secret_…` API keys through supported environment variables.
  * Existing JWT-based service-role keys remain compatible.
* **Documentation**
  * Updated setup guidance and error messages to describe supported key options.
  * Marked the legacy service-key environment variable as deprecated.
* **Bug Fixes**
  * Added a deprecation warning when the legacy service-key variable is used.
* **Tests**
  * Added coverage for secret-key support, legacy compatibility, and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->