### PR TITLE
Add Gemini Interactions Tool Retrieval path + Amiko CLI catalog

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -85,6 +85,11 @@ import { withOpenRouterAttribution } from './agent-runner/openrouter-attribution
 import { buildUserFacingModelError } from './agent-runner/user-facing-error.js';
 import { withAmikoTwinAttribution } from './agent-runner/amiko-attribution.js';
 import {
+  createAmikoToolRetrievalToolset,
+  isToolRetrievalModel,
+  withGoogleInteractionsToolRetrieval,
+} from './providers/google-interactions-tool-retrieval.js';
+import {
   awaitTriggeredTurn,
   surfaceRunError,
 } from './agent-runner/scheduled-turn.js';
@@ -2343,6 +2348,23 @@ export class AgentRunner implements SessionRuntime {
       }
 
       tools = toolsFromToolsets(toolsets);
+
+      // Gemini Tool Retrieval models (api: 'google-interactions') must NOT
+      // receive the full OpenHermit toolset — the whole point of tool_search
+      // is a search-gated catalog. Replace the built-in toolsets with the
+      // curated Amiko CLI catalog toolset (tool_search + catalog tools).
+      // Approval wrapping and the policy filter below still apply.
+      let isRetrievalModel = false;
+      try {
+        isRetrievalModel = isToolRetrievalModel(resolveModel(input.config));
+      } catch {
+        isRetrievalModel = false;
+      }
+      if (isRetrievalModel) {
+        const amikoToolset = wrapToolset(createAmikoToolRetrievalToolset());
+        toolsets = [amikoToolset];
+        tools = toolsFromToolsets(toolsets);
+      }
     }
 
     const principal = buildPrincipal(this.scope.agentId, input.userId, input.userRole);
