### PR TITLE
fix(agent): drop orphaned tool-call/result pairs before MiniMax send

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -57,6 +57,7 @@ import {
   isAssistantMessage,
   isEmptyAssistantTurn,
   normalizeMessageAlternation,
+  repairToolCallPairing,
   downgradeImagesForTextModel,
   stripEmptyAssistantTurns,
   stripLeadingSpeakerTag,
@@ -3095,6 +3096,16 @@ export class AgentRunner implements SessionRuntime {
         liveState.push(...core);
       }
     }
+
+    // Wire-shape guard: drop tool-call/tool-result blocks that compaction or the
+    // rolling window left orphaned. The anthropic-messages endpoints (MiniMax's
+    // `/anthropic`) 400 with `invalid params (2013) … tool result's tool id(…)`
+    // when a toolResult references a toolCall no longer in the payload (or a
+    // toolCall lost its result) — a self-perpetuating wedge once baked into a
+    // long-lived session. Runs BEFORE alternation so a message it empties/drops
+    // gets its same-role neighbours coalesced. Request-only, like the guards
+    // below (never touches persisted history).
+    finalMessages = repairToolCallPairing(finalMessages);
 
     // Final wire-shape guard: coalesce any consecutive same-role messages so
     // the transcript strictly alternates user/assistant. Strict providers

--- a/apps/agent/src/agent-runner/message-utils.ts
+++ b/apps/agent/src/agent-runner/message-utils.ts
@@ -6,6 +6,7 @@ import type {
   TextContent,
   ThinkingContent,
   ToolCall,
+  ToolResultMessage,
   UserMessage,
 } from '@mariozechner/pi-ai';
 
@@ -159,6 +160,105 @@ export const normalizeMessageAlternation = (
     i = j;
   }
   return out;
