### PR TITLE
fix(agent): downgrade image blocks for text-only models before sending

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -57,6 +57,7 @@ import {
   isAssistantMessage,
   isEmptyAssistantTurn,
   normalizeMessageAlternation,
+  downgradeImagesForTextModel,
   stripEmptyAssistantTurns,
   stripLeadingSpeakerTag,
   transcodeGroupMentions,
@@ -2921,6 +2922,23 @@ export class AgentRunner implements SessionRuntime {
     // request payload, never the persisted history (same request-only contract
     // as truncateToolResults and the rolling window).
     finalMessages = normalizeMessageAlternation(finalMessages);
+
+    // Text-only models (e.g. MiniMax-M3) reject any request carrying an image
+    // content block — MiniMax 400s with `invalid params (2013)`. Images can
+    // enter a live session mid-turn via a tool result (`attachment_fetch` in
+    // image mode, a `doc_read` image page), a path the attachment-prepare
+    // downgrade never covers, so strip every image block down to a text
+    // placeholder here when the target model can't see images. REQUEST-ONLY
+    // (applied after the live-state write-back, like normalizeMessageAlternation):
+    // the stored history keeps the image bytes, so this also auto-unwedges a
+    // session that already baked an image into its persisted history — no DB
+    // surgery needed — and full fidelity returns if the agent moves back to a
+    // multimodal model.
+    const modelInputs = (model as { input?: string[] }).input;
+    const supportsImageInput = Array.isArray(modelInputs)
+      ? modelInputs.includes('image')
+      : true;
+    finalMessages = downgradeImagesForTextModel(finalMessages, supportsImageInput);
 
     if (AgentRunner.DEBUG) {
       const budget = getContextCompactionMaxTokens(config, {

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -161,6 +161,70 @@ export const normalizeMessageAlternation = (
   return out;
 };
 
+/**
+ * Downgrade every `image` content block to a text placeholder when the target
+ * model cannot accept image input. Text-only providers (e.g. MiniMax-M3) reject
+ * a request that carries an image block outright — MiniMax 400s with
+ * `invalid params (2013)` — and once such a block is in a session's history
+ * every following turn re-sends it, wedging the session forever.
+ *
+ * Images reach a text-only model by two routes:
+ *  1. A user-message attachment. `prepareAttachmentContent` already downgrades
+ *     these at prepare time when `supportsImageInput` is false.
+ *  2. A tool result (`attachment_fetch` in image mode, a `doc_read` image page)
+ *     that inlines `{ type: 'image', data }` on a LIVE turn — where the
+ *     attachment-prepare downgrade never runs. This is the gap that wedged
+ *     Somiko's session after the key swap moved it onto text-only MiniMax-M3.
+ *
+ * Applying this on the wire payload closes route 2 (and re-covers route 1 for
+ * reconstructed history). REQUEST-ONLY: callers run it after the live-state
+ * write-back, so the persisted history keeps the original image bytes — moving
+ * the agent back to a multimodal model restores full fidelity, and a session
+ * that already baked an image into its stored history auto-unwedges on its next
+ * turn without any DB surgery. Same contract as `normalizeMessageAlternation`.
+ *
+ * Returns the input array unchanged (same reference) when the model is
+ * multimodal or no image block is present.
+ */
+export const downgradeImagesForTextModel = (
+  messages: AgentMessage[],
+  supportsImageInput: boolean,
+): AgentMessage[] => {
+  if (supportsImageInput) return messages;
+
+  let changed = false;
+  const out = messages.map((message) => {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return message;
+
+    let blockChanged = false;
+    const nextContent = content.map((block) => {
+      if (
+        block &&
+        typeof block === 'object' &&
+        (block as { type?: unknown }).type === 'image'
+      ) {
+        blockChanged = true;
+        const mime = (block as { mimeType?: unknown }).mimeType;
+        const label = typeof mime === 'string' && mime ? ` (${mime})` : '';
+        return {
+          type: 'text' as const,
+          text:
+            `[image omitted${label}: an image was here, but the active model is ` +
+            'text-only and cannot view images. Switch to a multimodal model to see it.]',
+        };
+      }
+      return block;
+    });
+
+    if (!blockChanged) return message;
+    changed = true;
+    return { ...message, content: nextContent } as AgentMessage;
+  });
+
+  return changed ? out : messages;
+};
+
 // Innermost pair only: body may not contain another reasoning open tag. Used
 // iteratively so nested same-name tags do not leave residual close markup.
 const REASONING_INNERMOST_RE =

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -16,6 +16,7 @@ import {
   pushReasoningTagDelta,
   flushReasoningTagStream,
   normalizeMessageAlternation,
+  downgradeImagesForTextModel,
 } from '../src/agent-runner/message-utils.js';
 
 const assistantMsg = (text: string): AssistantMessage =>
@@ -345,6 +346,96 @@ describe('normalizeMessageAlternation', () => {
     const input: AgentMessage[] = [user('a'), user('b')] as AgentMessage[];
     const before = JSON.stringify(input);
     normalizeMessageAlternation(input);
+    assert.equal(JSON.stringify(input), before);
+  });
+});
+
+const toolResultWithImage = (id: string, name: string): ToolResultMessage =>
+  ({
+    role: 'toolResult',
+    toolCallId: id,
+    toolName: name,
+    content: [
+      { type: 'text', text: 'fetched attachment' },
+      { type: 'image', data: '/9j/4AAQSkZJRgABAQ==', mimeType: 'image/jpeg' },
+    ],
+    isError: false,
+    timestamp: 1,
+  }) as ToolResultMessage;
+
+const userWithImage = (text: string): UserMessage =>
+  ({
+    role: 'user',
+    content: [
+      { type: 'text', text },
+      { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' },
+    ],
+    timestamp: 1,
+  }) as UserMessage;
+
+describe('downgradeImagesForTextModel', () => {
+  test('replaces an image block in a tool result with a text placeholder for a text-only model', () => {
+    // Mirrors the production wedge: attachment_fetch inlined a JPEG image block
+    // that text-only MiniMax-M3 rejects with `invalid params (2013)`.
+    const messages: AgentMessage[] = [
+      user('给我看那张图'),
+      toolResultWithImage('call_1', 'attachment_fetch'),
+    ] as AgentMessage[];
+    const out = downgradeImagesForTextModel(messages, false);
+
+    const tr = out[1] as ToolResultMessage;
+    const types = tr.content.map((b) => b.type);
+    assert.deepEqual(types, ['text', 'text']);
+    // Original mime surfaces in the placeholder so the model knows what was there.
+    const placeholder = (tr.content[1] as { text: string }).text;
+    assert.match(placeholder, /image omitted \(image\/jpeg\)/);
+    assert.match(placeholder, /text-only/);
+    // No base64 payload survives into the wire message.
+    assert.ok(!JSON.stringify(out).includes('/9j/4AAQSkZJRg'));
+  });
+
+  test('downgrades image blocks in an array-form user message too', () => {
+    const messages: AgentMessage[] = [userWithImage('hi')] as AgentMessage[];
+    const out = downgradeImagesForTextModel(messages, false);
+    const u = out[0] as UserMessage;
+    const types = (u.content as { type: string }[]).map((b) => b.type);
+    assert.deepEqual(types, ['text', 'text']);
+    assert.ok(!JSON.stringify(out).includes('iVBORw0KGgo'));
+  });
+
+  test('is a no-op (same reference) when the model supports image input', () => {
+    const messages: AgentMessage[] = [
+      toolResultWithImage('call_1', 'attachment_fetch'),
+    ] as AgentMessage[];
+    const out = downgradeImagesForTextModel(messages, true);
+    assert.equal(out, messages);
+  });
+
+  test('returns the same reference when there is no image block to downgrade', () => {
+    const messages: AgentMessage[] = [
+      user('plain text'),
+      toolResult('call_1', 'x'),
+    ] as AgentMessage[];
+    const out = downgradeImagesForTextModel(messages, false);
+    assert.equal(out, messages);
+  });
+
+  test('leaves a string-content user message untouched', () => {
+    const messages: AgentMessage[] = [
+      { role: 'user', content: 'plain string', timestamp: 1 } as unknown as UserMessage,
+      toolResultWithImage('call_1', 'attachment_fetch'),
+    ] as AgentMessage[];
+    const out = downgradeImagesForTextModel(messages, false);
+    assert.equal((out[0] as UserMessage).content, 'plain string');
+    // But the tool-result image is still downgraded.
+    const tr = out[1] as ToolResultMessage;
+    assert.deepEqual(tr.content.map((b) => b.type), ['text', 'text']);
+  });
+
+  test('does not mutate the input messages', () => {
+    const input: AgentMessage[] = [toolResultWithImage('call_1', 'attachment_fetch')] as AgentMessage[];
+    const before = JSON.stringify(input);
+    downgradeImagesForTextModel(input, false);
     assert.equal(JSON.stringify(input), before);
   });
 });


### PR DESCRIPTION
## Problem

Text-only providers (e.g. **MiniMax-M3**) reject any request that carries an image content block — MiniMax returns `400 invalid params (2013)`. Once such a block is in a session's history, **every following turn re-sends it and the session wedges forever**.

This re-wedged **Somiko** (`amiko:cmnxcm8ck000004jxikqwn32r`) on 2026-09-01: 3× `2013` at 04:56–04:59 UTC, all after an `attachment_fetch` tool result inlined a ~1.6 MB base64 JPEG (`{type:"image", data:"/9j/4AAQ…"}`). The 08-28 key swap had moved Somiko onto text-only MiniMax-M3. This is a **different failure mode** from the 08-17 alternation wedge (#257) — `normalizeMessageAlternation` deliberately passes tool-result runs through untouched, so it can't help here.

## The gap

`prepareAttachmentContent` already downgrades **user-message attachments** to a text reference when `supportsImageInput` is false, and the DB-resumption path passes that capability through. But an image can also enter a **live** (non-resumed) session mid-turn via a **tool result** — `attachment_fetch` in image mode, or a `doc_read` image page. That path never runs the attachment-prepare downgrade, so the raw image reaches the provider.

## Fix

Add `downgradeImagesForTextModel`, a **request-only** sibling of `normalizeMessageAlternation`, applied in `transformContext` **after** the live-state write-back. When the resolved model's `input` capabilities don't include `image`, every `{ type: 'image' }` block (in tool results **and** array-form user messages) is replaced with a text placeholder naming the original mime type.

Because it runs on the **wire payload only** (never persisted):
- **#1 (core):** images never reach a text-only provider's request body — covers tool-result images the attachment-prepare path missed.
- **#2 (attachment_fetch):** the `attachment_fetch` / `doc_read` image path is covered for free, model-capability-gated, with no per-tool change and no regression for multimodal models.
- **#3 (unwedge):** a session that already baked an image into its stored history **auto-unwedges on its next turn — no DB surgery.** Full fidelity returns if the agent moves back to a multimodal model.

## Test

6 new unit tests in `message-utils.test.ts` (tool-result image → placeholder, array-form user image, no-op for multimodal models, no-op when no image present, string-content user untouched, input not mutated). Full suite: 38 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with text-only AI models by converting image content into descriptive text placeholders when needed.
  * Images returned by tools are also handled during requests.

* **Bug Fixes**
  * Preserved original conversation history and message data while preparing model-specific requests.
  * Retained image content when supported by the selected model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->