### PR TITLE
fix(agent): recover wedged turns via inactivity watchdog + stale-running sweep

### DIFF
--- a/apps/agent/src/agent-runner.ts
+++ b/apps/agent/src/agent-runner.ts
@@ -144,6 +144,21 @@ const addUserIdToList = (existing: string[], userId: string | undefined): string
   return existing.includes(userId) ? existing : [...existing, userId];
 };
 
+/** Default per-turn inactivity watchdog budget (10 min). Far longer than any
+ *  normal model stream gap, so it only trips on a genuinely wedged turn. */
+const DEFAULT_TURN_WATCHDOG_MS = 10 * 60_000;
+
+/**
+ * Parse `OPENHERMIT_TURN_WATCHDOG_MS`. Falls back to the default when unset or
+ * malformed; `0` (or negative) explicitly disables the watchdog.
+ */
+function parseTurnWatchdogMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_TURN_WATCHDOG_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_TURN_WATCHDOG_MS;
+  return Math.floor(parsed);
+}
+
 /**
  * Raised by `runScheduledJob` when a cron firing's turn ended in a model error
  * (`stopReason==='error'`). A model error means the run produced no reply, so
@@ -182,6 +197,18 @@ export class AgentRunner implements SessionRuntime {
 
   private workspaceIdleTimer: ReturnType<typeof setTimeout> | undefined;
 
+  /**
+   * Per-turn inactivity watchdog budget in ms. A turn that emits no agent
+   * event for this long is presumed wedged (a model/tool await that ignores
+   * the abort signal) and gets `agent.abort()`'d so the serial
+   * `session.queue` is released instead of blocking every later message
+   * forever. `0` disables the watchdog. Deliberately generous by default so
+   * a legitimately long tool call (a slow sandbox build emits no events
+   * between `tool_execution_start` and `_end`) is never killed mid-flight;
+   * override with `OPENHERMIT_TURN_WATCHDOG_MS`.
+   */
+  private readonly turnWatchdogMs: number;
+
   private mcpClientManager: McpClientManager | undefined;
 
   private researchOrchestrator: ResearchOrchestrator | undefined;