@@ -2563,9 +2585,14 @@ export class AgentRunner implements SessionRuntime {
     const systemPrompt = input.extraSystemPrompt
       ? `${baseSystemPrompt}\n\n${input.extraSystemPrompt}`.trim()
       : baseSystemPrompt;
+    // Tool-retrieval models are re-routed to the Google Interactions API by
+    // the outermost wrapper; every other model passes through untouched.
+    // Langfuse still wraps the whole chain so those turns are traced too.
     const streamFn = createLangfuseTracedStreamFn(
       this.options.langfuse,
-      withOpenRouterAttribution(withAmikoTwinAttribution(this.options.streamFn)),
+      withGoogleInteractionsToolRetrieval(
+        withOpenRouterAttribution(withAmikoTwinAttribution(this.options.streamFn)),
+      ),
       input.langfuseTurnContext ?? { currentTrace: undefined },
     );
 

--- a/apps/agent/src/agent-runner/model-utils.ts
+++ b/apps/agent/src/agent-runner/model-utils.ts
@@ -71,6 +71,25 @@ const minimaxM3 = (provider: string, baseUrl: string): Model<any> => ({
 } as Model<any>);
 
 const LOCAL_MODELS: Record<string, Model<any>> = {
+  // Confidential Google EAP model served ONLY by the Interactions API
+  // (/v1beta/interactions) with client-side tool_search. The 'google-interactions'
+  // api value routes it through the dedicated adapter in
+  // providers/google-interactions-tool-retrieval.ts instead of pi-ai's
+  // generateContent path (issue #262). Secrets: GEMINI_API_KEY / GOOGLE_API_KEY.
+  // The EAP endpoint host is NOT public — it must be supplied per deployment
+  // via config.model.base_url or GOOGLE_INTERACTIONS_BASE_URL; the adapter
+  // refuses to guess.
+  'google/gemini-flash-tool-retrieval': {
+    id: 'gemini-flash-tool-retrieval',
+    name: 'Gemini Flash (Tool Retrieval EAP)',
+    api: 'google-interactions',
+    provider: 'google',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 8192,
+  } as Model<any>,
   'minimax/MiniMax-M3': minimaxM3('minimax', 'https://api.minimax.io/anthropic'),
   'minimax-cn/MiniMax-M3': minimaxM3('minimax-cn', 'https://api.minimaxi.com/anthropic'),
   // OpenRouter routes MiniMax under the lowercase, slashed id and an

--- a/apps/agent/src/providers/google-interactions-tool-retrieval.ts
+++ b/apps/agent/src/providers/google-interactions-tool-retrieval.ts
@@ -1,0 +1,506 @@
+import type { StreamFn, AgentTool } from '@mariozechner/pi-agent-core';
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Context,
+  type Message,
+  type Model,
+  type ThinkingContent,
+  type TextContent,
+  type ToolCall,
+} from '@mariozechner/pi-ai';
+import type { TSchema } from 'typebox';
+
+import type { Toolset } from '../tools/shared.js';
+import { asTextContent } from '../tools/shared.js';
+import {
+  AMIKO_CLI_CATALOG,
+  getCatalogEntry,
+  runAmikoTool,
+  searchCatalog,
+  toFunctionDeclaration,
+  type FunctionDeclaration,
+} from '../tools/amiko-cli-catalog.js';
+
+/**
+ * Google Interactions API adapter with client-side Tool Retrieval
+ * (`tool_search`) over the Amiko CLI catalog.
+ *
+ * Context (issue #262): the EAP model `gemini-flash-tool-retrieval` requires
+ * the Interactions API (`/v1beta/interactions`) — pi-ai's google provider only
+ * speaks generateContent, and OpenHermit's default loop dumps every built-in
+ * tool schema each turn, which defeats Tool Retrieval. This adapter:
+ *
+ * - replaces the transport for models with `api: 'google-interactions'` via a
+ *   composable StreamFn wrapper (pi-agent-core still runs the tool loop, so
+ *   session events, persistence, approval gating, and Langfuse tracing are
+ *   unchanged);
+ * - advertises ONLY `tool_search` (execution: "client") to the model, plus the
+ *   function declarations already surfaced by earlier `amiko_tool_search`
+ *   results in this context — never the full OpenHermit toolset;
+ * - runs stateless (`store: false`), replaying the full step history each call
+ *   and round-tripping thought signatures via pi-ai's `thinkingSignature` /
+ *   `thoughtSignature` fields.
+ *
+ * Server-side `defer_loading: true` with full parameters is known to 400 on
+ * this EAP model — do not add it here; client-side execution is the supported
+ * mode until Google fixes it.
+ */
+
+/** `AgentModelConfig.api` value that routes a model through this adapter. */
+export const GOOGLE_INTERACTIONS_API = 'google-interactions';
+
+export const TOOL_SEARCH_NAME = 'amiko_tool_search';
+
+const API_REVISION = '2026-05-20';
+
+export const isToolRetrievalModel = (model: { api?: string }): boolean =>
+  model.api === GOOGLE_INTERACTIONS_API;
+
+// --- local toolset -----------------------------------------------------------
+
+interface ToolSearchDetails {
+  declarations: FunctionDeclaration[];
+}
+
+/**
+ * The `amiko_tool_search` result content is the JSON the Interactions loop
+ * sends back in `function_result.result` — an array of FunctionDeclarations.
+ * The stream adapter also re-reads it from history to know which catalog
+ * tools are unlocked for subsequent turns.
+ */
+const createToolSearchTool = (): AgentTool<TSchema, ToolSearchDetails> => ({
+  name: TOOL_SEARCH_NAME,
+  label: 'Amiko Tool Search',
+  description:
+    'Search the Amiko CLI tool catalog. Returns function declarations for matching tools, which become callable on the next turn.',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'What kind of tool you are looking for.' },
+      limit: { type: 'number', description: 'Maximum number of tools to return (default 8).' },
+    },
+    required: ['query'],
+  } as unknown as TSchema,
+  execute: async (_toolCallId, params: unknown) => {
+    const { query, limit } = (params ?? {}) as { query?: string; limit?: number };
+    const declarations = searchCatalog(query ?? '', limit ?? 8).map(toFunctionDeclaration);
+    return {
+      content: asTextContent(JSON.stringify({ tools: declarations })),
+      details: { declarations },
+    };
+  },
+});
+
+const createCatalogTool = (name: string): AgentTool<TSchema> => {
+  const entry = getCatalogEntry(name)!;
+  return {
+    name: entry.name,
+    label: entry.name,
+    description: entry.description,
+    parameters: entry.parameters as unknown as TSchema,
+    execute: async (_toolCallId, params: unknown, signal?: AbortSignal) => {
+      const result = await runAmikoTool(entry.name, (params ?? {}) as Record<string, unknown>, {
+        ...(signal ? { signal } : {}),
+      });
+      const body = result.exitCode === 0
+        ? result.stdout.trim() || '(no output)'
+        : `Command failed (exit ${result.exitCode}).\nstdout:\n${result.stdout.trim()}\nstderr:\n${result.stderr.trim()}`;
+      return {
+        content: asTextContent(body),
+        details: { command: result.command, exitCode: result.exitCode },
+      };
+    },
+  };
+};
+
+const AMIKO_TOOLSET_DESCRIPTION = `\
+### Amiko CLI (Tool Retrieval)
+
+Tools for the Amiko platform are discovered at runtime: call \`${TOOL_SEARCH_NAME}\` with a
+description of what you need (e.g. "credits balance"), then call the returned tools.`;
+
+/**
+ * Toolset installed in the agent's state for tool-retrieval models. All
+ * catalog tools are registered so pi-agent-core can execute whatever the
+ * model calls — but the stream adapter only ADVERTISES tool_search plus
+ * already-searched declarations to the API.
+ */
+export const createAmikoToolRetrievalToolset = (): Toolset => ({
+  id: 'amiko-cli-tool-retrieval',
+  description: AMIKO_TOOLSET_DESCRIPTION,
+  tools: [
+    { ...createToolSearchTool(), policy: { defaultGrants: [{ type: 'any' }] } },
+    ...AMIKO_CLI_CATALOG.map((entry) => ({
+      ...createCatalogTool(entry.name),
+      // Mutating commands (chat send, …) default to owner-only; readonly ones are open.
+      policy: entry.readonly
+        ? { defaultGrants: [{ type: 'any' as const }] }
+        : { defaultGrants: [{ type: 'role' as const, value: 'owner' as const }] },
+    })),
+  ],
+});
+
+// --- message mapping ---------------------------------------------------------
+
+type InteractionStep = Record<string, unknown>;
+
+const textBlocks = (content: UserContent): Array<{ type: 'text'; text: string }> => {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return content
+    .filter((b): b is TextContent => b.type === 'text')
+    .map((b) => ({ type: 'text' as const, text: b.text }));
+};
+
+type UserContent = string | Array<TextContent | { type: string; [k: string]: unknown }>;
+
+/**
+ * Map pi-ai transcript messages to Interactions steps (stateless replay).
+ * Thought signatures ride along: `thinking` blocks carry `thinkingSignature`,
+ * tool calls carry `thoughtSignature`; both were captured verbatim from
+ * earlier Interactions responses by `parseInteractionSteps`.
+ *
+ * Image/attachment content is dropped with a placeholder — this EAP smoke
+ * path is text-only.
+ */
+export const mapMessagesToSteps = (messages: Message[]): InteractionStep[] => {
+  const steps: InteractionStep[] = [];
+  for (const message of messages) {
+    if (message.role === 'user') {
+      steps.push({
+        type: 'user_input',
+        content: textBlocks(message.content as UserContent),
+      });
+    } else if (message.role === 'assistant') {
+      for (const block of message.content) {
+        if (block.type === 'thinking') {
+          const t = block as ThinkingContent;
+          // Signature is required by the API for replayed thoughts; a thought
+          // captured without one cannot be replayed and is skipped.
+          if (!t.thinkingSignature) continue;
+          steps.push({
+            type: 'thought',
+            ...(t.thinking ? { summary: t.thinking } : {}),
+            signature: t.thinkingSignature,
+          });
+        } else if (block.type === 'text') {
+          steps.push({
+            type: 'model_output',
+            content: [{ type: 'text', text: (block as TextContent).text }],
+          });
+        } else if (block.type === 'toolCall') {
+          const call = block as ToolCall;
+          steps.push({
+            type: 'function_call',
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments ?? {},
+            ...(call.thoughtSignature ? { signature: call.thoughtSignature } : {}),
+          });
+        }
+      }
+    } else if (message.role === 'toolResult') {
+      steps.push({
+        type: 'function_result',
+        name: message.toolName,
+        call_id: message.toolCallId,
+        result: textBlocks(message.content as UserContent),
+      });
+    }
+  }
+  return steps;
+};
+
+/**
+ * Names of catalog tools already surfaced by `amiko_tool_search` results in
+ * this transcript. Only these (plus tool_search itself) are advertised.
+ */
+export const collectUnlockedToolNames = (messages: Message[]): string[] => {
+  const names = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== 'toolResult' || message.toolName !== TOOL_SEARCH_NAME) continue;
+    for (const block of message.content) {
+      if (block.type !== 'text') continue;
+      try {
+        const parsed = JSON.parse(block.text) as { tools?: Array<{ name?: string }> };
+        for (const tool of parsed.tools ?? []) {
+          if (tool.name && getCatalogEntry(tool.name)) names.add(tool.name);
+        }
+      } catch {
+        // Not JSON (e.g. an error result) — nothing unlocked by this block.
+      }
+    }
+  }
+  return [...names];
+};
+
+/** Client-side tool_search declaration sent every turn. */
+const toolSearchDeclaration = (): Record<string, unknown> => ({
+  type: 'tool_search',
+  execution: 'client',
+  name: TOOL_SEARCH_NAME,
+  description:
+    'Search the Amiko CLI tool catalog for tools matching a natural-language need. '
+    + 'Returns function declarations that become callable afterwards.',
+});
+
+export const buildInteractionsRequest = (
+  model: Model<never> | { id: string },
+  context: Context,
+  options?: { maxTokens?: number },
+): Record<string, unknown> => {
+  const unlocked = collectUnlockedToolNames(context.messages);
+  const declarations = unlocked
+    .map((name) => getCatalogEntry(name))
+    .filter((e): e is NonNullable<typeof e> => Boolean(e))
+    .map(toFunctionDeclaration);
+  return {
+    model: (model as { id: string }).id,
+    store: false,
+    ...(context.systemPrompt ? { system_instruction: context.systemPrompt } : {}),
+    input: mapMessagesToSteps(context.messages),
+    tools: [toolSearchDeclaration(), ...declarations],
+    ...(options?.maxTokens
+      ? { generation_config: { max_output_tokens: options.maxTokens } }
+      : {}),
+  };
+};
+
+// --- response parsing --------------------------------------------------------
+
+interface InteractionResponse {
+  id?: string;
+  status?: string;
+  steps?: InteractionStep[];
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: unknown;
+}
+
+export const parseInteractionSteps = (
+  response: InteractionResponse,
+  base: { provider: string; model: string },
+): AssistantMessage => {
+  const content: AssistantMessage['content'] = [];
+  for (const step of response.steps ?? []) {
+    const type = step.type as string;
+    if (type === 'thought') {
+      content.push({
+        type: 'thinking',
+        thinking: typeof step.summary === 'string' ? step.summary : '',
+        ...(typeof step.signature === 'string' ? { thinkingSignature: step.signature } : {}),
+      } as ThinkingContent);
+    } else if (type === 'model_output') {
+      const blocks = Array.isArray(step.content) ? step.content : [];
+      for (const block of blocks as Array<{ type?: string; text?: string }>) {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          content.push({ type: 'text', text: block.text });
+        }
+      }
+    } else if (type === 'function_call') {
+      content.push({
+        type: 'toolCall',
+        id: typeof step.id === 'string' ? step.id : `call_${Math.random().toString(36).slice(2)}`,
+        name: String(step.name ?? ''),
+        arguments: (step.arguments ?? {}) as Record<string, unknown>,
+        ...(typeof step.signature === 'string' ? { thoughtSignature: step.signature } : {}),
+      } as ToolCall);
+    }
+    // user_input / function_result steps in the echo (if any) are replay, not output.
+  }
+
+  const usage = response.usage ?? {};
+  const input = usage.input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  const hasToolCall = content.some((b) => b.type === 'toolCall');
+  return {
+    role: 'assistant',
+    content,
+    api: GOOGLE_INTERACTIONS_API as never,
+    provider: base.provider as never,
+    model: base.model,
+    ...(response.id ? { responseId: response.id } : {}),
+    usage: {
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: usage.total_tokens ?? input + output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: hasToolCall ? 'toolUse' : 'stop',
+    timestamp: Date.now(),
+  };
+};
+
+// --- stream adapter ----------------------------------------------------------
+
+export interface GoogleInteractionsOptions {
+  /** Injectable fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override API host (default generativelanguage.googleapis.com). */
+  baseUrl?: string;
+}
+
+const errorMessageFor = (
+  base: { provider: string; model: string },
+  errorMessage: string,
+  reason: 'error' | 'aborted' = 'error',
+): AssistantMessage => ({
+  role: 'assistant',
+  content: [],
+  api: GOOGLE_INTERACTIONS_API as never,
+  provider: base.provider as never,
+  model: base.model,
+  usage: {
+    input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: reason,
+  errorMessage,
+  timestamp: Date.now(),
+});
+
+/**
+ * Wrap a StreamFn so tool-retrieval models are served over the Interactions
+ * API. All other models pass through to the wrapped function untouched, so
+ * this composes with the existing Langfuse/attribution wrapper chain.
+ */
+export const withGoogleInteractionsToolRetrieval = (
+  base: StreamFn,
+  adapterOptions: GoogleInteractionsOptions = {},
+): StreamFn => {
+  return (model, context, options) => {
+    if (!isToolRetrievalModel(model as { api?: string })) {
+      return base(model, context, options);
+    }
+
+    const stream = createAssistantMessageEventStream();
+    const fetchImpl = adapterOptions.fetchImpl ?? fetch;
+    // The EAP Interactions endpoint host is deployment-specific — never guess.
+    // Sources, in order: adapter option (tests), model.baseUrl (config.model.
+    // base_url), GOOGLE_INTERACTIONS_BASE_URL env.
+    const configuredBaseUrl = adapterOptions.baseUrl
+      ?? (model as { baseUrl?: string }).baseUrl
+      ?? process.env.GOOGLE_INTERACTIONS_BASE_URL;
+    const modelBase = {
+      provider: String((model as { provider?: string }).provider ?? 'google'),
+      model: String((model as { id?: string }).id ?? 'gemini-flash-tool-retrieval'),
+    };
+
+    void (async () => {
+      try {
+        if (!configuredBaseUrl) {
+          stream.push({
+            type: 'error',
+            reason: 'error',
+            error: errorMessageFor(
+              modelBase,
+              'No Interactions endpoint configured for this EAP model. Set config.model.base_url or the GOOGLE_INTERACTIONS_BASE_URL environment variable to the endpoint host provided with your EAP access.',
+            ),
+          });
+          return;
+        }
+        const baseUrl = configuredBaseUrl.replace(/\/+$/, '');
+        const apiKey = options?.apiKey
+          ?? process.env.GEMINI_API_KEY
+          ?? process.env.GOOGLE_API_KEY;
+        if (!apiKey) {
+          stream.push({
+            type: 'error',
+            reason: 'error',
+            error: errorMessageFor(modelBase, 'Missing Google API key (GEMINI_API_KEY / GOOGLE_API_KEY) for the Interactions API.'),
+          });
+          return;
+        }
+
+        const request = buildInteractionsRequest(model as { id: string }, context, {
+          ...(options?.maxTokens ? { maxTokens: options.maxTokens } : {}),
+        });
+
+        // A bare host gets the documented path appended; a URL already ending
+        // in /interactions is used verbatim (EAP endpoints may differ).
+        const endpoint = /\/interactions\/?$/.test(baseUrl)
+          ? baseUrl
+          : `${baseUrl}/v1beta/interactions`;
+        const response = await fetchImpl(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': apiKey,
+            'Api-Revision': API_REVISION,
+            ...(options?.headers ?? {}),
+          },
+          body: JSON.stringify(request),
+          ...(options?.signal ? { signal: options.signal } : {}),
+        });
+
+        if (!response.ok) {
+          const bodyText = await response.text().catch(() => '');
+          stream.push({
+            type: 'error',
+            reason: 'error',
+            error: errorMessageFor(
+              modelBase,
+              `Interactions API error ${response.status}: ${bodyText.slice(0, 2000)}`,
+            ),
+          });
+          return;
+        }
+
+        const payload = (await response.json()) as InteractionResponse;
+        if (payload.status === 'failed') {
+          stream.push({
+            type: 'error',
+            reason: 'error',
+            error: errorMessageFor(modelBase, `Interaction failed: ${JSON.stringify(payload.error ?? payload).slice(0, 2000)}`),
+          });
+          return;
+        }
+
+        const message = parseInteractionSteps(payload, modelBase);
+        // Non-streaming under the hood: replay the parsed message as protocol
+        // events so downstream consumers (session events, UI) see the usual
+        // start → block start/end → done sequence.
+        stream.push({ type: 'start', partial: { ...message, content: [] } });
+        message.content.forEach((block, contentIndex) => {
+          if (block.type === 'text') {
+            stream.push({ type: 'text_start', contentIndex, partial: message });
+            stream.push({ type: 'text_delta', contentIndex, delta: block.text, partial: message });
+            stream.push({ type: 'text_end', contentIndex, content: block.text, partial: message });
+          } else if (block.type === 'thinking') {
+            stream.push({ type: 'thinking_start', contentIndex, partial: message });
+            if (block.thinking) {
+              stream.push({ type: 'thinking_delta', contentIndex, delta: block.thinking, partial: message });
+            }
+            stream.push({ type: 'thinking_end', contentIndex, content: block.thinking, partial: message });
+          } else if (block.type === 'toolCall') {
+            stream.push({ type: 'toolcall_start', contentIndex, partial: message });
+            stream.push({ type: 'toolcall_end', contentIndex, toolCall: block, partial: message });
+          }
+        });
+        stream.push({
+          type: 'done',
+          reason: message.stopReason as 'stop' | 'toolUse',
+          message,
+        });
+      } catch (error) {
+        const aborted = error instanceof Error && error.name === 'AbortError';
+        stream.push({
+          type: 'error',
+          reason: aborted ? 'aborted' : 'error',
+          error: errorMessageFor(
+            modelBase,
+            error instanceof Error ? error.message : String(error),
+            aborted ? 'aborted' : 'error',
+          ),
+        });
+      }
+    })();
+
+    return stream;
+  };
+};