+};
+
+/**
+ * Drop tool-call / tool-result blocks left orphaned by compaction or the
+ * rolling context window.
+ *
+ * The anthropic-messages wire format (MiniMax's `/anthropic` endpoint, and
+ * Anthropic itself) demands strict pairing: every assistant `toolCall` must be
+ * answered by a `toolResult` carrying the same id, and every `toolResult` must
+ * reference a `toolCall` earlier in the transcript. Compaction summarizes and
+ * drops old turns and the rolling window slices the transcript — either can cut
+ * between a toolCall and its toolResult, leaving:
+ *   - an orphaned `toolResult` (its `toolCall` was dropped) — MiniMax 400s with
+ *     `invalid params (2013) … tool result's tool id(call_…)`;
+ *   - an orphaned `toolCall` (its `toolResult` was dropped) — the mirror 400.
+ * Once such an orphan is baked into a long-lived session every following turn
+ * re-sends it and 400s — a self-perpetuating wedge, exactly what hit the Lucky
+ * Girl Helen session (`invalid params (2013)` firing immediately after a
+ * `context_compaction`).
+ *
+ * Repair, in two passes:
+ *   1. Drop `toolResult` messages whose `toolCallId` matches no assistant
+ *      `toolCall`.
+ *   2. Strip `toolCall` blocks whose id has no surviving `toolResult`; drop an
+ *      assistant message this empties, and demote a `toolUse` stopReason to
+ *      `stop` when the last call is removed but text/thinking remains.
+ *
+ * Compaction preserves message order, so a set-based match (a call and its
+ * result are matched wherever they sit) is safe — anything that survives both
+ * passes keeps its original order and therefore its valid pairing.
+ *
+ * REQUEST-ONLY — same contract as `normalizeMessageAlternation`: callers apply
+ * it to the wire payload after the live-state write-back, never to persisted
+ * history, so a session that already baked an orphan in auto-unwedges on its
+ * next turn with no DB surgery. Run it BEFORE `normalizeMessageAlternation` so a
+ * dropped message that leaves two same-role turns adjacent is then coalesced.
+ * Returns the input array unchanged (same reference) when nothing is orphaned.
+ */
+export const repairToolCallPairing = (
+  messages: AgentMessage[],
+): AgentMessage[] => {
+  const isToolResult = (m: AgentMessage): m is ToolResultMessage =>
+    (m as Message).role === 'toolResult';
+  const toolCallsOf = (m: AgentMessage): ToolCall[] =>
+    isAssistantMessage(m)
+      ? (m.content.filter((b) => b.type === 'toolCall') as ToolCall[])
+      : [];
+
+  // Every toolCall id present anywhere in the transcript.
+  const callIds = new Set<string>();
+  for (const m of messages) for (const c of toolCallsOf(m)) callIds.add(c.id);
+
+  let changed = false;
+
+  // Pass 1: drop toolResults whose toolCall was compacted away, and record the
+  // toolCallIds of the results that survive.
+  const resultIds = new Set<string>();
+  const afterResults = messages.filter((m) => {
+    if (!isToolResult(m)) return true;
+    if (!callIds.has(m.toolCallId)) {
+      changed = true;
+      return false;
+    }
+    resultIds.add(m.toolCallId);
+    return true;
+  });
+
+  // Pass 2: strip toolCall blocks whose result didn't survive.
+  const out: AgentMessage[] = [];
+  for (const m of afterResults) {
+    const calls = toolCallsOf(m);
+    if (calls.length === 0 || calls.every((c) => resultIds.has(c.id))) {
+      out.push(m);
+      continue;
+    }
+    changed = true;
+    const orphanIds = new Set(
+      calls.filter((c) => !resultIds.has(c.id)).map((c) => c.id),
+    );
+    const assistant = m as AssistantMessage;
+    const nextContent = assistant.content.filter(
+      (b) => !(b.type === 'toolCall' && orphanIds.has((b as ToolCall).id)),
+    );
+    const hasUsable = nextContent.some(
+      (b) => b.type !== 'text' || ((b as TextContent).text?.trim().length ?? 0) > 0,
+    );
+    // Nothing worth sending once the orphan calls are gone — drop the turn.
+    if (!hasUsable) continue;
+    const stillHasCall = nextContent.some((b) => b.type === 'toolCall');
+    out.push({
+      ...assistant,
+      content: nextContent,
+      ...(assistant.stopReason === 'toolUse' && !stillHasCall
+        ? { stopReason: 'stop' as const }
+        : {}),
+    } as AgentMessage);
+  }
+
+  return changed ? out : messages;
 };
 
 /**

--- a/apps/agent/test/message-utils.test.ts
+++ b/apps/agent/test/message-utils.test.ts
@@ -16,6 +16,7 @@ import {
   pushReasoningTagDelta,
   flushReasoningTagStream,
   normalizeMessageAlternation,
+  repairToolCallPairing,
   downgradeImagesForTextModel,
 } from '../src/agent-runner/message-utils.js';
 
@@ -346,6 +347,106 @@ describe('normalizeMessageAlternation', () => {
     const input: AgentMessage[] = [user('a'), user('b')] as AgentMessage[];
     const before = JSON.stringify(input);
     normalizeMessageAlternation(input);
+    assert.equal(JSON.stringify(input), before);
+  });
+});
+
+describe('repairToolCallPairing', () => {
+  test('drops a toolResult whose toolCall was compacted away (the 2013 wedge)', () => {
+    // Mirrors Lucky Girl Helen: compaction dropped the assistant(toolCall) but
+    // kept its toolResult, so MiniMax 400s with `tool result's tool id(call_…)`.
+    const orphaned: AgentMessage[] = [
+      user('刚发的帖子'),
+      toolResult('call_gone', 'web_search'),
+      assistantText('看到了'),
+    ] as AgentMessage[];
+    const out = repairToolCallPairing(orphaned);
+    assert.equal(roles(out), 'UA');
+    assert.ok(!out.some((m) => (m as { role: string }).role === 'toolResult'));
+  });
+
+  test('strips a toolCall whose result was dropped, keeping the text', () => {
+    const orphaned: AgentMessage[] = [
+      user('hi'),
+      {
+        ...assistantText('稍等,我查一下'),
+        content: [
+          { type: 'text', text: '稍等,我查一下' },
+          { type: 'toolCall', id: 'call_x', name: 'web_search', arguments: {} },
+        ],
+        stopReason: 'toolUse',
+      } as AssistantMessage,
+    ] as AgentMessage[];
+    const out = repairToolCallPairing(orphaned);
+    assert.equal(out.length, 2);
+    const asst = out[1] as AssistantMessage;
+    assert.deepEqual(asst.content.map((b) => b.type), ['text']);
+    // No toolCall remains, so it must no longer claim a tool-use turn.
+    assert.equal(asst.stopReason, 'stop');
+  });
+
+  test('drops an assistant left empty after its only toolCall is stripped', () => {
+    const orphaned: AgentMessage[] = [
+      user('hi'),
+      assistantCall('call_x', 'web_search'), // result never arrived
+      user('还在吗'),
+    ] as AgentMessage[];
+    const out = repairToolCallPairing(orphaned);
+    assert.equal(roles(out), 'UU');
+    assert.equal(out.length, 2);
+  });
+
+  test('keeps a matched call/result pair untouched', () => {
+    const paired: AgentMessage[] = [
+      user('hi'),
+      assistantCall('call_1', 'web_search'),
+      toolResult('call_1', 'web_search'),
+      assistantText('结果如下'),
+    ] as AgentMessage[];
+    const out = repairToolCallPairing(paired);
+    assert.equal(roles(out), 'UATA');
+    assert.equal(out.length, 4);
+  });
+
+  test('keeps the matched half of a parallel call, strips the orphan half', () => {
+    const mixed: AgentMessage[] = [
+      {
+        ...assistantText(''),
+        content: [
+          { type: 'toolCall', id: 'call_a', name: 'x', arguments: {} },
+          { type: 'toolCall', id: 'call_b', name: 'y', arguments: {} },
+        ],
+        stopReason: 'toolUse',
+      } as AssistantMessage,
+      toolResult('call_a', 'x'), // only A came back; B is orphaned
+    ] as AgentMessage[];
+    const out = repairToolCallPairing(mixed);
+    const asst = out[0] as AssistantMessage;
+    const ids = asst.content
+      .filter((b) => b.type === 'toolCall')
+      .map((b) => (b as { id: string }).id);
+    assert.deepEqual(ids, ['call_a']);
+    assert.equal(asst.stopReason, 'toolUse'); // still a tool-use turn (call_a remains)
+    assert.ok(out.some((m) => (m as { role: string }).role === 'toolResult'));
+  });
+
+  test('is a no-op (same reference) on a clean transcript', () => {
+    const clean: AgentMessage[] = [
+      user('hi'),
+      assistantCall('call_1', 'x'),
+      toolResult('call_1', 'x'),
+      assistantText('done'),
+    ] as AgentMessage[];
+    assert.equal(repairToolCallPairing(clean), clean);
+  });
+
+  test('does not mutate the input messages', () => {
+    const input: AgentMessage[] = [
+      toolResult('call_gone', 'x'),
+      assistantText('hi'),
+    ] as AgentMessage[];
+    const before = JSON.stringify(input);
+    repairToolCallPairing(input);
     assert.equal(JSON.stringify(input), before);
   });
 });


### PR DESCRIPTION
## Problem

The **Lucky Girl Helen** session (`minimax-cn/MiniMax-M3`, thinking:high) was intermittently returning **empty error replies** to the user. Forensics on `openhermit.session_events`:

- No credit/402 errors. The failures are `assistant` events with `stopReason=error`, message `400 invalid params (2013)`.
- **Every one fires immediately after a `context_compaction`** (e.g. 09-09 22:50: user → compaction → 2013 error → empty reply; user resent 22:52 → same 2013 → empty again).
- One variant is explicit: `… tool result's tool id(call_…)` (09-07).

Root cause: compaction and the rolling context window can cut **between an assistant `toolCall` and its `toolResult`**, leaving an orphan on either side. MiniMax's `/anthropic` endpoint demands strict pairing and 400s on the malformed payload. Once the orphan is baked into a long-lived session, every following turn re-sends it and 400s — a self-perpetuating wedge. The existing guards (`stripEmptyAssistantTurns`, `normalizeMessageAlternation`, `downgradeImagesForTextModel`) coalesce by role and strip images, but none repair tool-call/result pairing.

## Fix

`repairToolCallPairing` — a **request-only** guard (same contract as `normalizeMessageAlternation`: applied to the wire payload after the live-state write-back, never to persisted history):

1. Drop `toolResult` messages whose `toolCallId` matches no assistant `toolCall`.
2. Strip `toolCall` blocks whose id has no surviving `toolResult`; drop an assistant message this empties, and demote a `toolUse` stopReason to `stop` when the last call is removed but text remains.

Wired in **before** `normalizeMessageAlternation`, so a message it drops that leaves two same-role turns adjacent then gets coalesced. Because it never touches stored history, a session that already baked in an orphan **auto-unwedges on its next turn** — no DB surgery.

## Tests

7 new unit tests in `message-utils.test.ts` (orphan result, orphan call, emptied assistant, matched pair no-op, partial parallel call, same-reference no-op, no-mutation). Full `message-utils.test.ts` suite: 45/45 pass. Touched files typecheck clean.

## Not included (deliberately)

My earlier note suggested also forcing `minimax-cn` image-downgrade. On inspection, `MiniMax-M3` is **deliberately multimodal** (`minimax-m3.test.ts` asserts image input) — forcing text-only would regress vision. The image-related 2013s are a separate oversized/unsupported-format concern better handled surgically; happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of agent requests after message compaction or rolling-window processing.
  - Removed unmatched tool results and incomplete tool calls from outgoing requests.
  - Prevented malformed assistant messages when all associated tool calls are removed.
- **Tests**
  - Added coverage for matched and unmatched tool-call pairs, parallel calls, unchanged inputs, and input immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->