@@ -207,6 +234,7 @@ export class AgentRunner implements SessionRuntime {
     this.security = options.security;
     this.workspace = options.workspace;
     this.scope = { agentId: options.security.agentId };
+    this.turnWatchdogMs = parseTurnWatchdogMs(process.env.OPENHERMIT_TURN_WATCHDOG_MS);
     this.containerManager =
       options.containerManager
       ?? new DockerContainerManager(options.workspace, {
@@ -223,7 +251,57 @@ export class AgentRunner implements SessionRuntime {
       agentId: runner.scope.agentId,
       at: new Date().toISOString(),
     });
+    // Clear any persisted `running`/`awaiting_approval` rows left behind by a
+    // prior process that died (or was restarted) mid-turn. This runner holds
+    // no in-memory turn for this agent yet — under the single-writer-per-agent
+    // model, an active-status row at hydration time is always stale, and
+    // `listSessions` reads status from the DB row, so without this sweep such
+    // a session would show a phantom `running` forever and its channel would
+    // look wedged. In-memory reopen already lands on `idle`, so this only
+    // fixes sessions not yet reopened.
+    await runner.recoverStaleRunningSessions();
     return runner;
+  }
+
+  /**
+   * Reset persisted sessions stuck in an active status (`running` /
+   * `awaiting_approval`) back to `idle` at hydration. See {@link create} for
+   * why this is safe (single-writer-per-agent: no other process owns these
+   * rows, and this process has not opened them yet).
+   */
+  private async recoverStaleRunningSessions(): Promise<void> {
+    let entries;
+    try {
+      entries = await this.store.sessions.list(this.scope, { includeInactive: true });
+    } catch (error) {
+      // Recovery is best-effort; never let it block agent hydration.
+      this.logRuntime(
+        `stale-session recovery: list failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return;
+    }
+    const stale = entries.filter(
+      (e) => e.status === 'running' || e.status === 'awaiting_approval',
+    );
+    if (stale.length === 0) return;
+    let recovered = 0;
+    for (const entry of stale) {
+      try {
+        await this.store.sessions.updateStatus(this.scope, entry.sessionId, 'idle');
+        recovered += 1;
+      } catch (error) {
+        this.logRuntime(
+          `stale-session recovery: reset ${entry.sessionId} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    this.logRuntime(
+      `stale-session recovery: reset ${recovered}/${stale.length} session(s) from active→idle`,
+    );
   }
 
   /**
@@ -1212,6 +1290,55 @@ export class AgentRunner implements SessionRuntime {
     session.idleSummaryTimer = undefined;
   }
 
+  /**
+   * Arm the per-turn inactivity watchdog. Called once at turn start. The
+   * timer is re-armed by {@link bumpTurnWatchdog} on every agent event, so it
+   * only fires after a full `turnWatchdogMs` of complete silence. On fire it
+   * aborts the run: if the wedged await honors the abort signal the turn
+   * settles normally (queue released); if it doesn't, the abort is a no-op
+   * and the turn is logged as unrecoverable-without-restart (see the PR — the
+   * startup sweep makes that restart clean).
+   */
+  private armTurnWatchdog(session: RunnerSession): void {
+    this.clearTurnWatchdog(session);
+    if (this.turnWatchdogMs <= 0) return;
+    session.turnWatchdogTimer = setTimeout(() => {
+      // Single-shot: clear the handle first so the abort-triggered agent_end
+      // (which flows back through bumpTurnWatchdog) cannot re-arm us against an
+      // already-settling turn.
+      session.turnWatchdogTimer = undefined;
+      const idleSec = session.turnStartMs
+        ? Math.round((Date.now() - session.turnStartMs) / 1000)
+        : Math.round(this.turnWatchdogMs / 1000);
+      this.logRuntime(
+        `turn watchdog: no agent activity for ${idleSec}s on session ${session.spec.sessionId} — aborting presumed-wedged turn`,
+      );
+      agentErrorsTotal.inc({ agent_id: this.scope.agentId, source: 'watchdog' });
+      try {
+        session.agent.abort();
+      } catch (error) {
+        this.logRuntime(
+          `turn watchdog: abort threw for ${session.spec.sessionId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }, this.turnWatchdogMs);
+  }
+
+  /** Re-arm the watchdog if a turn is currently being watched. No-op between
+   *  turns (timer undefined), so late events never resurrect the timer. */
+  private bumpTurnWatchdog(session: RunnerSession): void {
+    if (!session.turnWatchdogTimer) return;
+    this.armTurnWatchdog(session);
+  }
+
+  private clearTurnWatchdog(session: RunnerSession): void {
+    if (!session.turnWatchdogTimer) return;
+    clearTimeout(session.turnWatchdogTimer);
+    session.turnWatchdogTimer = undefined;
+  }
+
   private scheduleIdleSummary(session: RunnerSession): void {
     this.clearIdleSummaryTimer(session);
     session.idleSummaryTimer = setTimeout(() => {
@@ -1496,6 +1623,11 @@ export class AgentRunner implements SessionRuntime {
           );
         }
         session.turnStartMs = Date.now();
+        // Arm the inactivity watchdog for the whole turn — including the
+        // pre-prompt attachment/config prep below, which has hung in the past
+        // on remote media fetches. Re-armed by every agent event via
+        // bumpTurnWatchdog; cleared in the finally.
+        this.armTurnWatchdog(session);
         const modelInputs = session.agent.state.model?.input;
         const supportsImageInput = Array.isArray(modelInputs)
           ? modelInputs.includes('image')
@@ -1519,6 +1651,8 @@ export class AgentRunner implements SessionRuntime {
           error,
           (runError) => this.handleRunError(session, runError),
         );
+      } finally {
+        this.clearTurnWatchdog(session);
       }
     };
 
@@ -3278,6 +3412,10 @@ export class AgentRunner implements SessionRuntime {
   }
 
   private handleAgentEvent(session: RunnerSession, event: AgentEvent): void {
+    // Any agent activity means the turn is alive — push the watchdog deadline
+    // out. No-op between turns (timer undefined), so a late event from an
+    // already-settled turn can't resurrect the timer.
+    this.bumpTurnWatchdog(session);
     switch (event.type) {
       case 'agent_start': {
         const ts = new Date().toISOString();

--- a/apps/agent/src/agent-runner/types.ts
+++ b/apps/agent/src/agent-runner/types.ts
@@ -57,6 +57,13 @@ export interface RunnerSession extends SessionDescriptor {
   resolvedChannelUserId?: string;
   langfuseTurnContext?: LangfuseTurnContext;
   turnStartMs?: number;
+  /** Per-turn inactivity watchdog. Armed at turn start, re-armed on every
+   *  agent event, cleared when the turn settles. If no agent event arrives
+   *  for `turnWatchdogMs`, the turn is presumed wedged (a model/tool await
+   *  that never returns) and the watchdog calls `agent.abort()` to release
+   *  the serial `session.queue`, which a hung turn would otherwise block
+   *  forever. Undefined when no turn is in flight. */
+  turnWatchdogTimer?: ReturnType<typeof setTimeout> | undefined;
   /** Consecutive failed tool results in the current turn. Resets at turn
    *  start and on any successful tool result. The agent aborts the turn
    *  when this reaches `MAX_CONSECUTIVE_TOOL_FAILURES` to prevent the

--- a/apps/agent/test/agent-runner.test.ts
+++ b/apps/agent/test/agent-runner.test.ts
@@ -1754,3 +1754,105 @@ test('AgentRunner emits no mentions when a group reply addresses nobody', async 
   assert.equal(final.text, 'no idea, ask someone else');
   assert.equal(final.mentions, undefined);
 });
+
+test('AgentRunner resets stale persisted running sessions to idle at hydration', async (t) => {
+  const { workspace, security, agentId } = await createSecurityFixture(t, {
+    secrets: {
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+    },
+  });
+  await security.load();
+
+  // First runner: create and settle a session so a persisted index row exists.
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () => createTextResponseStream('reply'),
+    ]),
+  });
+  await runner.openSession({
+    sessionId: 'cli:crashed-turn',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:crashed-turn', { text: 'hello' });
+  await runner.waitForSessionIdle('cli:crashed-turn');
+
+  // Simulate a process that died mid-turn: the persisted row is left as
+  // `running` while no runner holds an in-memory turn for it.
+  const store = await DbInternalStateStore.open();
+  t.after(() => store.close());
+  const scope = { agentId };
+  await store.sessions.updateStatus(scope, 'cli:crashed-turn', 'running');
+  assert.equal((await store.sessions.get(scope, 'cli:crashed-turn'))?.status, 'running');
+
+  // A fresh runner hydration must sweep that stale `running` back to `idle`.
+  const restoredRunner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: createSequentialStreamFn([
+      () => createTextResponseStream('reply-2'),
+    ]),
+  });
+  const restored = await restoredRunner.listSessions({ kind: 'cli' });
+  const entry = restored.find((s) => s.sessionId === 'cli:crashed-turn');
+  assert.equal(entry?.status, 'idle');
+  assert.equal((await store.sessions.get(scope, 'cli:crashed-turn'))?.status, 'idle');
+});
+
+test('turn watchdog aborts a wedged turn so the session queue is released', async (t) => {
+  const prev = process.env.OPENHERMIT_TURN_WATCHDOG_MS;
+  process.env.OPENHERMIT_TURN_WATCHDOG_MS = '80';
+  t.after(() => {
+    if (prev === undefined) delete process.env.OPENHERMIT_TURN_WATCHDOG_MS;
+    else process.env.OPENHERMIT_TURN_WATCHDOG_MS = prev;
+  });
+
+  const { workspace, security } = await createSecurityFixture(t, {
+    secrets: {
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+    },
+  });
+  await security.load();
+
+  let sawAbort = false;
+  // A stream call that never yields — the exact zombie shape a wedged
+  // MiniMax turn produces — but one that honors the abort signal. The
+  // watchdog must trip and abort it, letting the run settle and the queue free.
+  const hangingStreamFn = ((_model: unknown, _ctx: unknown, options: { signal?: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      const signal = options?.signal;
+      const onAbort = () => {
+        sawAbort = true;
+        reject(new Error('aborted by watchdog'));
+      };
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener('abort', onAbort, { once: true });
+    })) as unknown as StreamFn;
+
+  const runner = await AgentRunner.create({
+    workspace,
+    security,
+    streamFn: hangingStreamFn,
+  });
+
+  await runner.openSession({
+    sessionId: 'cli:wedged-turn',
+    source: { kind: 'cli', interactive: true },
+  });
+  await runner.postMessage('cli:wedged-turn', { text: 'this turn will hang' });
+
+  // Without the watchdog this would never resolve (the queue is blocked on the
+  // hung run). With it, the abort fires at ~80ms and the run settles.
+  await runner.waitForSessionIdle('cli:wedged-turn');
+
+  assert.equal(sawAbort, true, 'watchdog should have aborted the wedged stream');
+  const sessions = await runner.listSessions({ kind: 'cli' });
+  assert.equal(
+    sessions.find((s) => s.sessionId === 'cli:wedged-turn')?.status,
+    'idle',
+  );
+});


### PR DESCRIPTION
## Problem

A turn **wedges** when `session.agent.prompt()` hangs on a model/tool `await` that never returns — the exact failure we hit repeatedly with MiniMax-M3 streams that ignore the abort signal. The turn reaches neither `agent_end` nor `handleRunError`, so:

- `status='running'` is persisted and **never cleared**;
- the serial `session.queue = session.queue.then(run, run)` is **blocked on the hung `run`**, so every subsequent message to that session is silently stuck forever;
- `sessionInterrupt` can't rescue it (it just calls `abort()`, which the hang ignores);
- a gateway restart only self-heals sessions whose persisted tail is a `tool_result`; a session whose tail is an **unanswered user message** stays phantom-`running` and its channel looks dead.

This is the class of incident behind the Somiko / Lucky Girl Helen wedges.

## Fix (abort-only strategy)

**1. Startup stale-running sweep** — `recoverStaleRunningSessions()`, run from `AgentRunner.create`. Resets persisted `running`/`awaiting_approval` rows to `idle` at hydration. Safe under single-writer-per-agent: at `create` time this process holds no in-memory turn, so an active-status row is always stale, and `listSessions` reads status from the DB row (not memory) — without this, a not-yet-reopened session shows a phantom `running` indefinitely. Best-effort; never blocks hydration.

**2. Per-turn inactivity watchdog** — armed at turn start, re-armed on every agent event in `handleAgentEvent`, cleared when the turn settles (`finally`). After `turnWatchdogMs` of **total silence** it calls `session.agent.abort()`:
- when the blocked `await` honors the signal → turn settles normally, queue freed;
- when it doesn't → the abort is a no-op, but it's logged and counted (`agent_errors_total{source=watchdog}`), and the startup sweep makes the required restart clean.

Default budget **10 min** (`OPENHERMIT_TURN_WATCHDOG_MS`, `0` disables). Deliberately generous so a legitimately long tool call — which emits no events between `tool_execution_start` and `_end` — is never killed mid-flight.

### Why abort-only (not agent-rebuild)

pi-agent-core holds `activeRun` until its `await executor(signal)` returns; there is **no public API to force-clear a wedged `activeRun`** (`reset()` doesn't touch it, and `prompt()` throws while it's set). Fully curing an abort-deaf hang in-process would require discarding and rebuilding the `Agent` — a larger, riskier lifecycle change. This PR ships the safe, high-value part; the rebuild escalation can be a tracked follow-up if abort-deaf hangs persist.

## Tests

- stale `running` row is reset to `idle` on fresh hydration;
- a hanging stream that honors abort is tripped by the watchdog so `waitForSessionIdle` resolves and status lands `idle`.

Both new tests pass. Note: 5 tests in `agent-runner.test.ts` fail on `main` already (missing-API-key / Langfuse / userIds / memory-role / resumption — unrelated to this change, default-model drift); this PR neither adds to nor fixes those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019g9PfRVVsrwKL9XrGCTZCS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added an inactivity watchdog that automatically aborts stalled or unresponsive agent turns.
  - Watchdog timeout is configurable and can be disabled when needed.
  - Sessions left active after an interrupted startup are now restored to an idle state, allowing them to run normally again.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->