--- a/apps/agent/src/tools/amiko-cli-catalog.ts
+++ b/apps/agent/src/tools/amiko-cli-catalog.ts
@@ -1,0 +1,412 @@
+import { execFile } from 'node:child_process';
+
+/**
+ * Amiko CLI tool catalog for Gemini Tool Retrieval (client-side tool_search).
+ *
+ * Each entry maps one readonly-leaning Amiko CLI subcommand to a function
+ * declaration the model can discover via `amiko_tool_search` and then call.
+ * Execution shells out to the `amiko` binary (configurable via AMIKO_BIN;
+ * AMIKO_CWD selects the directory whose `.amiko.json` provides twin auth).
+ * Tokens/secrets are never part of argv — auth is resolved by the CLI itself
+ * from its config file / environment.
+ */
+
+export interface AmikoCatalogEntry {
+  /** Tool name exposed to the model, e.g. `amiko_credits_balance`. */
+  name: string;
+  description: string;
+  /** JSON-schema parameters object (Interactions function declaration shape). */
+  parameters: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  /** Build the amiko CLI argv (without the binary) from validated args. */
+  argv: (args: Record<string, unknown>) => string[];
+  /** True when the command only reads state. Mutating entries are excluded from the default smoke. */
+  readonly: boolean;
+  /** Extra keywords to boost search matching beyond name/description tokens. */
+  keywords?: string[];
+}
+
+const str = (v: unknown): string => String(v ?? '');
+
+const opt = (args: Record<string, unknown>, key: string, flag: string): string[] =>
+  args[key] === undefined || args[key] === null || args[key] === '' ? [] : [flag, str(args[key])];
+
+const limitParam = {
+  limit: { type: 'number', description: 'Maximum number of rows to return.' },
+};
+
+export const AMIKO_CLI_CATALOG: AmikoCatalogEntry[] = [
+  {
+    name: 'amiko_version',
+    description: 'Show the installed Amiko CLI version.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['--version'],
+    readonly: true,
+    keywords: ['version', 'cli', 'release', 'build'],
+  },
+  {
+    name: 'amiko_credits_balance',
+    description: 'Show the twin\'s Amiko credit balance (10,000 credits = $1).',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['credits', 'balance'],
+    readonly: true,
+    keywords: ['credits', 'balance', 'money', 'funds', 'account'],
+  },
+  {
+    name: 'amiko_accounts',
+    description: 'Show resolved identity: platform, user id, twin id, and wallets.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['accounts'],
+    readonly: true,
+    keywords: ['identity', 'whoami', 'account', 'twin', 'user'],
+  },
+  {
+    name: 'amiko_info',
+    description: 'Get twin info: name, description, voice ids, avatar.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['info'],
+    readonly: true,
+    keywords: ['twin', 'profile', 'about'],
+  },
+  {
+    name: 'amiko_config_show',
+    description: 'Show resolved CLI configuration (from .amiko.json). Secrets are managed by the CLI.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['config'],
+    readonly: true,
+    keywords: ['config', 'settings', 'setup'],
+  },
+  {
+    name: 'amiko_wallets_list',
+    description: 'List wallets for the authenticated twin (addresses and chains).',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['wallets', 'list'],
+    readonly: true,
+    keywords: ['wallet', 'solana', 'base', 'address', 'crypto'],
+  },
+  {
+    name: 'amiko_wallets_balance',
+    description: 'Sync and show token balances for a single twin wallet address.',
+    parameters: {
+      type: 'object',
+      properties: {
+        address: { type: 'string', description: 'Wallet address (Solana or Base).' },
+      },
+      required: ['address'],
+    },
+    argv: (a) => ['wallets', 'balance', str(a.address)],
+    readonly: true,
+    keywords: ['wallet', 'balance', 'tokens', 'sol', 'usdc'],
+  },
+  {
+    name: 'amiko_chat_list',
+    description: 'List the owner\'s conversations (DMs and group chats).',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['chat', 'list', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['chat', 'conversations', 'messages', 'dm', 'group'],
+  },
+  {
+    name: 'amiko_chat_read',
+    description: 'Read recent messages in a conversation (by conversation id, user id, @handle, or name).',
+    parameters: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', description: 'Conversation id, user id, @handle, or name.' },
+        ...limitParam,
+      },
+      required: ['target'],
+    },
+    argv: (a) => ['chat', 'read', str(a.target), ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['chat', 'read', 'messages', 'history'],
+  },
+  {
+    name: 'amiko_chat_send',
+    description: 'Send a chat message as the owner to a conversation or person.',
+    parameters: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', description: 'Conversation id, user id, @handle, or name.' },
+        message: { type: 'string', description: 'Message text to send.' },
+      },
+      required: ['target', 'message'],
+    },
+    argv: (a) => ['chat', 'send', str(a.target), str(a.message)],
+    readonly: false,
+    keywords: ['chat', 'send', 'message', 'reply'],
+  },
+  {
+    name: 'amiko_drive_list',
+    description: 'List twin drive files, optionally filtered by folder or search term.',
+    parameters: {
+      type: 'object',
+      properties: {
+        folder: { type: 'string', description: 'Folder to list.' },
+        ...limitParam,
+      },
+    },
+    argv: (a) => ['drive', 'list', ...opt(a, 'folder', '--folder'), ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['drive', 'files', 'docs', 'documents', 'storage'],
+  },
+  {
+    name: 'amiko_drive_search',
+    description: 'Search drive files by name, description, or parsed content.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query.' },
+        ...limitParam,
+      },
+      required: ['query'],
+    },
+    argv: (a) => ['drive', 'search', str(a.query), ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['drive', 'search', 'files', 'rag'],
+  },
+  {
+    name: 'amiko_drive_get',
+    description: 'Show one drive file\'s metadata, parsed content, and signed URL.',
+    parameters: {
+      type: 'object',
+      properties: { doc_id: { type: 'string', description: 'Drive document id.' } },
+      required: ['doc_id'],
+    },
+    argv: (a) => ['drive', 'get', str(a.doc_id)],
+    readonly: true,
+    keywords: ['drive', 'file', 'metadata', 'download'],
+  },
+  {
+    name: 'amiko_friends_list',
+    description: 'List the twin owner\'s friends.',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['friends', 'list', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['friends', 'social', 'contacts'],
+  },
+  {
+    name: 'amiko_friends_requests',
+    description: 'List pending friend requests (incoming and outgoing).',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['friends', 'requests'],
+    readonly: true,
+    keywords: ['friends', 'requests', 'pending', 'invitations'],
+  },
+  {
+    name: 'amiko_friends_matches',
+    description: 'List friend matches suggested for the owner.',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['friends', 'matches', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['friends', 'matches', 'matchmaking', 'suggestions'],
+  },
+  {
+    name: 'amiko_users_search',
+    description: 'Search Amiko users by name or handle.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Name or handle to search for.' },
+        ...limitParam,
+      },
+      required: ['query'],
+    },
+    argv: (a) => ['users', 'search', str(a.query), ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['users', 'people', 'search', 'handle'],
+  },
+  {
+    name: 'amiko_users_profile',
+    description: 'View a user\'s public profile by handle.',
+    parameters: {
+      type: 'object',
+      properties: { handle: { type: 'string', description: 'User handle, with or without @.' } },
+      required: ['handle'],
+    },
+    argv: (a) => ['users', 'profile', str(a.handle)],
+    readonly: true,
+    keywords: ['users', 'profile', 'public'],
+  },
+  {
+    name: 'amiko_notifications_list',
+    description: 'List platform notifications (friend requests, system alerts, activity).',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['notifications', 'list', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['notifications', 'alerts', 'activity', 'inbox'],
+  },
+  {
+    name: 'amiko_memory_list',
+    description: 'List the caller\'s cross-agent memories, newest first.',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['memory', 'list', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['memory', 'memories', 'recall'],
+  },
+  {
+    name: 'amiko_memory_search',
+    description: 'Hybrid search across the caller\'s cross-agent memories.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query.' },
+        ...limitParam,
+      },
+      required: ['query'],
+    },
+    argv: (a) => ['memory', 'search', str(a.query), ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['memory', 'search', 'recall'],
+  },
+  {
+    name: 'amiko_memory_status',
+    description: 'Show counts of memories and uploaded memory files.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['memory', 'status'],
+    readonly: true,
+    keywords: ['memory', 'status', 'counts'],
+  },
+  {
+    name: 'amiko_feed',
+    description: 'Get recent feed posts.',
+    parameters: { type: 'object', properties: { ...limitParam } },
+    argv: (a) => ['feed', ...opt(a, 'limit', '--limit')],
+    readonly: true,
+    keywords: ['feed', 'posts', 'timeline', 'social'],
+  },
+  {
+    name: 'amiko_markets_discover',
+    description: 'Show MPP marketplace service info, endpoints, and pricing.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['markets', 'discover'],
+    readonly: true,
+    keywords: ['markets', 'marketplace', 'mpp', 'services', 'pricing'],
+  },
+  {
+    name: 'amiko_markets_ping',
+    description: 'Check whether the MPP marketplace service is online.',
+    parameters: { type: 'object', properties: {} },
+    argv: () => ['markets', 'ping'],
+    readonly: true,
+    keywords: ['markets', 'ping', 'health', 'online'],
+  },
+];
+
+const byName = new Map(AMIKO_CLI_CATALOG.map((e) => [e.name, e]));
+
+export const getCatalogEntry = (name: string): AmikoCatalogEntry | undefined => byName.get(name);
+
+/** Interactions-API function declaration shape for a catalog entry. */
+export interface FunctionDeclaration {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: AmikoCatalogEntry['parameters'];
+}
+
+export const toFunctionDeclaration = (entry: AmikoCatalogEntry): FunctionDeclaration => ({
+  type: 'function',
+  name: entry.name,
+  description: entry.description,
+  parameters: entry.parameters,
+});
+
+const tokenize = (text: string): string[] =>
+  text.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 1);
+
+/**
+ * Rank catalog entries against a free-text query by token overlap over
+ * name, description, and keywords. Deliberately simple and deterministic —
+ * the model refines with follow-up searches when the first page misses.
+ */
+export const searchCatalog = (query: string, limit = 8): AmikoCatalogEntry[] => {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return AMIKO_CLI_CATALOG.slice(0, limit);
+  const scored = AMIKO_CLI_CATALOG.map((entry) => {
+    const haystackTokens = new Set([
+      ...tokenize(entry.name),
+      ...tokenize(entry.description),
+      ...(entry.keywords ?? []).flatMap(tokenize),
+    ]);
+    let score = 0;
+    for (const qt of queryTokens) {
+      if (haystackTokens.has(qt)) score += 2;
+      else if ([...haystackTokens].some((ht) => ht.startsWith(qt) || qt.startsWith(ht))) score += 1;
+    }
+    return { entry, score };
+  });
+  return scored
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.name.localeCompare(b.entry.name))
+    .slice(0, limit)
+    .map((s) => s.entry);
+};
+
+export interface RunAmikoOptions {
+  /** Path to the amiko binary. Default: env AMIKO_BIN, else `amiko` from PATH. */
+  bin?: string;
+  /** Working directory (where `.amiko.json` lives). Default: env AMIKO_CWD, else process cwd. */
+  cwd?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface RunAmikoResult {
+  command: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Execute a catalog tool by shelling out to the Amiko CLI. argv is built by
+ * the entry's own mapper — arguments are passed via execFile (no shell), so
+ * user-controlled values cannot inject commands.
+ */
+export const runAmikoTool = (
+  name: string,
+  args: Record<string, unknown>,
+  options: RunAmikoOptions = {},
+): Promise<RunAmikoResult> => {
+  const entry = byName.get(name);
+  if (!entry) return Promise.reject(new Error(`Unknown Amiko catalog tool: ${name}`));
+  const argv = entry.argv(args ?? {});
+  const bin = options.bin ?? process.env.AMIKO_BIN ?? 'amiko';
+  const cwd = options.cwd ?? process.env.AMIKO_CWD ?? process.cwd();
+  const timeout = options.timeoutMs ?? 60_000;
+  // `.js` entrypoints (a pinned checkout build) run through node explicitly so
+  // AMIKO_BIN doesn't depend on the file's executable bit or shebang.
+  const [file, prefix] = bin.endsWith('.js')
+    ? [process.execPath, [bin]]
+    : [bin, [] as string[]];
+  return new Promise((resolve) => {
+    execFile(
+      file,
+      [...prefix, ...argv],
+      {
+        cwd,
+        timeout,
+        maxBuffer: 4 * 1024 * 1024,
+        ...(options.signal ? { signal: options.signal } : {}),
+        env: process.env,
+      },
+      (error, stdout, stderr) => {
+        const exitCode = error
+          ? typeof (error as NodeJS.ErrnoException & { code?: unknown }).code === 'number'
+            ? ((error as unknown as { code: number }).code)
+            : 1
+          : 0;
+        resolve({
+          command: ['amiko', ...argv].join(' '),
+          exitCode,
+          stdout: String(stdout ?? ''),
+          stderr: error && !stderr ? String(error.message) : String(stderr ?? ''),
+        });
+      },
+    );
+  });
+};

--- a/apps/agent/test/amiko-cli-catalog.test.ts
+++ b/apps/agent/test/amiko-cli-catalog.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AMIKO_CLI_CATALOG,
+  getCatalogEntry,
+  runAmikoTool,
+  searchCatalog,
+  toFunctionDeclaration,
+} from '../src/tools/amiko-cli-catalog.js';
+
+test('catalog entries have unique names and valid parameter schemas', () => {
+  const names = new Set<string>();
+  for (const entry of AMIKO_CLI_CATALOG) {
+    assert.ok(!names.has(entry.name), `duplicate catalog name: ${entry.name}`);
+    names.add(entry.name);
+    assert.match(entry.name, /^amiko_[a-z0-9_]+$/);
+    assert.equal(entry.parameters.type, 'object');
+    assert.ok(entry.description.length > 0);
+  }
+  // Readonly-leaning: the vast majority of the catalog must be readonly.
+  const mutating = AMIKO_CLI_CATALOG.filter((e) => !e.readonly);
+  assert.ok(mutating.length <= 2, `too many mutating entries: ${mutating.map((e) => e.name).join(', ')}`);
+});
+
+test('searchCatalog finds credits balance for a balance query', () => {
+  const results = searchCatalog('what is my credits balance');
+  assert.ok(results.length > 0);
+  assert.equal(results[0]!.name, 'amiko_credits_balance');
+});
+
+test('searchCatalog finds the version tool', () => {
+  const results = searchCatalog('cli version');
+  assert.ok(results.some((r) => r.name === 'amiko_version'));
+});
+
+test('searchCatalog is bounded by limit and returns nothing meaningless for gibberish', () => {
+  assert.ok(searchCatalog('wallet chat drive friends', 3).length <= 3);
+  assert.equal(searchCatalog('zzqqxx').length, 0);
+});
+
+test('argv mapping: required and optional args', () => {
+  assert.deepEqual(getCatalogEntry('amiko_credits_balance')!.argv({}), ['credits', 'balance']);
+  assert.deepEqual(getCatalogEntry('amiko_version')!.argv({}), ['--version']);
+  assert.deepEqual(
+    getCatalogEntry('amiko_chat_read')!.argv({ target: '@mars', limit: 5 }),
+    ['chat', 'read', '@mars', '--limit', '5'],
+  );
+  assert.deepEqual(
+    getCatalogEntry('amiko_drive_search')!.argv({ query: 'tax report' }),
+    ['drive', 'search', 'tax report'],
+  );
+  assert.deepEqual(
+    getCatalogEntry('amiko_wallets_balance')!.argv({ address: 'Gu2b...' }),
+    ['wallets', 'balance', 'Gu2b...'],
+  );
+});
+
+test('toFunctionDeclaration produces the Interactions function shape', () => {
+  const decl = toFunctionDeclaration(getCatalogEntry('amiko_users_search')!);
+  assert.equal(decl.type, 'function');
+  assert.equal(decl.name, 'amiko_users_search');
+  assert.deepEqual(decl.parameters.required, ['query']);
+});
+
+test('runAmikoTool rejects unknown tools and reports failures without throwing', async () => {
+  await assert.rejects(runAmikoTool('amiko_nope', {}), /Unknown Amiko catalog tool/);
+  const result = await runAmikoTool('amiko_version', {}, {
+    bin: '/nonexistent/amiko-binary',
+    timeoutMs: 5_000,
+  });
+  assert.notEqual(result.exitCode, 0);
+  assert.equal(result.command, 'amiko --version');
+  assert.ok(result.stderr.length > 0);
+});

--- a/apps/agent/test/google-interactions-tool-retrieval.test.ts
+++ b/apps/agent/test/google-interactions-tool-retrieval.test.ts
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { Context, Message, Model } from '@mariozechner/pi-ai';
+
+import {
+  buildInteractionsRequest,
+  collectUnlockedToolNames,
+  createAmikoToolRetrievalToolset,
+  GOOGLE_INTERACTIONS_API,
+  isToolRetrievalModel,
+  mapMessagesToSteps,
+  parseInteractionSteps,
+  TOOL_SEARCH_NAME,
+  withGoogleInteractionsToolRetrieval,
+} from '../src/providers/google-interactions-tool-retrieval.js';
+
+const MODEL = {
+  id: 'gemini-flash-tool-retrieval',
+  name: 'Gemini Flash (Tool Retrieval EAP)',
+  api: GOOGLE_INTERACTIONS_API,
+  provider: 'google',
+  baseUrl: 'https://interactions.example.test',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000000,
+  maxTokens: 8192,
+} as unknown as Model<never>;
+
+const userMessage = (text: string): Message => ({ role: 'user', content: text, timestamp: 1 });
+
+const toolSearchResult = (declaredNames: string[]): Message => ({
+  role: 'toolResult',
+  toolCallId: 'call_1',
+  toolName: TOOL_SEARCH_NAME,
+  content: [{
+    type: 'text',
+    text: JSON.stringify({
+      tools: declaredNames.map((name) => ({ type: 'function', name, description: 'x', parameters: { type: 'object', properties: {} } })),
+    }),
+  }],
+  isError: false,
+  timestamp: 3,
+});
+
+test('isToolRetrievalModel matches only the google-interactions api', () => {
+  assert.ok(isToolRetrievalModel({ api: GOOGLE_INTERACTIONS_API }));
+  assert.ok(!isToolRetrievalModel({ api: 'google-generative-ai' }));
+  assert.ok(!isToolRetrievalModel({}));
+});
+
+test('turn 1 request advertises ONLY the client tool_search tool', () => {
+  const request = buildInteractionsRequest(MODEL, {
+    systemPrompt: 'You are a helpful hermit.',
+    messages: [userMessage('what is my credits balance?')],
+  } as Context);
+  assert.equal(request.model, 'gemini-flash-tool-retrieval');
+  assert.equal(request.store, false);
+  assert.equal(request.system_instruction, 'You are a helpful hermit.');
+  const tools = request.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0]!.type, 'tool_search');
+  assert.equal(tools[0]!.execution, 'client');
+  assert.equal(tools[0]!.name, TOOL_SEARCH_NAME);
+});
+
+test('after a tool_search result, searched declarations are advertised (and only those)', () => {
+  const messages: Message[] = [
+    userMessage('credits balance and version please'),
+    {
+      role: 'assistant',
+      content: [{ type: 'toolCall', id: 'call_1', name: TOOL_SEARCH_NAME, arguments: { query: 'credits' } }],
+      api: GOOGLE_INTERACTIONS_API as never,
+      provider: 'google' as never,
+      model: 'gemini-flash-tool-retrieval',
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: 'toolUse',
+      timestamp: 2,
+    },
+    toolSearchResult(['amiko_credits_balance', 'amiko_version', 'not_in_catalog']),
+  ];
+  assert.deepEqual(
+    collectUnlockedToolNames(messages).sort(),
+    ['amiko_credits_balance', 'amiko_version'],
+  );
+  const request = buildInteractionsRequest(MODEL, { messages } as Context);
+  const tools = request.tools as Array<Record<string, unknown>>;
+  assert.equal(tools[0]!.type, 'tool_search');
+  const functionNames = tools.slice(1).map((t) => t.name).sort();
+  assert.deepEqual(functionNames, ['amiko_credits_balance', 'amiko_version']);
+  assert.ok(tools.slice(1).every((t) => t.type === 'function'));
+});
+
+test('mapMessagesToSteps round-trips history with thought signatures', () => {
+  const messages: Message[] = [
+    userMessage('hi'),
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'pondering', thinkingSignature: 'sig-thought' },
+        { type: 'toolCall', id: 'call_9', name: 'amiko_credits_balance', arguments: {}, thoughtSignature: 'sig-call' },
+      ],
+      api: GOOGLE_INTERACTIONS_API as never,
+      provider: 'google' as never,
+      model: 'gemini-flash-tool-retrieval',
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: 'toolUse',
+      timestamp: 2,
+    },
+    {
+      role: 'toolResult',
+      toolCallId: 'call_9',
+      toolName: 'amiko_credits_balance',
+      content: [{ type: 'text', text: 'Balance: 120,000 credits' }],
+      isError: false,
+      timestamp: 3,
+    },
+  ];
+  const steps = mapMessagesToSteps(messages);
+  assert.deepEqual(steps.map((s) => s.type), ['user_input', 'thought', 'function_call', 'function_result']);
+  assert.equal((steps[1] as { signature?: string }).signature, 'sig-thought');
+  const call = steps[2] as { id: string; name: string; signature?: string };
+  assert.equal(call.id, 'call_9');
+  assert.equal(call.signature, 'sig-call');
+  const result = steps[3] as { call_id: string; result: Array<{ text: string }> };
+  assert.equal(result.call_id, 'call_9');
+  assert.equal(result.result[0]!.text, 'Balance: 120,000 credits');
+});
+
+test('parseInteractionSteps maps steps to an AssistantMessage with signatures', () => {
+  const message = parseInteractionSteps({
+    id: 'int_123',
+    steps: [
+      { type: 'thought', summary: 'let me search', signature: 'sig-1' },
+      { type: 'function_call', id: 'call_2', name: TOOL_SEARCH_NAME, arguments: { query: 'credits' }, signature: 'sig-2' },
+    ],
+    usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+  }, { provider: 'google', model: 'gemini-flash-tool-retrieval' });
+  assert.equal(message.stopReason, 'toolUse');
+  assert.equal(message.responseId, 'int_123');
+  assert.equal(message.usage.totalTokens, 15);
+  const [thought, call] = message.content;
+  assert.equal(thought!.type, 'thinking');
+  assert.equal((thought as { thinkingSignature?: string }).thinkingSignature, 'sig-1');
+  assert.equal(call!.type, 'toolCall');
+  assert.equal((call as { thoughtSignature?: string }).thoughtSignature, 'sig-2');
+});
+
+test('toolset: tool_search returns declarations; catalog tools are registered', async () => {
+  const toolset = createAmikoToolRetrievalToolset();
+  const toolSearch = toolset.tools.find((t) => t.name === TOOL_SEARCH_NAME)!;
+  const result = await toolSearch.execute('call_x', { query: 'credits balance' });
+  const parsed = JSON.parse((result.content[0] as { text: string }).text) as { tools: Array<{ name: string }> };
+  assert.ok(parsed.tools.some((t) => t.name === 'amiko_credits_balance'));
+  assert.ok(toolset.tools.some((t) => t.name === 'amiko_credits_balance'));
+  assert.ok(toolset.tools.some((t) => t.name === 'amiko_version'));
+  // Mutating tools are owner-gated.
+  const send = toolset.tools.find((t) => t.name === 'amiko_chat_send')!;
+  assert.deepEqual(send.policy?.defaultGrants, [{ type: 'role', value: 'owner' }]);
+});
+
+test('stream adapter: passes non-TR models through and serves TR models over Interactions', async () => {
+  let passthroughCalled = false;
+  const base = (() => {
+    passthroughCalled = true;
+    return undefined as never;
+  }) as never;
+
+  const fetchCalls: Array<{ url: string; body: Record<string, unknown>; headers: Record<string, string> }> = [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    fetchCalls.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      headers: init?.headers as Record<string, string>,
+    });
+    return new Response(JSON.stringify({
+      id: 'int_1',
+      status: 'completed',
+      steps: [
+        { type: 'function_call', id: 'call_1', name: TOOL_SEARCH_NAME, arguments: { query: 'credits' } },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as typeof fetch;
+
+  const streamFn = withGoogleInteractionsToolRetrieval(base, { fetchImpl });
+
+  // Non-TR model → delegates to the wrapped function.
+  streamFn({ api: 'openai-completions' } as never, { messages: [] } as never, {});
+  assert.ok(passthroughCalled);
+
+  // TR model → Interactions request + parsed tool call.
+  const stream = await streamFn(MODEL as never, {
+    systemPrompt: 'sys',
+    messages: [userMessage('balance?')],
+  } as never, { apiKey: 'test-key' });
+  const message = await stream.result();
+  assert.equal(message.stopReason, 'toolUse');
+  assert.equal(message.content[0]!.type, 'toolCall');
+
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0]!.url, 'https://interactions.example.test/v1beta/interactions');
+  assert.equal(fetchCalls[0]!.headers['x-goog-api-key'], 'test-key');
+  const tools = fetchCalls[0]!.body.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0]!.type, 'tool_search');
+});
+
+test('stream adapter: HTTP errors and missing endpoint become error messages, never throws', async () => {
+  const failingFetch = (async () =>
+    new Response('{"error": "bad"}', { status: 400 })) as typeof fetch;
+  const streamFn = withGoogleInteractionsToolRetrieval(((() => {
+    throw new Error('must not delegate');
+  }) as never), { fetchImpl: failingFetch });
+
+  const stream = await streamFn(MODEL as never, { messages: [userMessage('x')] } as never, { apiKey: 'k' });
+  const message = await stream.result();
+  assert.equal(message.stopReason, 'error');
+  assert.match(message.errorMessage ?? '', /Interactions API error 400/);
+
+  // No baseUrl anywhere → explicit configuration error.
+  const bareModel = { ...(MODEL as object), baseUrl: undefined } as never;
+  const prevEnv = process.env.GOOGLE_INTERACTIONS_BASE_URL;
+  delete process.env.GOOGLE_INTERACTIONS_BASE_URL;
+  try {
+    const s2 = await streamFn(bareModel, { messages: [userMessage('x')] } as never, { apiKey: 'k' });
+    const m2 = await s2.result();
+    assert.equal(m2.stopReason, 'error');
+    assert.match(m2.errorMessage ?? '', /No Interactions endpoint configured/);
+  } finally {
+    if (prevEnv !== undefined) process.env.GOOGLE_INTERACTIONS_BASE_URL = prevEnv;
+  }
+});
+
+test('stream adapter: full endpoint URLs ending in /interactions are used verbatim', async () => {
+  let seenUrl = '';
+  const fetchImpl = (async (url: string | URL) => {
+    seenUrl = String(url);
+    return new Response(JSON.stringify({ id: 'i', status: 'completed', steps: [{ type: 'model_output', content: [{ type: 'text', text: 'hi' }] }] }), { status: 200 });
+  }) as typeof fetch;
+  const streamFn = withGoogleInteractionsToolRetrieval(((() => undefined) as never), { fetchImpl });
+  const model = { ...(MODEL as object), baseUrl: 'https://eap.example.test/custom/interactions' } as never;
+  const stream = await streamFn(model, { messages: [userMessage('x')] } as never, { apiKey: 'k' });
+  const message = await stream.result();
+  assert.equal(seenUrl, 'https://eap.example.test/custom/interactions');
+  assert.equal(message.stopReason, 'stop');
+  assert.deepEqual(message.content, [{ type: 'text', text: 'hi' }]);
+});

