### PR TITLE
fix(agent): normalize message alternation before LLM calls (unwedge MiniMax 2013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Fixed** a session-wedge where strict providers (notably MiniMax, `400 invalid params (2013)`) rejected every turn of a long-lived session forever. Before each LLM call the request payload is now normalized to strictly alternate user/assistant turns (`normalizeMessageAlternation`): consecutive same-role messages are coalesced. This unwedges two production failure modes — (1) failed turns whose empty error-placeholder was stripped left orphan user messages that accumulated into a non-alternating run, and (2) an assistant text turn landing between a `toolCall` and its `toolResult`. The transform is request-only; persisted history is untouched, and `toolResult` messages (parallel results) are never merged.
 - **Changed** Supabase attachment storage to prefer a new-style Supabase secret API key (`sb_secret_…`). The key now resolves from `SUPABASE_SERVICE_ROLE_KEY` or the new `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`. `OPENHERMIT_ATTACHMENT_SUPABASE_SERVICE_KEY` is **deprecated** — it still works as a fallback but logs a warning; rename it to `OPENHERMIT_ATTACHMENT_SUPABASE_SECRET_KEY`. The legacy JWT service-role key continues to work.
 
 ## SDK 0.5.1 — 2026-05-18

--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -56,6 +56,7 @@ import {
   extractToolResultText,
   isAssistantMessage,
   isEmptyAssistantTurn,
+  normalizeMessageAlternation,
   stripEmptyAssistantTurns,
   stripLeadingSpeakerTag,
   transcodeGroupMentions,
@@ -2910,6 +2911,16 @@ export class AgentRunner implements SessionRuntime {
         liveState.push(...core);
       }
     }
+
+    // Final wire-shape guard: coalesce any consecutive same-role messages so
+    // the transcript strictly alternates user/assistant. Strict providers
+    // (MiniMax 400s with `invalid params (2013)`) reject consecutive user or
+    // assistant turns, and a failed turn whose empty placeholder was stripped
+    // can leave two user messages adjacent — which then wedges every following
+    // turn. Applied AFTER the live-state write-back so this only reshapes the
+    // request payload, never the persisted history (same request-only contract
+    // as truncateToolResults and the rolling window).
+    finalMessages = normalizeMessageAlternation(finalMessages);
 
     if (AgentRunner.DEBUG) {
       const budget = getContextCompactionMaxTokens(config, {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -1,5 +1,13 @@
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
-import type { AssistantMessage, ImageContent, Message, TextContent } from '@mariozechner/pi-ai';
+import type {
+  AssistantMessage,
+  ImageContent,
+  Message,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  UserMessage,
+} from '@mariozechner/pi-ai';
 
 import type { SessionAttachment, SessionMessage } from '@openhermit/protocol';
 import type { AttachmentStorage, AttachmentStore } from '@openhermit/store';
@@ -48,6 +56,110 @@ export const isEmptyAssistantTurn = (message: AgentMessage): boolean => {
  */
 export const stripEmptyAssistantTurns = (messages: AgentMessage[]): AgentMessage[] =>
   messages.filter((message) => !isEmptyAssistantTurn(message));
+
+const toUserBlocks = (
+  content: UserMessage['content'],
+): (TextContent | ImageContent)[] =>
+  typeof content === 'string'
+    ? content.length > 0
+      ? [{ type: 'text', text: content }]
+      : []
+    : content;
+
+/**
+ * Merge runs of consecutive `{type:'text'}` blocks into one, joining with a
+ * blank line. Non-text blocks (images, toolCalls, thinking) pass through
+ * verbatim and in order. Inputs are never mutated — a coalesced text block is
+ * a fresh object — so the caller's original messages stay untouched (this is a
+ * request-only transform).
+ */
+const coalesceTextBlocks = <B extends { type: string }>(blocks: B[]): B[] => {
+  const out: B[] = [];
+  for (const block of blocks) {
+    const prev = out[out.length - 1];
+    if (
+      block.type === 'text' &&
+      prev &&
+      prev.type === 'text'
+    ) {
+      out[out.length - 1] = {
+        ...prev,
+        text: `${(prev as unknown as TextContent).text}\n\n${(block as unknown as TextContent).text}`,
+      };
+    } else {
+      out.push(block);
+    }
+  }
+  return out;
+};
+
+const mergeUserRun = (run: UserMessage[]): UserMessage => {
+  const blocks = coalesceTextBlocks(run.flatMap((m) => toUserBlocks(m.content)));
+  return { ...run[run.length - 1]!, role: 'user', content: blocks };
+};
+
+const mergeAssistantRun = (run: AssistantMessage[]): AssistantMessage => {
+  const blocks = coalesceTextBlocks(
+    run.flatMap((m) => m.content as (TextContent | ThinkingContent | ToolCall)[]),
+  );
+  const last = run[run.length - 1]!;
+  const hasToolCall = blocks.some((b) => b.type === 'toolCall');
+  return {
+    ...last,
+    role: 'assistant',
+    content: blocks,
+    // A merged assistant that still carries a toolCall must be reported as a
+    // tool-use turn so the toolResult(s) that follow it stay valid.
+    stopReason: hasToolCall ? 'toolUse' : last.stopReason,
+  };
+};
+
+/**
+ * Coalesce consecutive same-role user/assistant messages so the transcript
+ * strictly alternates. Strict providers (notably MiniMax, `400 invalid params
+ * (2013)`) reject two user or two assistant messages in a row, whereas
+ * Anthropic silently merges them.
+ *
+ * Two production failure modes this fixes, both seen wedging a single
+ * long-lived session forever:
+ *  1. A failed turn records an empty error-placeholder assistant turn;
+ *     `stripEmptyAssistantTurns` drops it, leaving the failed turn's user
+ *     message adjacent to the next user message. Each subsequent failure adds
+ *     another orphan user turn, so the run of consecutive user messages grows
+ *     and every future turn 400s — a self-perpetuating lock.
+ *  2. An assistant text turn landing between a toolCall and its toolResult
+ *     (`assistant(toolCall) → assistant(text) → toolResult`) — merging the two
+ *     assistant turns restores `assistant(toolCall,text) → toolResult`.
+ *
+ * `toolResult` messages pass through untouched: consecutive toolResults are
+ * legitimate parallel results and must not be merged. Request-only — callers
+ * apply this to the wire payload, never to persisted state.
+ */
+export const normalizeMessageAlternation = (
+  messages: AgentMessage[],
+): AgentMessage[] => {
+  const out: AgentMessage[] = [];
+  let i = 0;
+  while (i < messages.length) {
+    const role = (messages[i] as Message).role;
+    if (role !== 'user' && role !== 'assistant') {
+      out.push(messages[i]!);
+      i += 1;
+      continue;
+    }
+    let j = i + 1;
+    while (j < messages.length && (messages[j] as Message).role === role) j += 1;
+    if (j - i === 1) {
+      out.push(messages[i]!);
+    } else if (role === 'user') {
+      out.push(mergeUserRun(messages.slice(i, j) as unknown as UserMessage[]));
+    } else {
+      out.push(mergeAssistantRun(messages.slice(i, j) as unknown as AssistantMessage[]));
+    }
+    i = j;
+  }
+  return out;
+};
 
 // Innermost pair only: body may not contain another reasoning open tag. Used
 // iteratively so nested same-name tags do not leave residual close markup.

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import type { AssistantMessage } from '@mariozechner/pi-ai';
+import type {
+  AssistantMessage,
+  ToolResultMessage,
+  UserMessage,
+} from '@mariozechner/pi-ai';
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
 
 import {
   stripReasoningTags,
@@ -10,6 +15,7 @@ import {
   reasoningStreamUnclosedTag,
   pushReasoningTagDelta,
   flushReasoningTagStream,
+  normalizeMessageAlternation,
 } from '../src/agent-runner/message-utils.js';
 
 const assistantMsg = (text: string): AssistantMessage =>
@@ -234,5 +240,111 @@ describe('reasoning tag stream', () => {
     // The authoritative text_final comes from stripReasoningTags, which leaves
     // untagged text alone — nothing is lost, only the typing effect.
     assert.equal(stripReasoningTags('pure reply that never closes'), 'pure reply that never closes');
+  });
+});
+
+const user = (text: string): UserMessage =>
+  ({ role: 'user', content: [{ type: 'text', text }], timestamp: 1 }) as UserMessage;
+const assistantText = (text: string): AssistantMessage =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    api: 'openai-completions',
+    provider: 'minimax',
+    model: 'MiniMax-M3',
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: 'stop',
+    timestamp: 1,
+  }) as AssistantMessage;
+const assistantCall = (id: string, name: string): AssistantMessage =>
+  ({
+    ...assistantText(''),
+    content: [{ type: 'toolCall', id, name, arguments: {} }],
+    stopReason: 'toolUse',
+  }) as AssistantMessage;
+const toolResult = (id: string, name: string): ToolResultMessage =>
+  ({
+    role: 'toolResult',
+    toolCallId: id,
+    toolName: name,
+    content: [{ type: 'text', text: 'ok' }],
+    isError: false,
+    timestamp: 1,
+  }) as ToolResultMessage;
+
+const roles = (messages: AgentMessage[]): string =>
+  messages.map((m) => (m as { role: string }).role[0]!.toUpperCase()).join('');
+
+describe('normalizeMessageAlternation', () => {
+  test('collapses the trailing run of consecutive user turns (the wedge)', () => {
+    // Mirrors the production wedge: a session where every failed turn left an
+    // orphan user message behind, producing 7 users in a row that MiniMax 400s.
+    const wedged: AgentMessage[] = [
+      assistantText('reply'),
+      user('最近一个文档发我'),
+      user('hi'),
+      user('hi'),
+      user('hi'),
+      user('hello'),
+      user('hi'),
+    ] as AgentMessage[];
+    const out = normalizeMessageAlternation(wedged);
+    assert.equal(roles(out), 'AU');
+    const merged = out[1] as UserMessage;
+    assert.ok(Array.isArray(merged.content));
+    // Six user turns coalesce into one text block joined by blank lines.
+    const text = (merged.content as { type: string; text: string }[])
+      .map((b) => b.text)
+      .join('');
+    assert.match(text, /最近一个文档发我\n\nhi\n\nhi\n\nhi\n\nhello\n\nhi/);
+  });
+
+  test('merges assistant(toolCall) + assistant(text) so the toolResult stays adjacent', () => {
+    // assistant(toolCall) → assistant(text) → toolResult is the other observed
+    // corruption; merging the two assistants restores a valid tool pairing.
+    const broken: AgentMessage[] = [
+      assistantCall('call_1', 'attachment_send'),
+      assistantText('发你 👇'),
+      toolResult('call_1', 'attachment_send'),
+    ] as AgentMessage[];
+    const out = normalizeMessageAlternation(broken);
+    assert.equal(roles(out), 'AT');
+    const merged = out[0] as AssistantMessage;
+    const types = merged.content.map((b) => b.type);
+    assert.deepEqual(types, ['toolCall', 'text']);
+    // Still a tool-use turn so the following toolResult is valid.
+    assert.equal(merged.stopReason, 'toolUse');
+  });
+
+  test('leaves consecutive toolResults (parallel results) untouched', () => {
+    const parallel: AgentMessage[] = [
+      assistantCall('call_a', 'x'),
+      toolResult('call_a', 'x'),
+      toolResult('call_b', 'y'),
+      assistantText('done'),
+    ] as AgentMessage[];
+    const out = normalizeMessageAlternation(parallel);
+    // toolResults are NOT merged; nothing collapses here.
+    assert.equal(roles(out), 'ATTA');
+    assert.equal(out.length, 4);
+  });
+
+  test('is a no-op on an already-alternating transcript', () => {
+    const clean: AgentMessage[] = [
+      user('hi'),
+      assistantText('hello'),
+      user('bye'),
+      assistantText('cya'),
+    ] as AgentMessage[];
+    const out = normalizeMessageAlternation(clean);
+    assert.equal(roles(out), 'UAUA');
+    assert.equal(out.length, 4);
+  });
+
+  test('does not mutate the input messages', () => {
+    const input: AgentMessage[] = [user('a'), user('b')] as AgentMessage[];
+    const before = JSON.stringify(input);
+    normalizeMessageAlternation(input);
+    assert.equal(JSON.stringify(input), before);
   });
 });


### PR DESCRIPTION
## What & why

A single long-lived amiko web session (`amiko:cmnxcm8ck000004jxikqwn32r`, Somiko) failed **every** turn with the frontend's "出了点问题，请重试". Root cause, confirmed from the Langfuse trace of the failing turn ([`791f0732…`](https://us.cloud.langfuse.com/project/cme5qv5i40csaad07jfzzboqe/traces/791f0732-c155-43d1-84ae-a56d05b009b0)):

MiniMax rejected the request with `400 {"type":"error","error":{"type":"invalid_request_error","message":"invalid params, 400 (2013)"}}` (usage all-zero — rejected at validation). The 67-message payload had **no orphaned tool results and no empty blocks**, but the role sequence violated MiniMax's strict user/assistant alternation:

```
… A A T A U U U U U U U
```

- **7 consecutive user turns at the tail.** Self-perpetuating: each failed turn records an empty error-placeholder assistant turn, `stripEmptyAssistantTurns` drops it, and the failed turn's user message is left adjacent to the next — so the run grows and every future turn 400s. Anthropic silently merges consecutive same-role messages; MiniMax does not.
- **`assistant(toolCall) → assistant(text) → toolResult`** — a stray assistant text between a toolCall and its result (`attachment_send` flow).

Scheduled telegram/`schedule:` tasks and any fresh session use the **same** agent/model/key and succeed — only this 3-month-old, 1788-compaction session is wedged.

## Change

Add `normalizeMessageAlternation`, applied to the wire payload in `transformContext` right before the LLM call — **after** the live-state write-back, so it's request-only (same contract as `truncateToolResults` / the rolling window; persisted history is untouched).

- Coalesces runs of consecutive `user`/`assistant` messages; text blocks join with a blank line, toolCalls/images/thinking preserved in order.
- A merged assistant that still carries a toolCall keeps `stopReason: 'toolUse'` so the following toolResult stays valid.
- `toolResult` messages pass through untouched — consecutive toolResults are legitimate parallel results and must not be merged.
- No-op on already-alternating transcripts (the common case).

## Tests

`apps/agent/test/message-utils.test.ts` — 5 new cases (the 7-user wedge, the toolCall/text/toolResult merge, parallel-toolResult passthrough, alternating no-op, input-not-mutated). All 32 pass. `tsc -b apps/agent` introduces no new errors (pre-existing optional-dep failures unrelated).

## Ops note

The already-wedged prod session recovers on the next turn once this deploys (the normalizer reshapes its replayed history). No data migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request processing by consistently combining consecutive messages from the same speaker.
  * Removed empty user messages and merged adjacent text where appropriate.
  * Improved handling of assistant responses that include tool calls while preserving separate tool results.
  * Ensured valid conversation transcripts remain unchanged and saved conversation history is not modified.

* **Tests**
  * Added coverage for message normalization, tool interactions, parallel tool results, and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->