### PR TITLE
fix(agent): pin OpenRouter reasoning format for amiko-proxied models

### DIFF
--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -143,6 +143,16 @@ export const resolveModel = (config: AgentConfig): Model<any> => {
       ? (tryRegistry(priceCatalog, config.model.model) ??
         tryRegistry(priceCatalog, config.model.model.replace(/-\d{8}$/, '')))
       : undefined;
+    // Gateways that proxy OpenRouter (priceCatalog='openrouter') also speak
+    // OpenRouter's reasoning param semantics, but their base URL isn't
+    // openrouter.ai — so pi-ai's compat auto-detection classifies them as plain
+    // "openai" and never emits the nested `reasoning` object. Pin the format so
+    // pi-ai sends `reasoning:{effort:"none"}` when thinking is off (OpenRouter
+    // then suppresses reasoning instead of letting a model's "thought summaries"
+    // bleed into the reply text, e.g. gemini-3) and `reasoning:{effort}` when
+    // it's on (reasoning comes back in its own field → a real thinking block).
+    const compat =
+      priceCatalog === 'openrouter' ? { thinkingFormat: 'openrouter' as const } : undefined;
     return {
       id: config.model.model,
       name: config.model.model,
@@ -154,6 +164,7 @@ export const resolveModel = (config: AgentConfig): Model<any> => {
       cost: priceRef?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: priceRef?.contextWindow ?? 128000,
       maxTokens: config.model.max_tokens ?? priceRef?.maxTokens,
+      ...(compat ? { compat } : {}),
     } as Model<any>;
   }
 

--- a/apps/agent/test/amiko-provider.test.ts
+++ b/apps/agent/test/amiko-provider.test.ts
@@ -78,6 +78,33 @@ test('arbitrary custom providers do not borrow OpenRouter pricing', () => {
   assert.deepEqual(m.cost, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 });
 
+test('amiko models pin OpenRouter reasoning format so thoughts do not leak into content', () => {
+  // The router's base URL is api.heyamiko.com, not openrouter.ai, so pi-ai would
+  // auto-detect thinkingFormat="openai" and never emit the nested `reasoning`
+  // object. Without it, no `reasoning:{effort:"none"}` is sent and models like
+  // gemini-3 return "thought summaries" inline in the reply text.
+  const m = resolveModel(modelConfig('amiko', 'google/gemini-3-flash-preview')) as {
+    compat?: { thinkingFormat?: string };
+  };
+  assert.equal(m.compat?.thinkingFormat, 'openrouter');
+});
+
+test('non-OpenRouter-proxying custom providers are left to pi-ai auto-detection', () => {
+  // No priceCatalog => we must not force a reasoning format the gateway may not
+  // speak; pi-ai detects it from the provider/URL instead.
+  const m = resolveModel(
+    ({
+      model: {
+        provider: 'my-vllm',
+        model: 'some/model',
+        api: 'openai-completions',
+        base_url: 'http://localhost:8000/v1',
+      },
+    } as unknown) as AgentConfig,
+  ) as { compat?: unknown };
+  assert.equal(m.compat, undefined);
+});
+
 // --- dynamic catalog ---
 
 const ROUTER_MODELS_BODY = {


### PR DESCRIPTION
## Problem

Reasoning models routed through the **amiko** gateway (e.g. `google/gemini-3-flash-preview`) leak their **thought summaries into the user-facing reply** (`content`), which reads to users as the model rambling / looping through its own reasoning.

## Root cause

The amiko router is OpenAI-compatible and **proxies OpenRouter** (`priceCatalog:'openrouter'`), so it speaks OpenRouter's `reasoning` param semantics. But its base URL is `api.heyamiko.com`, **not** `openrouter.ai` — so pi-ai's `getCompat` auto-detects `thinkingFormat:"openai"` and **never emits the nested `reasoning` object**. With no reasoning-control param sent, the provider default applies and Gemini returns thought summaries inline in `content`.

Forensic confirmation (openhermit `session_events`): the leaked assistant turns had `thinking` length 0 with 12k+ chars in `content` — i.e. reasoning arrived in the text field, not the `reasoning`/`reasoning_content` field pi-ai already routes to a thinking block.

The amiko-router itself is a passthrough proxy (`Amiko-Layer/amiko-router`: `google/gemini-*` → OpenRouter, no response transform), so the fix belongs on the request side, in openhermit.

## Fix

Pin `compat.thinkingFormat:'openrouter'` on synthesized models whose gateway proxies OpenRouter (`priceCatalog==='openrouter'`). pi-ai then:

- sends `reasoning:{effort:"none"}` when the agent has **no** thinking configured → OpenRouter suppresses reasoning instead of inlining it;
- sends `reasoning:{effort}` when thinking **is** configured → reasoning returns in its own field → a real thinking block, not leaked reply text.

Providers without an OpenRouter `priceCatalog` are left to pi-ai's auto-detection (we must not force a format the gateway may not speak).

## Tests

`apps/agent/test/amiko-provider.test.ts`: asserts amiko models pin `thinkingFormat:'openrouter'`, and non-proxying custom providers do not. Full file 17/17 pass; no new typecheck errors.

## Verify post-deploy

Re-run the `session_events` check on gemini-3 assistant turns — thought prose should stop appearing in `content` (thinking configured → shows up as a thinking block instead; thinking off → gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning-format compatibility for custom models using the OpenRouter pricing catalog.
  * Prevented internal thought summaries from appearing in generated response content.
  * Ensured reasoning settings behave consistently when thinking is enabled or disabled.

* **Tests**
  * Added coverage for Amiko models and custom providers to verify correct reasoning output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->