--- a/docs/gemini-tool-retrieval.md
+++ b/docs/gemini-tool-retrieval.md
@@ -1,0 +1,87 @@
+# Gemini Tool Retrieval (Interactions API) + Amiko CLI catalog
+
+> Internal / EAP. The `gemini-flash-tool-retrieval` model is a confidential
+> Google early-access preview — do not enable it for end users or document the
+> endpoint publicly.
+
+## What this is
+
+OpenHermit's normal Google path goes through pi-ai's `generateContentStream`
+and sends **every** registered tool schema on each turn. Google Tool Retrieval
+works differently: the model gets a single `tool_search` tool (client-side
+execution), searches a catalog at runtime, and only then receives the matching
+function declarations.
+
+The adapter in
+`apps/agent/src/providers/google-interactions-tool-retrieval.ts` implements
+this over the Interactions API (`/v1beta/interactions`) for models configured
+with `api: "google-interactions"`:
+
+- the transport is a composable `StreamFn` wrapper — pi-agent-core still runs
+  the tool loop, so session events, message persistence, approval gating, and
+  Langfuse tracing all behave as usual;
+- requests are stateless (`store: false`); the full step history is replayed
+  each call, with Gemini thought signatures round-tripped via pi-ai's
+  `thinkingSignature` / `thoughtSignature` fields;
+- turn 1 advertises **only** `tool_search` (`execution: "client"`); after an
+  `amiko_tool_search` result, exactly the searched declarations are added;
+- server-side `defer_loading: true` with full parameters is known to return
+  HTTP 400 on this EAP model (misleading JSON-syntax error). Do not add it —
+  client-side execution is the supported mode.
+
+The searchable catalog (`apps/agent/src/tools/amiko-cli-catalog.ts`) exposes
+~25 readonly-leaning Amiko CLI commands (credits, wallets, chat, drive,
+friends, users, notifications, memory, feed, markets). Execution shells out to
+the `amiko` binary via `execFile` (no shell interpolation). Mutating entries
+(e.g. `amiko_chat_send`) are owner-gated by policy.
+
+## Configuration
+
+Agent `config_json.model`:
+
+```json
+{
+  "provider": "google",
+  "model": "gemini-flash-tool-retrieval",
+  "max_tokens": 8192,
+  "thinking": "off",
+  "base_url": "<EAP Interactions endpoint>"
+}
+```
+
+Environment / secrets:
+
+| Variable | Purpose |
+|---|---|
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | API key with EAP access to the model |
+| `GOOGLE_INTERACTIONS_BASE_URL` | Interactions endpoint, if not set via `base_url`. A bare host gets `/v1beta/interactions` appended; a URL ending in `/interactions` is used verbatim. **There is no default — the adapter errors without one.** |
+| `AMIKO_BIN` | Path to the amiko CLI. Pin the Commander build (`@heyamiko/amiko-cli` ≥ 0.14.0-beta.25, e.g. a checkout's `dist/index.js`) — **not** the old 0.4.12 Ink TUI some machines have globally. `.js` paths are run through `node` automatically. |
+| `AMIKO_CWD` | Directory whose `.amiko.json` provides twin auth. Tokens never appear on argv and are never logged. |
+
+## Smoke test
+
+Prompt an agent configured as above:
+
+> Using Amiko CLI tools, what is my credits balance? Then show the amiko CLI
+> version.
+
+Success means the transcript shows the Tool Retrieval path — not the normal
+tool loop:
+
+1. Turn 1 request `tools` contains only `tool_search` (client execution).
+2. Model calls `amiko_tool_search` (query ≈ credits / version).
+3. Tool result carries function declarations for `amiko_credits_balance` /
+   `amiko_version`.
+4. Model calls those tools; the runner executes `amiko credits balance` and
+   `amiko --version` and returns real output.
+5. Final assistant text cites the live balance and version.
+
+A run that answers via `exec` + the amiko skill, or via `web_search`, does
+**not** validate Tool Retrieval.
+
+Unit tests (no keys needed — Interactions is mocked):
+
+```bash
+cd apps/agent
+node --import tsx --test test/amiko-cli-catalog.test.ts test/google-interactions-tool-retrieval.test.ts
+```


### PR DESCRIPTION
Implements #262 (client-side path).

## What

- **`apps/agent/src/providers/google-interactions-tool-retrieval.ts`** — Interactions API adapter for models with `api: "google-interactions"`, built as a composable `StreamFn` wrapper (option B from the research map, B2 shape): pi-agent-core still runs the tool loop, so session events, message persistence, approval gating, and Langfuse tracing are unchanged.
  - Stateless calls (`store: false`) with full step replay; Gemini thought signatures round-trip via pi-ai `thinkingSignature` / `thoughtSignature`.
  - Turn 1 advertises **only** `tool_search` (`execution: "client"`); after an `amiko_tool_search` result, exactly the searched declarations are added — never the full OpenHermit tool dump.
  - Server-side `defer_loading` intentionally not implemented (known EAP 400).
  - The EAP endpoint is deployment-configured (`config.model.base_url` or `GOOGLE_INTERACTIONS_BASE_URL`); the adapter errors rather than guessing a host.
- **`apps/agent/src/tools/amiko-cli-catalog.ts`** — ~25 readonly-leaning Amiko CLI tools (credits, wallets, chat, drive, friends, users, notifications, memory, feed, markets) + deterministic `searchCatalog()`. Execution shells to a configurable binary (`AMIKO_BIN` / `AMIKO_CWD`, `execFile` — no shell, no secrets on argv). Mutating entries (`amiko_chat_send`) are owner-gated by policy.
- **`agent-runner.ts`** — for tool-retrieval models the curated Amiko toolset replaces the built-in toolsets (approval wrapping + policy filter still apply); streamFn chain gains the Interactions wrapper.
- **`model-utils.ts`** — `LOCAL_MODELS['google/gemini-flash-tool-retrieval']` (`api: google-interactions`); appears in the picker via `listLocalModels`. Secrets stay `GEMINI_API_KEY` / `GOOGLE_API_KEY`.
- **Docs**: `docs/gemini-tool-retrieval.md` (config, env, smoke steps).
- **Tests**: 16 unit tests with mocked Interactions responses — no keys needed in CI (`apps/agent/test/amiko-cli-catalog.test.ts`, `apps/agent/test/google-interactions-tool-retrieval.test.ts`). All pass; `tsc --noEmit` shows only pre-existing `src/research/*` errors.

## Smoke (needs EAP key + endpoint)

Prompt: *"Using Amiko CLI tools, what is my credits balance? Then show the amiko CLI version."* — success = transcript shows client `tool_search` → injected FunctionDeclarations → live `amiko credits balance` + `amiko --version` (not bare exec / web tools).

## Out of scope (per issue)

Default-enabling the EAP model, Google's server-side defer bug, spend/mutate Amiko ops in the default smoke.

**Do not merge** — open for review per #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)